### PR TITLE
bug-fixing: mysql client connection leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,10 +358,10 @@ ssh:
     aws: # bastion host ID      ◄──────────────────────────────┐
       host: aws.basition.com:22 #                              │
       username: ubuntu # login user                            │
-      key: /patch/to/aws/basion/key.pem # private key file     │
+      key: /path/to/aws/basion/key.pem # private key file      │
     gcp: # bastion host ID                                     │
       host: ubuntu@gcp.basition.com:22 # bastion host          │
-      key: /patch/to/gcp/basion/key.pem # private key file     │
+      key: /path/to/gcp/basion/key.pem # private key file      │
   # SSH Probe configuration                                    │
   servers:   #                                                 │
     # run redis-cli ping and check the "PONG"                  │

--- a/probe/client/mysql/mysql.go
+++ b/probe/client/mysql/mysql.go
@@ -78,6 +78,9 @@ func (r MySQL) Probe() (bool, string) {
 	}
 
 	db, err := sql.Open("mysql", r.ConnStr)
+	if err != nil {
+		return false, err.Error()
+	}
 	defer db.Close()
 
 	err = db.Ping()

--- a/probe/client/mysql/mysql.go
+++ b/probe/client/mysql/mysql.go
@@ -84,10 +84,11 @@ func (r MySQL) Probe() (bool, string) {
 	if err != nil {
 		return false, err.Error()
 	}
-	_, err = db.Query("show status like \"uptime\"") // run a SQL to test
+	row, err := db.Query("show status like \"uptime\"") // run a SQL to test
 	if err != nil {
 		return false, err.Error()
 	}
+	defer row.Close()
 
 	return true, "Check MySQL Server Successfully!"
 

--- a/web/server.go
+++ b/web/server.go
@@ -59,10 +59,10 @@ func Server() {
 	host := c.Settings.HTTPServer.IP
 	port := c.Settings.HTTPServer.Port
 
-	// Configure the http server 
-	if len(host)>0 && net.ParseIP(host) == nil {
+	// Configure the http server
+	if len(host) > 0 && net.ParseIP(host) == nil {
 		host = global.DefaultHTTPServerIP
-	} 
+	}
 	p, err := strconv.Atoi(port)
 	if err != nil || p <= 1024 || p > 65535 {
 		log.Warnf("[Web] Invalid port number: %s, use the default value: %s", port, global.DefaultHTTPServerPort)


### PR DESCRIPTION
fix issue #56 

- fix the connection leak - run  `row.Close()` after the `sql.Query()` 
- fix the null pointer error if the `sql.Open()` return error
- typo fix and `go fmt`

