### PR TITLE
Use discord username

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ notify:
   sms:
     - name: "sms alert service"
       provider: "yunpian"
-      key: xxxxxxxxxxxx # yunpian apikey 
+      key: xxxxxxxxxxxx # yunpian apikey
       mobile: 123456789,987654321 # mobile phone number, multiple phone number joint by `,`
       sign: "xxxxxxxx" # need to register; usually brand name
 ```
@@ -539,6 +539,7 @@ notify:
   # Notify to Discord Text Channel
   discord:
     - name: "Server #Alert"
+      username: EaseProbe #The name you like to appear on your messages
       webhook: "https://discord.com/api/webhooks/...../....../"
       # the avatar and thumbnail setting for notify block
       avatar: "https://img.icons8.com/ios/72/appointment-reminders--v1.png"
@@ -585,7 +586,7 @@ notify:
   sms:
     - name: "sms alert service - yunpian"
       provider: "yunpian"
-      key: xxxxxxxxxxxx # yunpian apikey 
+      key: xxxxxxxxxxxx # yunpian apikey
       mobile: 123456789,987654321 # mobile phone number, multi phone number joint by `,`
       sign: "xxxxx" # get this from yunpian
 

--- a/notify/discord/discord.go
+++ b/notify/discord/discord.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -155,6 +156,11 @@ func (c *NotifyConfig) NewDiscord(result probe.Result) Discord {
 	description := fmt.Sprintf("%s %s - ⏱ %s\n```%s```",
 		result.Status.Emoji(), result.Endpoint, rtt, result.Message)
 
+	myname, err := os.Hostname()
+	if err != nil {
+		myname = "localhost.localdomain"
+	}
+
 	discord.Embeds = append(discord.Embeds, Embed{
 		Author:      Author{},
 		Title:       result.Title(),
@@ -164,7 +170,7 @@ func (c *NotifyConfig) NewDiscord(result probe.Result) Discord {
 		Timestamp:   result.StartTime.UTC().Format(time.RFC3339),
 		Thumbnail:   Thumbnail{URL: c.Thumbnail},
 		Fields:      []Fields{},
-		Footer:      Footer{Text: "Probed at", IconURL: global.Icon},
+		Footer:      Footer{Text: "Probed from " + myname + " at", IconURL: global.Icon},
 	})
 	return discord
 }

--- a/notify/discord/discord.go
+++ b/notify/discord/discord.go
@@ -104,6 +104,7 @@ type Discord struct {
 // NotifyConfig is the slack notification configuration
 type NotifyConfig struct {
 	base.DefaultNotify `yaml:",inline"`
+	Username           string `yaml:"username"`
 	WebhookURL         string `yaml:"webhook"`
 	Avatar             string `yaml:"avatar"`
 	Thumbnail          string `yaml:"thumbnail"`
@@ -127,6 +128,10 @@ func (c *NotifyConfig) Config(gConf global.NotifySettings) error {
 		c.Thumbnail = global.Icon
 	}
 
+	if len(strings.TrimSpace(c.Username)) <= 0 {
+		c.Username = global.Prog
+	}
+
 	log.Debugf("Notification [%s] - [%s] configuration: %+v", c.MyKind, c.Name, c)
 	return nil
 }
@@ -134,7 +139,7 @@ func (c *NotifyConfig) Config(gConf global.NotifySettings) error {
 // NewDiscord new a discord object from a result
 func (c *NotifyConfig) NewDiscord(result probe.Result) Discord {
 	discord := Discord{
-		Username:  global.Prog,
+		Username:  c.Username,
 		AvatarURL: c.Avatar,
 		Content:   "",
 		Embeds:    []Embed{},
@@ -246,7 +251,7 @@ func (c *NotifyConfig) NewEmbeds(probers []probe.Prober) []Discord {
 
 	for p := 0; p < pages; p++ {
 		discord := Discord{
-			Username:  global.Prog,
+			Username:  c.Username,
 			AvatarURL: c.Avatar,
 			Content:   fmt.Sprintf("**Overall SLA Report (%d/%d)**", p+1, pages),
 			Embeds:    []Embed{},


### PR DESCRIPTION
Hi, I had 3 different easeprobe instances running on 3 different hosts monitoring the same targets (for triangulation purposes) but when the alerts on discord arrived i couldnt distinguish which is which since all of them had the same name. 

This change adds support for setting the username that the discord notifications will appear from 
![image](https://user-images.githubusercontent.com/4373752/167451913-25669291-6f2c-495b-a49d-29c458e33b32.png)

```yaml
    - name: "easeprobe #Alert"
      username: "my bot username"
      webhook: "https://discord.com/api/webhooks/.../..."
```