### PR TITLE
support the bastion/jumper server for SSH probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,7 @@ Ease Probe supports the following probing methods:
   ssh:
     servers:
       - name : ServerX
-        host: 172.10.1.1:22
-        username: ubuntu
+        host: ubuntu@172.10.1.1:22
         password: xxxxxxx
         key: /Users/user/.ssh/id_rsa
         cmd: "ps auxwe | grep easeprobe | grep -v grep"
@@ -304,6 +303,11 @@ SSH probe is similar with Shell probe.
 - Support Password and Private key authentication.
 - Support the Bastion host tunnel.
 
+The `host` supports the following configuration
+- `example.com`
+- `example.com:22`
+- `user@example.com:22`
+
 The following are example of SSH probe configuration.
 
 ```YAML
@@ -312,11 +316,11 @@ ssh:
   # SSH bastion host configuration
   bastion:
     aws: # bastion host ID      ◄──────────────────────────────┐
-      host: aws.basition.exmaple.com:22 #                      │
+      host: aws.basition.com:22 #                              │
       username: ubuntu # login user                            │
       key: /patch/to/aws/basion/key.pem # private key file     │
     gcp: # bastion host ID                                     │
-      host: gcp.basition.exmaple.com:22 # bastion host         │
+      host: ubuntu@gcp.basition.com:22 # bastion host          │
       username: ubuntu # login user                            │
       key: /patch/to/gcp/basion/key.pem # private key file     │
   # SSH Probe configuration                                    │

--- a/README.md
+++ b/README.md
@@ -66,19 +66,19 @@ Ease Probe supports the following probing methods:
       contain : "PONG"
   ```
 
-- **SSH**. Run a remote command via SSH and check the result. ([SSH Command Probe Configuration](#34-ssh-command-probe-configuration))
+- **SSH**. Run a remote command via SSH and check the result. Support the bastion/jump server  ([SSH Command Probe Configuration](#34-ssh-command-probe-configuration))
 
-```YAML
-ssh:
-  - name : CubieBoard
-    host: 192.168.10.10:22
-    username: root
-    password: xxxxxxx
-    key: /Users/user/.ssh/id_rsa
-    cmd: "ps auxwe | grep easeprobe | grep -v grep"
-    contain: easeprobe
-```
-
+  ```YAML
+  ssh:
+    servers:
+      - name : ServerX
+        host: 172.10.1.1:22
+        username: ubuntu
+        password: xxxxxxx
+        key: /Users/user/.ssh/id_rsa
+        cmd: "ps auxwe | grep easeprobe | grep -v grep"
+        contain: easeprobe
+  ```
 
 - **Client**. Currently, support the following native client. Support the mTLS. ( [Native Client Probe](#35-native-client-probe) )
   - **MySQL**. Connect to the MySQL server and run the `SHOW STATUS` SQL.
@@ -109,7 +109,7 @@ Ease Probe supports the following notifications:
 - **Telegram**. Using Telegram Bot for notification
 - **Email**. Support multiple email addresses.
 - **AWS SNS**. Support AWS Simple Notification Service.
-- **WeChat Work**. Support Enterprise WeChat Wrok notification.
+- **WeChat Work**. Support Enterprise WeChat Work notification.
 - **DingTalk**. Support the DingTalk notification.
 - **Log File**. Write the notification into a log file
 
@@ -184,7 +184,7 @@ $ make
 
 ### 2.2 Run
 
-Running the following command for local test
+Running the following command for the local test
 
 ```shell
 $ build/bin/easeprobe -f config.yaml
@@ -300,28 +300,52 @@ shell:
 
 ### 3.4 SSH Command Probe Configuration
 
-SSH probe is similar with Shell probe, and it supports password and private key authentication.
+SSH probe is similar with Shell probe.
+- Support Password and Private key authentication.
+- Support the Bastion host tunnel.
 
 The following are example of SSH probe configuration.
 
 ```YAML
 # SSH Probe Configuration
 ssh:
-  # run redis-cli ping and check the "PONG"
-  - name: Redis (Remote)
-    username: ubuntu  # SSH Login username
-    password: xxxxx   # SSH Login password
-    key: /path/to/private.key # SSH login private file
-    cmd: "redis-cli"
-    args:
-      - "-h"
-      - "127.0.0.1"
-      - "ping"
-    env:
-      # set the `REDISCLI_AUTH` environment variable for redis password
-      - "REDISCLI_AUTH=abc123"
-    # check the command output, if does not contain the PONG, mark the status down
-    contain : "PONG"
+  # SSH bastion host configuration
+  bastion:
+    aws: # bastion host ID      ◄──────────────────────────────┐
+      host: aws.basition.exmaple.com:22 #                      │
+      username: ubuntu # login user                            │
+      key: /patch/to/aws/basion/key.pem # private key file     │
+    gcp: # bastion host ID                                     │
+      host: gcp.basition.exmaple.com:22 # bastion host         │
+      username: ubuntu # login user                            │
+      key: /patch/to/gcp/basion/key.pem # private key file     │
+  # SSH Probe configuration                                    │
+  servers:   #                                                 │
+    # run redis-cli ping and check the "PONG"                  │
+    - name: Redis (AWS) # Name                                 │
+      bastion: aws  # bastion host id ------------------------─┘
+      host: 172.20.2.202:22
+      username: ubuntu  # SSH Login username
+      password: xxxxx   # SSH Login password
+      key: /path/to/private.key # SSH login private file
+      cmd: "redis-cli"
+      args:
+        - "-h"
+        - "127.0.0.1"
+        - "ping"
+      env:
+        # set the `REDISCLI_AUTH` environment variable for redis password
+        - "REDISCLI_AUTH=abc123"
+      # check the command output, if does not contain the PONG, mark the status down
+      contain : "PONG"
+    
+    # Check the process status of `Kafka`
+    - name:  Kafka (GCP)
+      bastion: gcp         #  ◄------ bastion host id
+      host: 172.10.1.100:22
+      username: ubuntu
+      key: /path/to/private.key
+      cmd: "ps -ef | grep kafka"
 ```
 
 

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -194,6 +194,7 @@ func New(conf *string) (Conf, error) {
 	}
 
 	c.initLog()
+	ssh.ParseAllBastionHost()
 
 	config = &c
 

--- a/probe/base/base.go
+++ b/probe/base/base.go
@@ -106,25 +106,19 @@ func (d *DefaultOptions) Probe() probe.Result {
 
 	d.ProbeResult.RoundTripTime.Duration = time.Since(now)
 
-	var status probe.Status
-	if stat == true {
-		status = probe.StatusUp
-		if len(d.ProbeTag) > 0 {
-			d.ProbeResult.Message = fmt.Sprintf("Success (%s/%s): %s", d.ProbeKind, d.ProbeTag, msg)
-			log.Debugf("[%s / %s / %s] - %s", d.ProbeKind, d.ProbeTag, d.ProbeName, msg)
-		} else {
-			d.ProbeResult.Message = fmt.Sprintf("Success (%s): %s", d.ProbeKind, msg)
-			log.Debugf("[%s / %s] - %s", d.ProbeKind, d.ProbeName, msg)
-		}
-	} else {
+	status := probe.StatusUp
+	title := "Success"
+	if stat != true {
 		status = probe.StatusDown
-		if len(d.ProbeTag) > 0 {
-			d.ProbeResult.Message = fmt.Sprintf("Error (%s/%s): %s", d.ProbeKind, d.ProbeTag, msg)
-			log.Errorf("[%s / %s / %s] - %s", d.ProbeKind, d.ProbeTag, d.ProbeName, msg)
-		} else {
-			d.ProbeResult.Message = fmt.Sprintf("Error (%s): %s", d.ProbeKind, msg)
-			log.Errorf("[%s / %s] - %s", d.ProbeKind, d.ProbeName, msg)
-		}
+		title = "Error"
+	}
+
+	if len(d.ProbeTag) > 0 {
+		d.ProbeResult.Message = fmt.Sprintf("%s (%s/%s): %s", title, d.ProbeKind, d.ProbeTag, msg)
+		log.Debugf("[%s / %s / %s] - %s", d.ProbeKind, d.ProbeTag, d.ProbeName, msg)
+	} else {
+		d.ProbeResult.Message = fmt.Sprintf("%s (%s): %s", title, d.ProbeKind, msg)
+		log.Debugf("[%s / %s] - %s", d.ProbeKind, d.ProbeName, msg)
 	}
 
 	d.ProbeResult.PreStatus = d.ProbeResult.Status

--- a/probe/ssh/endpoint.go
+++ b/probe/ssh/endpoint.go
@@ -1,0 +1,71 @@
+package ssh
+
+import (
+	"io/ioutil"
+	"net"
+
+	"strings"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// Endpoint is SSH Endpoint
+type Endpoint struct {
+	PrivateKey string      `yaml:"key"`
+	Host       string      `yaml:"host"`
+	User       string      `yaml:"username"`
+	Password   string      `yaml:"password"`
+	client     *ssh.Client `yaml:"-"`
+}
+
+// ParseHost check the host is configured the port or not
+func (e *Endpoint) ParseHost() error {
+
+	if strings.LastIndex(e.Host, ":") < 0 {
+		e.Host = e.Host + ":22"
+	}
+	if strings.Index(e.Host, "@") > 0 {
+		e.User = e.Host[:strings.Index(e.Host, "@")]
+		e.Host = e.Host[strings.Index(e.Host, "@")+1:]
+	}
+	_, _, err := net.SplitHostPort(e.Host)
+
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// SSHConfig returns the ssh.ClientConfig
+func (e *Endpoint) SSHConfig(kind, name string, timeout time.Duration) (*ssh.ClientConfig, error) {
+	var Auth []ssh.AuthMethod
+
+	if len(e.Password) > 0 {
+		Auth = append(Auth, ssh.Password(e.Password))
+	}
+
+	if len(e.PrivateKey) > 0 {
+		key, err := ioutil.ReadFile(e.PrivateKey)
+		if err != nil {
+			return nil, err
+		}
+
+		// Create the Signer for this private key.
+		signer, err := ssh.ParsePrivateKey(key)
+		if err != nil {
+			return nil, err
+		}
+
+		Auth = append(Auth, ssh.PublicKeys(signer))
+	}
+
+	config := &ssh.ClientConfig{
+		User:            e.User,
+		Auth:            Auth,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         timeout,
+	}
+
+	return config, nil
+}

--- a/probe/ssh/endpoint.go
+++ b/probe/ssh/endpoint.go
@@ -25,9 +25,10 @@ func (e *Endpoint) ParseHost() error {
 	if strings.LastIndex(e.Host, ":") < 0 {
 		e.Host = e.Host + ":22"
 	}
-	if strings.Index(e.Host, "@") > 0 {
-		e.User = e.Host[:strings.Index(e.Host, "@")]
-		e.Host = e.Host[strings.Index(e.Host, "@")+1:]
+	userIdx := strings.Index(e.Host, "@")
+	if userIdx > 0 {
+		e.User = e.Host[:userIdx]
+		e.Host = e.Host[userIdx+1:]
 	}
 	_, _, err := net.SplitHostPort(e.Host)
 

--- a/probe/ssh/endpoint_test.go
+++ b/probe/ssh/endpoint_test.go
@@ -1,0 +1,30 @@
+package ssh
+
+import "testing"
+
+func check(t *testing.T, fname string, err error, result, expected string) {
+	if err != nil {
+		t.Errorf("%s error: %s", fname, err)
+	}
+	if result != expected {
+		t.Errorf("%s result: %s, expected: %s", fname, result, expected)
+	}
+}
+
+func TestParseHost(t *testing.T) {
+	e := Endpoint{}
+
+	const fname = "ParseHost"
+	e.Host = "example.com:22"
+	check(t, fname, e.ParseHost(), e.Host, "example.com:22")
+
+	e.Host = "192.168.1.1"
+	check(t, fname, e.ParseHost(), e.Host, "192.168.1.1:22")
+
+	e.Host = "example.com:2222"
+	check(t, fname, e.ParseHost(), e.Host, "example.com:2222")
+
+	e.Host = "user@example.com"
+	check(t, fname, e.ParseHost(), e.Host, "example.com:22")
+	check(t, fname, nil, e.User, "user")
+}

--- a/probe/ssh/ssh.go
+++ b/probe/ssh/ssh.go
@@ -55,6 +55,19 @@ type SSH struct {
 // BastionMap is a map of bastion
 var BastionMap map[string]Endpoint
 
+// ParseAllBastionHost parse all bastion host
+func ParseAllBastionHost() {
+	for k, v:= range BastionMap {
+		err := v.ParseHost()
+		if err != nil {
+			log.Errorf("Bastion Host error: [%s / %s] - %v", k, BastionMap[k].Host, err)
+			delete(BastionMap, k)
+			continue
+		}
+		BastionMap[k] = v
+	}
+}
+
 // Config SSH Config Object
 func (s *Server) Config(gConf global.ProbeSettings) error {
 
@@ -71,9 +84,8 @@ func (s *Server) Config(gConf global.ProbeSettings) error {
 		if bastion, ok := BastionMap[s.BastionID]; ok {
 			log.Debugf("[%s / %s] - has the bastion [%s]", s.ProbeKind, s.ProbeName, bastion.Host)
 			s.bastion = &bastion
-			if err := s.bastion.ParseHost(); err != nil {
-				return err
-			}
+		} else {
+			log.Warnf("[%s / %s] - wrong bastion [%s]", s.ProbeKind, s.ProbeName, s.BastionID)
 		}
 	}
 


### PR DESCRIPTION
- Support the bastion/jumper server 
- SSH host support  `user@server:port` scheme
- recursively reflect the probe interface in config structure
- remove the "known_hosts".
- refine the probe log code - remove the duplication code