### PR TITLE
feat(probe): support host resource usage probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,10 @@ Support the host probe, the configuration example as below.
 
 The feature probe the CPU, Memory, and Disk usage, if one of them exceeds the threshold, then mark the host as status down.
 
-> Note: The disk usage only check the root disk.
+> Note: 
+> - The thresholds are **OR** condition, if one of them exceeds the threshold, then mark the host as status down.
+> - The Host needs remote server have the following command: `top`, `df`, `free`, `awk`, `grep`, `tr`, and `hostname` (check the [source code](./blob/work/probe/host/host.go) to see how it works).
+> - The disk usage only check the root disk.
 
 ```yaml
 host:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ EaseProbe is a simple, standalone, and lightWeight tool that can do health/statu
     - [3.2 TCP Probe Configuration](#32-tcp-probe-configuration)
     - [3.3 Shell Command Probe Configuration](#33-shell-command-probe-configuration)
     - [3.4 SSH Command Probe Configuration](#34-ssh-command-probe-configuration)
+    - [3.5 Host Resource Usage Probe Configuration](#35-host-resource-usage-probe-configuration)
     - [3.5 Native Client Probe](#35-native-client-probe)
     - [3.6 Notification Configuration](#36-notification-configuration)
     - [3.7 Global Setting Configuration](#37-global-setting-configuration)
@@ -27,7 +28,7 @@ EaseProbe would do 3 kinds of work - **Probe**, **Notify**, and **Report**.
 
 ### 1.1 Probe
 
-Ease Probe supports the following probing methods:
+Ease Probe supports the following probing methods: **HTTP**, **TCP**, **Shell Command**, **SSH Command**,  **Host Resource Usage**, and **Native Client**.
 
 - **HTTP**. Checking the HTTP status code, Support mTLS, HTTP Basic Auth, and can set the Request Header/Body. ( [HTTP Probe Configuration](#31-http-probe-configuration) )
 
@@ -77,6 +78,20 @@ Ease Probe supports the following probing methods:
         key: /Users/user/.ssh/id_rsa
         cmd: "ps auxwe | grep easeprobe | grep -v grep"
         contain: easeprobe
+  ```
+
+  - **Host**. Run a SSh command on remote host and check the CPU, Memory, and Disk usage. ( [Host Load Probe](#35-native-client-probe) )
+
+  ```yaml
+  host:
+    servers:
+      - name : server
+        host: ubuntu@172.20.2.202:22
+        key: /path/to/server.pem
+        threshold:
+          cpu: 0.80  # cpu usage  80%
+          mem: 0.70  # memory usage 70%
+          disk: 0.90  # disk usage 90%
   ```
 
 - **Client**. Currently, support the following native client. Support the mTLS. ( [Native Client Probe](#35-native-client-probe) )
@@ -351,7 +366,35 @@ ssh:
       cmd: "ps -ef | grep kafka"
 ```
 
+### 3.5 Host Resource Usage Probe Configuration
 
+Support the host probe, the configuration example as below.
+
+The feature probe the CPU, Memory, and Disk usage, if one of them exceeds the threshold, then mark the host as status down.
+
+```yaml
+host:
+  bastion: # bastion server configuration
+    aws: # bastion host ID      ◄──────────────────┐
+      host: ubuntu@example.com # bastion host      │
+      key: /path/to/bastion.pem # private key file │
+  # Servers List                                   │
+  servers: #                                       │
+    - name : aws server   #                        │
+      bastion: aws #  <-- bastion server id ------─┘
+      host: ubuntu@172.20.2.202:22
+      key: /path/to/server.pem
+      threshold:
+        cpu: 0.80  # cpu usage  80%
+        mem: 0.70  # memory usage 70%
+        disk: 0.90  # disk usage 90%
+
+    # Using the default threshold 
+    # cpu 80%, mem 80% and disk 95%
+    - name : My VPS
+      host: user@example.com:22
+      key: /Users/user/.ssh/id_rsa
+```
 
 ### 3.5 Native Client Probe
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ EaseProbe is a simple, standalone, and lightWeight tool that can do health/statu
     - [3.3 Shell Command Probe Configuration](#33-shell-command-probe-configuration)
     - [3.4 SSH Command Probe Configuration](#34-ssh-command-probe-configuration)
     - [3.5 Host Resource Usage Probe Configuration](#35-host-resource-usage-probe-configuration)
-    - [3.5 Native Client Probe](#35-native-client-probe)
-    - [3.6 Notification Configuration](#36-notification-configuration)
-    - [3.7 Global Setting Configuration](#37-global-setting-configuration)
+    - [3.6 Native Client Probe](#36-native-client-probe)
+    - [3.7 Notification Configuration](#37-notification-configuration)
+    - [3.8 Global Setting Configuration](#38-global-setting-configuration)
   - [4. Community](#4-community)
   - [5. License](#5-license)
 
@@ -80,7 +80,7 @@ Ease Probe supports the following probing methods: **HTTP**, **TCP**, **Shell Co
         contain: easeprobe
   ```
 
-  - **Host**. Run a SSh command on remote host and check the CPU, Memory, and Disk usage. ( [Host Load Probe](#35-native-client-probe) )
+- **Host**. Run a SSH command on remote host and check the CPU, Memory, and Disk usage. ( [Host Load Probe](#35-host-resource-usage-probe-configuration) )
 
   ```yaml
   host:
@@ -94,7 +94,7 @@ Ease Probe supports the following probing methods: **HTTP**, **TCP**, **Shell Co
           disk: 0.90  # disk usage 90%
   ```
 
-- **Client**. Currently, support the following native client. Support the mTLS. ( [Native Client Probe](#35-native-client-probe) )
+- **Client**. Currently, support the following native client. Support the mTLS. ( [Native Client Probe](#36-native-client-probe) )
   - **MySQL**. Connect to the MySQL server and run the `SHOW STATUS` SQL.
   - **Redis**. Connect to the Redis server and run the `PING` command.
   - **MongoDB**. Connect to MongoDB server and just ping server.
@@ -166,7 +166,7 @@ notify:
       webhook: "https://oapi.dingtalk.com/robot/send?access_token=xxxx"
 ```
 
-Check the  [Notification Configuration](#36-notification-configuration) to see how to configure it.
+Check the  [Notification Configuration](#37-notification-configuration) to see how to configure it.
 
 ### 1.3 Report
 
@@ -182,7 +182,7 @@ settings:
     time: "23:59"
 ```
 
-for more information, please check the [3.7 Global Setting Configuration](#37-global-setting-configuration)
+For more information, please check the [Global Setting Configuration](#38-global-setting-configuration)
 
 ## 2. Getting Start
 
@@ -372,6 +372,8 @@ Support the host probe, the configuration example as below.
 
 The feature probe the CPU, Memory, and Disk usage, if one of them exceeds the threshold, then mark the host as status down.
 
+> Note: The disk usage only check the root disk.
+
 ```yaml
 host:
   bastion: # bastion server configuration
@@ -396,7 +398,7 @@ host:
       key: /Users/user/.ssh/id_rsa
 ```
 
-### 3.5 Native Client Probe
+### 3.6 Native Client Probe
 
 ```YAML
 # Native Client Probe
@@ -448,7 +450,7 @@ client:
 ```
 
 
-### 3.6 Notification Configuration
+### 3.7 Notification Configuration
 
 ```YAML
 # Notification Configuration
@@ -519,7 +521,7 @@ notify:
 ```
 
 
-### 3.7 Global Setting Configuration
+### 3.8 Global Setting Configuration
 
 ```YAML
 # Global settings for all probes and notifiers.

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -29,6 +29,7 @@ import (
 	"github.com/megaease/easeprobe/notify"
 	"github.com/megaease/easeprobe/probe"
 	"github.com/megaease/easeprobe/probe/client"
+	"github.com/megaease/easeprobe/probe/host"
 	"github.com/megaease/easeprobe/probe/http"
 	"github.com/megaease/easeprobe/probe/shell"
 	"github.com/megaease/easeprobe/probe/ssh"
@@ -140,8 +141,9 @@ type Conf struct {
 	HTTP     []http.HTTP     `yaml:"http"`
 	TCP      []tcp.TCP       `yaml:"tcp"`
 	Shell    []shell.Shell   `yaml:"shell"`
-	SSH      ssh.SSH         `yaml:"ssh"`
 	Client   []client.Client `yaml:"client"`
+	SSH      ssh.SSH         `yaml:"ssh"`
+	Host     host.Host       `yaml:"host"`
 	Notify   notify.Config   `yaml:"notify"`
 	Settings Settings        `yaml:"settings"`
 }
@@ -149,14 +151,18 @@ type Conf struct {
 // New read the configuration from yaml
 func New(conf *string) (Conf, error) {
 	c := Conf{
-		HTTP:  []http.HTTP{},
-		TCP:   []tcp.TCP{},
-		Shell: []shell.Shell{},
+		HTTP:   []http.HTTP{},
+		TCP:    []tcp.TCP{},
+		Shell:  []shell.Shell{},
+		Client: []client.Client{},
 		SSH: ssh.SSH{
 			Bastion: &ssh.BastionMap,
 			Servers: []ssh.Server{},
 		},
-		Client: []client.Client{},
+		Host: host.Host{
+			Bastion: &host.BastionMap,
+			Servers: []host.Server{},
+		},
 		Notify: notify.Config{},
 		Settings: Settings{
 			LogFile:    "",
@@ -196,7 +202,8 @@ func New(conf *string) (Conf, error) {
 	}
 
 	c.initLog()
-	ssh.ParseAllBastionHost()
+	ssh.BastionMap.ParseAllBastionHost()
+	host.BastionMap.ParseAllBastionHost()
 
 	config = &c
 

--- a/notify/base/base.go
+++ b/notify/base/base.go
@@ -78,9 +78,9 @@ func (c *DefaultNotify) NotifyStat(probers []probe.Prober) {
 // SendWithRetry sends the notification with retry if got error
 func (c *DefaultNotify) SendWithRetry(title string, message string, tag string) {
 	fn := func() error {
-		log.Debugf("[%s / %s] - %s", c.MyKind, tag, title)
+		log.Debugf("[%s / %s / %s] - %s", c.MyKind, c.Name, tag, title)
 		if c.SendFunc == nil {
-			log.Errorf("[%s / %s] - %s SendFunc is nil", c.MyKind, tag, title)
+			log.Errorf("[%s / %s / %s] - %s SendFunc is nil", c.MyKind, c.Name, tag, title)
 		}
 		return c.SendFunc(title, message)
 	}

--- a/notify/slack/slack.go
+++ b/notify/slack/slack.go
@@ -80,6 +80,7 @@ func (c *NotifyConfig) SendSlackNotification(msg string) error {
 		return err
 	}
 	if resp.StatusCode != 200 {
+		log.Debugf(msg)
 		return fmt.Errorf("Error response from Slack [%d] - [%s]", resp.StatusCode, string(buf))
 	}
 	// if buf.String() != "ok" {

--- a/probe/host/host.go
+++ b/probe/host/host.go
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package host
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/probe"
+	"github.com/megaease/easeprobe/probe/ssh"
+	log "github.com/sirupsen/logrus"
+)
+
+// Default threshold
+const (
+	DefaultCPUThreshold  = 0.8
+	DefaultMemThreshold  = 0.8
+	DefaultDiskThreshold = 0.95
+)
+
+// Threshold is the threshold of a probe
+type Threshold struct {
+	CPU  float64 `yaml:"cpu"`
+	Mem  float64 `yaml:"mem"`
+	Disk float64 `yaml:"disk"`
+}
+
+func (t *Threshold) String() string {
+	return fmt.Sprintf("CPU: %.2f, Mem: %.2f, Disk: %.2f", t.CPU, t.Mem, t.Disk)
+}
+
+// Server is the server of a host probe
+type Server struct {
+	ssh.Server `yaml:",inline"`
+	Threshold  Threshold `yaml:"threshold"`
+}
+
+// Host is the host probe configuration
+type Host struct {
+	Bastion *ssh.BastionMapType `yaml:"bastion"`
+	Servers []Server            `yaml:"servers"`
+}
+
+// BastionMap is a map of bastion
+var BastionMap ssh.BastionMapType
+
+// Config is the host probe configuration
+func (s *Server) Config(gConf global.ProbeSettings) error {
+	kind := "host"
+	tag := "server"
+	name := s.ProbeName
+
+	// The following commands are:
+	// 1. retrive the hostname: 	`hostname``
+	// 2. retrive the os:  			`awk -F= '/^NAME/{print $2}' /etc/os-release | tr -d '\"'`
+	// 3. retrive the memory usage:	`free -m | awk 'NR==2{printf "%s %s %.2f\n", $3,$2,$3*100/$2 }'`
+	// 4. retrive the cpu core:		`grep -c ^processor /proc/cpuinfo;`
+	// 5. retrive the cpu usage:	`top -b -n 1 | grep Cpu | awk -F ":" '{print $2}'`
+	// 6. retrive the disk usage	`df -h | awk '$NF=="/"{printf "%d %d %s\n", $3,$2,$5}'`
+	s.Command = `hostname;
+	awk -F= '/^NAME/{print $2}' /etc/os-release | tr -d '\"';
+	free -m | awk 'NR==2{printf "%s %s %.2f\n", $3,$2,$3*100/$2 }';
+	grep -c ^processor /proc/cpuinfo;
+	top -b -n 1 | grep Cpu | awk -F ":" '{print $2}';
+	df -h | awk '$NF=="/"{printf "%d %d %s\n", $3,$2,$5}'`
+
+	if s.Threshold.CPU == 0 {
+		s.Threshold.CPU = DefaultCPUThreshold
+	}
+	if s.Threshold.Mem == 0 {
+		s.Threshold.Mem = DefaultMemThreshold
+	}
+	if s.Threshold.Disk == 0 {
+		s.Threshold.Disk = DefaultDiskThreshold
+	}
+
+	endpoint := s.Threshold.String()
+	return s.Configure(gConf, kind, tag, name, endpoint, &BastionMap, s.DoProbe)
+}
+
+// DoProbe return the checking result
+func (s *Server) DoProbe() (bool, string) {
+
+	output, err := s.RunSSHCmd()
+
+	if err != nil {
+		log.Errorf("[%s / %s] %v", s.ProbeKind, s.ProbeName, err)
+		return false, err.Error() + " - " + output
+	}
+
+	log.Debugf("[%s / %s] - %s", s.ProbeKind, s.ProbeName, probe.CommandLine(s.Command, s.Args))
+	log.Debugf("[%s / %s] - %s", s.ProbeKind, s.ProbeName, probe.CheckEmpty(string(output)))
+
+	info, err := s.ParseHostInfo(string(output))
+	if err != nil {
+		log.Errorf("[%s / %s] %v", s.ProbeKind, s.ProbeName, err)
+		return false, fmt.Sprintf("Prase the output failed: %v", err)
+	}
+	log.Debugf("[%s / %s] - %+v", s.ProbeKind, s.ProbeName, info)
+	return s.CheckThreshold(info)
+}
+
+// CheckThreshold check the threshold
+func (s *Server) CheckThreshold(info Info) (bool, string) {
+	status := true
+	head := "Fine! "
+	message := fmt.Sprintf("( CPU: %.2f%% - ", (100 - info.CPU.Idle))
+	message += fmt.Sprintf("Memory: %.2f%% - ", info.Memory.Usage)
+	message += fmt.Sprintf("Disk: %.2f%% )", info.Disk.Usage)
+
+	if (s.Threshold.CPU > 0 && s.Threshold.CPU <= (100-info.CPU.Idle)/100) ||
+		(s.Threshold.Mem > 0 && s.Threshold.Mem <= info.Memory.Usage/100) ||
+		(s.Threshold.Disk > 0 && s.Threshold.Disk <= info.Disk.Usage/100) {
+		head = "Busy! "
+		status = false
+	}
+	return status, head + message
+}
+
+// Usage is the resource usage for memory and disk
+type Usage struct {
+	Used  int     `yaml:"used"`
+	Total int     `yaml:"total"`
+	Usage float64 `yaml:"usage"`
+}
+
+// CPU is the cpu usage
+// "1.6 us,  1.6 sy,  3.2 ni, 91.9 id,  1.6 wa,  0.0 hi,  0.0 si,  0.0 st"
+type CPU struct {
+	User  float64 `yaml:"user"`
+	Sys   float64 `yaml:"sys"`
+	Nice  float64 `yaml:"nice"`
+	Idle  float64 `yaml:"idle"`
+	Wait  float64 `yaml:"wait"`
+	Hard  float64 `yaml:"hard"`
+	Soft  float64 `yaml:"soft"`
+	Steal float64 `yaml:"steal"`
+}
+
+// Parse a string to a CPU struct
+func (c *CPU) Parse(s string) error {
+	cpu := strings.Split(s, ",")
+	if len(cpu) < 8 {
+		return fmt.Errorf("invalid cpu output")
+	}
+	c.User = strFloat(first(cpu[0]))
+	c.Sys = strFloat(first(cpu[1]))
+	c.Nice = strFloat(first(cpu[2]))
+	c.Idle = strFloat(first(cpu[3]))
+	c.Wait = strFloat(first(cpu[4]))
+	c.Hard = strFloat(first(cpu[5]))
+	c.Soft = strFloat(first(cpu[6]))
+	c.Steal = strFloat(first(cpu[7]))
+	return nil
+}
+
+func first(str string) string {
+	return strings.Split(strings.TrimSpace(str), " ")[0]
+}
+
+// Info is the host probe information
+type Info struct {
+	HostName string `yaml:"hostname"`
+	OS       string `yaml:"os"`
+	Core     int64  `yaml:"core"`
+	CPU      CPU    `yaml:"cpu"`
+	Memory   Usage  `yaml:"memory"`
+	Disk     Usage  `yaml:"disk"`
+}
+
+// ParseHostInfo parse the host info
+func (s *Server) ParseHostInfo(str string) (Info, error) {
+	info := Info{}
+	line := strings.Split(str, "\n")
+	if len(line) < 5 {
+		return info, fmt.Errorf("invalid output")
+	}
+
+	info.HostName = line[0]
+	info.OS = line[1]
+
+	mem := strings.Split(line[2], " ")
+	if len(mem) < 3 {
+		return info, fmt.Errorf("invalid memory output")
+	}
+	info.Memory.Used = int(strInt(mem[0]))
+	info.Memory.Total = int(strInt(mem[1]))
+	info.Memory.Usage = strFloat(mem[2])
+
+	info.Core = strInt(line[3])
+	if err := info.CPU.Parse(line[4]); err != nil {
+		return info, err
+	}
+
+	disk := strings.Split(line[5], " ")
+	if len(disk) < 3 {
+		return info, fmt.Errorf("invalid disk output")
+	}
+	info.Disk.Used = int(strInt(disk[0]))
+	info.Disk.Total = int(strInt(disk[1]))
+	info.Disk.Usage = strFloat(disk[2][:len(disk[2])-1])
+
+	return info, nil
+}
+
+func strFloat(str string) float64 {
+	n, _ := strconv.ParseFloat(str, 32)
+	return n
+}
+
+func strInt(str string) int64 {
+	n, _ := strconv.ParseInt(str, 10, 32)
+	return n
+}

--- a/probe/ssh/endpoint.go
+++ b/probe/ssh/endpoint.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ssh
 
 import (

--- a/probe/ssh/endpoint_test.go
+++ b/probe/ssh/endpoint_test.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ssh
 
 import "testing"

--- a/report/sla.go
+++ b/report/sla.go
@@ -238,7 +238,7 @@ func SLASlackSection(r *probe.Result) string {
 		message = "`" + message + "`"
 	}
 
-	return fmt.Sprintf(json, r.Name, r.Endpoint,
+	return fmt.Sprintf(json, r.Name, JSONEscape(r.Endpoint),
 		DurationStr(r.Stat.UpTime), DurationStr(r.Stat.DownTime), SLAPercent(r),
 		r.Stat.Total, SLAStatusText(r.Stat, MarkdownSocial),
 		t, r.Status.Emoji()+" "+r.Status.String(), message)


### PR DESCRIPTION
Support the host probe, the configuration example as below.

The feature probe the CPU, Memory, and Disk usage, if one of them exceeds the threshold, then mark the host as status down.

```yaml
host:
  bastion: # bastion server configuration
    aws:
      host: ubuntu@example.com
      key: /path/to/bastion.pem

  servers:
    - name : aws server
      bastion: aws #  <-- bastion server id
      host: ubuntu@172.20.2.202:22
      key: /path/to/server.pem
      threshold:
        cpu: 0.80  # cpu usage  80%
        mem: 0.70  # memory usage 70%
        disk: 0.90  # disk usage 90%

    # using the default threshold - cpu 80%, mem 80%  and disk 95%
    - name : My VPS
      host: user@example.com:22
      key: /Users/user/.ssh/id_rsa
```