### PR TITLE
bug-fixing: mkdir error  when the SLA data file is not specified the path

### DIFF
--- a/cmd/easeprobe/main.go
+++ b/cmd/easeprobe/main.go
@@ -166,7 +166,7 @@ func saveData(doneSave chan bool) {
 	file := c.Settings.SLAReport.DataFile
 	save := func() {
 		if err := probe.SaveDataToFile(file); err != nil {
-			log.Errorf("Failed to save the SLA data to file: %v", err)
+			log.Errorf("Failed to save the SLA data to file(%s): %v", file, err)
 		} else {
 			log.Debugf("Successfully save the SLA data to file: %s", file)
 		}

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -284,7 +284,7 @@ func (conf *Conf) initData() {
 		file = global.DefaultDataFile
 	}
 	// if dir is empty, get the working directory
-	if strings.TrimSpace(dir) == ""  {
+	if strings.TrimSpace(dir) == "" {
 		dir = global.GetWorkDir()
 	}
 	filename := filepath.Join(dir, "data", file)

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -278,12 +278,17 @@ func logLogfileInfo(name string, file string) {
 
 func (conf *Conf) initData() {
 
-	filename := conf.Settings.SLAReport.DataFile
-	if filename == "" {
-		dir := global.GetWorkDir()
-		filename = filepath.Join(dir, "data", global.DefaultDataFile)
-		conf.Settings.SLAReport.DataFile = filename
+	dir, file := filepath.Split(conf.Settings.SLAReport.DataFile)
+	// if filename is empty, use default file name
+	if strings.TrimSpace(file) == "" {
+		file = global.DefaultDataFile
 	}
+	// if dir is empty, get the working directory
+	if strings.TrimSpace(dir) == ""  {
+		dir = global.GetWorkDir()
+	}
+	filename := filepath.Join(dir, "data", file)
+	conf.Settings.SLAReport.DataFile = filename
 
 	if _, err := os.Stat(filename); os.IsNotExist(err) {
 		log.Infof("The data file %s is not found!", filename)
@@ -291,7 +296,7 @@ func (conf *Conf) initData() {
 	}
 
 	if err := probe.LoadDataFromFile(filename); err != nil {
-		log.Warnf("Cannot load data from file: %v", err)
+		log.Warnf("Cannot load data from file(%s): %v", filename, err)
 	}
 
 	probe.CleanDataFile(filename, conf.Settings.SLAReport.Backups)


### PR DESCRIPTION
If the configuration is:

```yaml
settings:
   sla:
        data: data.yaml
```

The EaseProbe would raise an error 

```
Failed to save the SLA data to file: mkdir : no such file or directory
```

Because the `dir` string we pass to `os.MkdirAll(dir, 0755)` is empty. 

this is a fix for this bug.