### PR TITLE
Support max backups of SLA data files

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,6 +715,8 @@ settings:
     # SLA data persistence file path.
     # The default location is `$CWD/data/data.yaml`
     data: /path/to/data/file.yaml
+    backups: 5 # max of SLA data file backups. default: 5
+               # if set to a negative value, keep all backup files
 
   notify:
     # dry: true # Global settings for dry run

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -99,6 +99,7 @@ type SLAReport struct {
 	Time     string   `yaml:"time"`
 	Debug    bool     `yaml:"debug"`
 	DataFile string   `yaml:"data"`
+	Backups  int      `yaml:"backups"`
 }
 
 // HTTPServer is the settings of http server
@@ -215,7 +216,8 @@ func New(conf *string) (*Conf, error) {
 				Schedule: Daily,
 				Time:     "00:00",
 				Debug:    false,
-				DataFile: "",
+				DataFile: global.DefaultDataFile,
+				Backups:  global.DefaultMaxBackups,
 			},
 			HTTPServer: HTTPServer{
 				IP:        global.DefaultHTTPServerIP,
@@ -292,6 +294,7 @@ func (conf *Conf) initData() {
 		log.Warnf("Cannot load data from file: %v", err)
 	}
 
+	probe.CleanDataFile(filename, conf.Settings.SLAReport.Backups)
 }
 
 // isProbe checks whether a interface is a probe type

--- a/probe/data.go
+++ b/probe/data.go
@@ -97,7 +97,7 @@ func LoadDataFromFile(filename string) error {
 		return err
 	}
 
-	time := time.Now().Format(time.RFC3339)
+	time := time.Now().UTC().Format(time.RFC3339)
 	os.Rename(filename, filename+"-"+time)
 
 	return nil

--- a/probe/data.go
+++ b/probe/data.go
@@ -127,7 +127,7 @@ func CleanDataFile(filename string, backups int) {
 	// remove the oldest backup files
 	sort.Strings(matches)
 
-	for i := 0; i < len(matches) - backups; i++ {
+	for i := 0; i < len(matches)-backups; i++ {
 		if err := os.Remove(matches[i]); err != nil {
 			log.Errorf("Cannot clean data file: %v", err)
 			continue


### PR DESCRIPTION
Support to configure the max of SLA data file backups. default: 5
If set to a negative value, keep all backup files

```yaml
  sla:
    data: /tmp/data/data.yaml
    backups: 20
```

keep addressing the issue  #69 