### PR TITLE
EaseProbe exits if the web server address already in use

### DIFF
--- a/cmd/easeprobe/main.go
+++ b/cmd/easeprobe/main.go
@@ -80,6 +80,9 @@ func main() {
 		log.Infoln("Dry Notification Mode...")
 	}
 
+	// Start the HTTP Server
+	web.Server()
+
 	// Probers
 	probers := c.AllProbers()
 
@@ -107,9 +110,8 @@ func main() {
 	// Start the Event Watching
 	go watchEvent(notifyChan, notifies, doneWatch)
 
-	// Start the HTTP Server
+	// Set probers into web server
 	web.SetProbers(probers)
-	web.Server()
 
 	// Set the Cron Job for SLA Report
 	if conf.Get().Settings.SLAReport.Schedule != conf.None {

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	go.mongodb.org/mongo-driver v1.9.0
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
 	golang.org/x/exp v0.0.0-20220328175248-053ad81199eb
+	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
@@ -47,7 +48,6 @@ require (
 	github.com/xdg-go/stringprep v1.0.2 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect


### PR DESCRIPTION
This PR addresses the issue #89 

1)  splite the `http.LisentAndServe()` to  `net.Lisen()` and `http.Serve()`
2) move the `web.Server()` before starting the probe and notifcation, so that easeprobe can be exited safely.