### PR TITLE
remove sigint from our main handlers

### DIFF
--- a/cmd/easeprobe/main.go
+++ b/cmd/easeprobe/main.go
@@ -123,7 +123,6 @@ func main() {
 	// Graceful Shutdown
 	done := make(chan os.Signal)
 	signal.Notify(done, syscall.SIGTERM)
-	signal.Notify(done, syscall.SIGINT)
 
 	// Rotate the log file
 	rotateLog := make(chan os.Signal, 1)


### PR DESCRIPTION
This PR removes SIGINT from our handlers and brings back instant stop when CTRL+C is pressed

fixes #88