### PR TITLE
Disable SLA persistence when conf.Settings.SLAReport.DataFile is "-"

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ EaseProbe would do three kinds of work - **Probe**, **Notify**, and **Report**.
 
 Ease Probe supports the following probing methods: **HTTP**, **TCP**, **Shell Command**, **SSH Command**,  **Host Resource Usage**, and **Native Client**.
 
-> **Notes**:
+
+> **Note**:
 >
-> The prober name is a unique ID, DO NOT use the same name for a different prober.
+> **Keep in mind that the prober name must be **unique** among probes. If multiple probes are defined with the same name, it could lead to corruption of the metrics data and the behavior of the application will be non-deterministic.**
 
 - **HTTP**. Checking the HTTP status code, Support mTLS, HTTP Basic Auth, and can set the Request Header/Body. ( [HTTP Probe Configuration](#31-http-probe-configuration) )
 
@@ -183,7 +184,7 @@ notify:
   sms:
     - name: "sms alert service"
       provider: "yunpian"
-      key: xxxxxxxxxxxx # yunpian apikey 
+      key: xxxxxxxxxxxx # yunpian apikey
       mobile: 123456789,987654321 # mobile phone number, multiple phone number joint by `,`
       sign: "xxxxxxxx" # need to register; usually brand name
 ```
@@ -216,13 +217,9 @@ Check the  [Notification Configuration](#37-notification-configuration) to see h
 
 - **SLA Data Persistence**. Save the SLA statistics data on the disk.
 
-  The SLA data would be persisted in `$CWD/data/data.yaml` by default. If you want to configure the path, you can do it in the `settings` section.
+  The SLA data would be persisted in `$CWD/data.yaml` by default. If you want to configure the path, you can do it in the `settings` section.
 
-  Whenever EaseProbe starts,  load the data if found, and remove the probers that are not in configuration if the configuration changes.
-
-  > **Note**:
-  >
-  > **The prober's name is a unique ID, so if multiple probes with the same name, the data would conflict, and the behavior is unknown.**
+  When EaseProbe starts, it loads the data found in `data.yaml` (if found) and removes any probers that are no longer present in the configuration file. Setting a an empty `data:` disables SLA persistence (eg `data: ""`).
 
   ```YAML
   settings:
@@ -248,7 +245,7 @@ There are some administration configuration options:
     pid: /var/run/easeprobe.pid
   ```
 
-  - If the file already exists, EaseProbe would overwrite it. 
+  - If the file already exists, EaseProbe would overwrite it.
   - If the file cannot be written, EaseProbe would exit with an error.
 
   If you want to disable the PID file, you can configure the pid file to "".
@@ -260,7 +257,7 @@ There are some administration configuration options:
 
 **2) Log file Rotation**
 
-  There are two types of log file: **Application Log** and **HTTP Access Log**. 
+  There are two types of log file: **Application Log** and **HTTP Access Log**.
 
   Both Application Log and HTTP Access Log would be StdOut by default.  They all can be configured by:
 
@@ -270,7 +267,7 @@ There are some administration configuration options:
     self_rotate: true # default: true
   ```
 
-  If `self_rotate` is `true`, EaseProbe would rotate the log automatically, and the following options are available: 
+  If `self_rotate` is `true`, EaseProbe would rotate the log automatically, and the following options are available:
 
   ```YAML
     size: 10 # max size of log file. default: 10M
@@ -282,7 +279,7 @@ There are some administration configuration options:
   If `self_rotate` is `false`, EaseProbe will not rotate the log, and the log file will have to be rotated by a 3rd-party tool (such as `logrotate`) or manually by the administrator.
 
   ```shell
-  mv /path/to/easeprobe.log /path/to/easeprobe.log.0 
+  mv /path/to/easeprobe.log /path/to/easeprobe.log.0
   kill -HUP `cat /path/to/easeprobe.pid`
   ```
 
@@ -658,7 +655,7 @@ notify:
   sms:
     - name: "sms alert service - yunpian"
       provider: "yunpian"
-      key: xxxxxxxxxxxx # yunpian apikey 
+      key: xxxxxxxxxxxx # yunpian apikey
       mobile: 123456789,987654321 # mobile phone number, multi phone number joint by `,`
       sign: "xxxxx" # get this from yunpian
 
@@ -687,16 +684,16 @@ settings:
 
   # Daemon settings
 
-  # pid file path,  default: $CWD/easeprobe.pid, 
+  # pid file path,  default: $CWD/easeprobe.pid,
   # if set to "", will not create pid file.
-  pid: /var/run/easeprobe.pid 
+  pid: /var/run/easeprobe.pid
 
   # A HTTP Server configuration
   http:
     ip: 127.0.0.1 # the IP address of the server. default:"0.0.0.0"
     port: 8181 # the port of the server. default: 8181
     refresh: 5s # the auto-refresh interval of the server. default: the minimum value of the probes' interval.
-    log: 
+    log:
       file: /path/to/access.log # access log file. default: Stdout
       # Log Rotate Configuration (optional)
       self_rotate: true # true: self rotate log file. default: true
@@ -720,6 +717,8 @@ settings:
     # SLA data persistence file path.
     # The default location is `$CWD/data/data.yaml`
     data: /path/to/data/file.yaml
+    # Use the following to disable SLA data persistence
+    # data: ""
     backups: 5 # max of SLA data file backups. default: 5
                # if set to a negative value, keep all backup files
 

--- a/README.md
+++ b/README.md
@@ -217,9 +217,9 @@ Check the  [Notification Configuration](#37-notification-configuration) to see h
 
 - **SLA Data Persistence**. Save the SLA statistics data on the disk.
 
-  The SLA data would be persisted in `$CWD/data.yaml` by default. If you want to configure the path, you can do it in the `settings` section.
+  The SLA data would be persisted in `$CWD/data/data.yaml` by default. If you want to configure the path, you can do it in the `settings` section.
 
-  When EaseProbe starts, it loads the data found in `data.yaml` (if found) and removes any probers that are no longer present in the configuration file. Setting a an empty `data:` disables SLA persistence (eg `data: ""`).
+  When EaseProbe starts, it looks for the location of `data.yaml` and if found, load the file and remove any probes that are no longer present in the configuration file. Setting a value of `"-"` for `data:` disables SLA persistence (eg `data: "-"`).
 
   ```YAML
   settings:
@@ -679,9 +679,8 @@ notify:
 settings:
 
   # The customized name and icon
-  name : "Easeprobe" # the name of the probe: default: "EaseProbe"
-  icon : "https://path/to/icon.png" # the icon of the probe. default: "https://megaease.com/favicon.png"
-
+  name: "Easeprobe" # the name of the probe: default: "EaseProbe"
+  icon: "https://path/to/icon.png" # the icon of the probe. default: "https://megaease.com/favicon.png"
   # Daemon settings
 
   # pid file path,  default: $CWD/easeprobe.pid,
@@ -718,7 +717,7 @@ settings:
     # The default location is `$CWD/data/data.yaml`
     data: /path/to/data/file.yaml
     # Use the following to disable SLA data persistence
-    # data: ""
+    # data: "-"
     backups: 5 # max of SLA data file backups. default: 5
                # if set to a negative value, keep all backup files
 

--- a/cmd/easeprobe/main.go
+++ b/cmd/easeprobe/main.go
@@ -164,25 +164,23 @@ func main() {
 
 func saveData(doneSave chan bool) {
 	c := conf.Get()
-	if strings.TrimSpace(c.Settings.SLAReport.DataFile) != "" {
-		file := c.Settings.SLAReport.DataFile
-		save := func() {
-			if err := probe.SaveDataToFile(file); err != nil {
-				log.Errorf("Failed to save the SLA data to file(%s): %v", file, err)
-			} else {
-				log.Debugf("Successfully save the SLA data to file: %s", file)
-			}
+	file := c.Settings.SLAReport.DataFile
+	save := func() {
+		if err := probe.SaveDataToFile(file); err != nil {
+			log.Errorf("Failed to save the SLA data to file(%s): %v", file, err)
+		} else {
+			log.Debugf("Successfully save the SLA data to file: %s", file)
 		}
-		save()
-		for {
-			select {
-			case <-doneSave:
-				save()
-				log.Info("Received the exit signal, Saving data process is exiting...")
-				return
-			case <-time.After(c.Settings.Probe.Interval):
-				save()
-			}
+	}
+	save()
+	for {
+		select {
+		case <-doneSave:
+			save()
+			log.Info("Received the exit signal, Saving data process is exiting...")
+			return
+		case <-time.After(c.Settings.Probe.Interval):
+			save()
 		}
 	}
 }

--- a/cmd/easeprobe/main.go
+++ b/cmd/easeprobe/main.go
@@ -172,6 +172,12 @@ func saveData(doneSave chan bool) {
 			log.Debugf("Successfully save the SLA data to file: %s", file)
 		}
 	}
+
+	// if datafile is explicitly disabled redefine as empty
+	if c.Settings.SLAReport.DataFile != "-" {
+		save = func() {}
+	}
+
 	save()
 	for {
 		select {

--- a/cmd/easeprobe/main.go
+++ b/cmd/easeprobe/main.go
@@ -164,26 +164,27 @@ func main() {
 
 func saveData(doneSave chan bool) {
 	c := conf.Get()
-	file := c.Settings.SLAReport.DataFile
-	save := func() {
-		if err := probe.SaveDataToFile(file); err != nil {
-			log.Errorf("Failed to save the SLA data to file(%s): %v", file, err)
-		} else {
-			log.Debugf("Successfully save the SLA data to file: %s", file)
+	if strings.TrimSpace(c.Settings.SLAReport.DataFile) != "" {
+		file := c.Settings.SLAReport.DataFile
+		save := func() {
+			if err := probe.SaveDataToFile(file); err != nil {
+				log.Errorf("Failed to save the SLA data to file(%s): %v", file, err)
+			} else {
+				log.Debugf("Successfully save the SLA data to file: %s", file)
+			}
+		}
+		save()
+		for {
+			select {
+			case <-doneSave:
+				save()
+				log.Info("Received the exit signal, Saving data process is exiting...")
+				return
+			case <-time.After(c.Settings.Probe.Interval):
+				save()
+			}
 		}
 	}
-	save()
-	for {
-		select {
-		case <-doneSave:
-			save()
-			log.Info("Received the exit signal, Saving data process is exiting...")
-			return
-		case <-time.After(c.Settings.Probe.Interval):
-			save()
-		}
-	}
-
 }
 
 // 1) all of probers send the result to notify channel

--- a/cmd/easeprobe/main.go
+++ b/cmd/easeprobe/main.go
@@ -183,6 +183,7 @@ func saveData(doneSave chan bool) {
 			save()
 		}
 	}
+
 }
 
 // 1) all of probers send the result to notify channel

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -278,6 +278,12 @@ func logLogfileInfo(name string, file string) {
 
 func (conf *Conf) initData() {
 
+	// Check if conf.Settings.SLAReport.DataFile == "" and return
+	if strings.TrimSpace(conf.Settings.SLAReport.DataFile) == "" {
+		log.Infof("SLA data file not set. Skipping SLA data store...")
+		return
+	}
+	//
 	dir, file := filepath.Split(conf.Settings.SLAReport.DataFile)
 	// if filename is empty, use default file name
 	if strings.TrimSpace(file) == "" {
@@ -287,11 +293,11 @@ func (conf *Conf) initData() {
 	if strings.TrimSpace(dir) == "" {
 		dir = global.GetWorkDir()
 	}
-	filename := filepath.Join(dir, "data", file)
+	filename := filepath.Join(dir, file)
 	conf.Settings.SLAReport.DataFile = filename
 
 	if _, err := os.Stat(filename); os.IsNotExist(err) {
-		log.Infof("The data file %s is not found!", filename)
+		log.Infof("The data file %s, was not found!", filename)
 		return
 	}
 

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -280,7 +280,7 @@ func (conf *Conf) initData() {
 
 	// Check if we are explicitly disabled
 	if strings.TrimSpace(conf.Settings.SLAReport.DataFile) == "-" {
-		log.Infof("SLA data file not set. Skipping SLA data store...")
+		log.Infof("SLA data disabled by configuration. Skipping SLA data store...")
 		return
 	}
 

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -283,7 +283,7 @@ func (conf *Conf) initData() {
 		log.Infof("SLA data file not set. Skipping SLA data store...")
 		return
 	}
-	//
+
 	dir, file := filepath.Split(conf.Settings.SLAReport.DataFile)
 	// if filename is empty, use default file name
 	if strings.TrimSpace(file) == "" {

--- a/global/global.go
+++ b/global/global.go
@@ -69,7 +69,7 @@ const (
 	// DefaultAccessLogFile is the default access log file name
 	DefaultAccessLogFile = "access.log"
 	// DefaultDataFile is the default data file name
-	DefaultDataFile = "data.yaml"
+	DefaultDataFile = "data/data.yaml"
 	// DefaultPIDFile is the default pid file name
 	DefaultPIDFile = "easeprobe.pid"
 )

--- a/probe/data.go
+++ b/probe/data.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -72,9 +73,8 @@ func SaveDataToFile(filename string) error {
 		return err
 	}
 
-	dir, _ := filepath.Split(filename)
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return err
+	if strings.TrimSpace(filename) == "-" {
+		return nil
 	}
 
 	if err := ioutil.WriteFile(filename, buf, 0644); err != nil {
@@ -85,9 +85,14 @@ func SaveDataToFile(filename string) error {
 
 // LoadDataFromFile load the results from file
 func LoadDataFromFile(filename string) error {
+	if strings.TrimSpace(filename) == "-" {
+		return nil
+	}
+
 	if _, err := os.Stat(filename); os.IsNotExist(err) {
 		return err
 	}
+
 	buf, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return err
@@ -105,6 +110,9 @@ func LoadDataFromFile(filename string) error {
 
 // CleanDataFile keeps the max backup of data file
 func CleanDataFile(filename string, backups int) {
+	if strings.TrimSpace(filename) == "-" {
+		return
+	}
 
 	// if backups is negative value, keep all backup files
 	if backups < 0 {

--- a/probe/results_test.go
+++ b/probe/results_test.go
@@ -45,7 +45,7 @@ func TestAll(t *testing.T) {
 		t.Errorf("LoadFromFile(-) error: %s", err)
 	}
 
-	tmpdir, err := ioutil.TempDir("/tmp", "easeprobe")
+	tmpdir, err := ioutil.TempDir("", "easeprobe")
 	if err != nil {
 		t.Errorf("TempDir(%s) error: %s", tmpdir, err)
 	}

--- a/probe/results_test.go
+++ b/probe/results_test.go
@@ -18,7 +18,6 @@
 package probe
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -45,32 +44,24 @@ func TestAll(t *testing.T) {
 		t.Errorf("LoadFromFile(-) error: %s", err)
 	}
 
-	tmpdir, err := ioutil.TempDir("", "easeprobe")
-	if err != nil {
-		t.Errorf("TempDir(%s) error: %s", tmpdir, err)
+	filename := "/tmp/easeprobe/data.yaml"
+	if err := os.MkdirAll("/tmp/easeprobe", 0755); err != nill {
+		t.Errorf("Mkdirall(\"/tmp/easeprobe\") error: %v", err)
 	}
 
-	file, err := ioutil.TempFile(tmpdir, "data.yaml")
-	if err != nil {
-		t.Errorf("TempFile(%s) error: %s", file.Name(), err)
+	if err := SaveDataToFile(filename); err != nil {
+		t.Errorf("SaveToFile(%s) error: %s", filename, err)
 	}
 
-	if err := SaveDataToFile(file.Name()); err != nil {
-		t.Errorf("SaveToFile(%s) error: %s", file.Name(), err)
-	}
-	if err := LoadDataFromFile(file.Name()); err != nil {
-		t.Errorf("LoadFromFile(%s) error: %s", file.Name(), err)
-	}
-
-	if err := SaveDataToFile(file.Name()); err != nil {
-		t.Errorf("SaveToFile(%s) afterLoad error: %s", file.Name(), err)
+	if err := LoadDataFromFile(filename); err != nil {
+		t.Errorf("LoadFromFile(%s) error: %s", filename, err)
 	}
 
 	if reflect.DeepEqual(resultData["Test1 Name"], r[0]) {
-		t.Errorf("LoadFromFile(\"%s\") = %v, expected %v", file.Name(), resultData["Test1 Name"], r[0])
+		t.Errorf("LoadFromFile(\"%s\") = %v, expected %v", filename, resultData["Test1 Name"], r[0])
 	}
 
-	if err := os.RemoveAll(tmpdir); err != nil {
-		t.Errorf("RemoveAll(\"%s\") = %v, expected nil", tmpdir, err)
+	if err := os.RemoveAll("/tmp/easeprobe"); err != nil {
+		t.Errorf("RemoveAll(\"/tmp/easeprobe\") = %v, expected nil", err)
 	}
 }

--- a/probe/results_test.go
+++ b/probe/results_test.go
@@ -45,7 +45,7 @@ func TestAll(t *testing.T) {
 	}
 
 	filename := "/tmp/easeprobe/data.yaml"
-	if err := os.MkdirAll("/tmp/easeprobe", 0755); err != nill {
+	if err := os.MkdirAll("/tmp/easeprobe", 0755); err != nil {
 		t.Errorf("Mkdirall(\"/tmp/easeprobe\") error: %v", err)
 	}
 

--- a/probe/results_test.go
+++ b/probe/results_test.go
@@ -35,7 +35,16 @@ func TestAll(t *testing.T) {
 		t.Errorf("GetResult(\"Test1 Name\") = %v, expected %v", x, r[0])
 	}
 
-	filename := "/tmp/easeprobe/data.yaml"
+	// ensure we dont save or load from '-'
+	if err := SaveDataToFile("-"); err != nil {
+		t.Errorf("SaveToFile(%s) error: %s", filename, err)
+	}
+
+	if err := LoadDataFromFile("-"); err != nil {
+		t.Errorf("LoadFromFile(%s) error: %s", filename, err)
+	}
+
+	filename := "/tmp/data.yaml"
 
 	if err := SaveDataToFile(filename); err != nil {
 		t.Errorf("SaveToFile(%s) error: %s", filename, err)
@@ -48,7 +57,7 @@ func TestAll(t *testing.T) {
 		t.Errorf("LoadFromFile(\"%s\") = %v, expected %v", filename, resultData["Test1 Name"], r[0])
 	}
 
-	if err := os.RemoveAll("/tmp/easeprobe"); err != nil {
-		t.Errorf("Remove(\"/tmp/easeprobe\") = %v, expected nil", err)
+	if err := os.RemoveAll("/tmp/data.yaml"); err != nil {
+		t.Errorf("Remove(\"/tmp/data.yaml\") = %v, expected nil", err)
 	}
 }

--- a/probe/results_test.go
+++ b/probe/results_test.go
@@ -18,6 +18,7 @@
 package probe
 
 import (
+	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -44,20 +45,32 @@ func TestAll(t *testing.T) {
 		t.Errorf("LoadFromFile(-) error: %s", err)
 	}
 
-	filename := "/tmp/data.yaml"
-
-	if err := SaveDataToFile(filename); err != nil {
-		t.Errorf("SaveToFile(%s) error: %s", filename, err)
+	tmpdir, err := ioutil.TempDir("/tmp", "easeprobe")
+	if err != nil {
+		t.Errorf("TempDir(%s) error: %s", tmpdir, err)
 	}
-	if err := LoadDataFromFile(filename); err != nil {
-		t.Errorf("LoadFromFile(%s) error: %s", filename, err)
+
+	file, err := ioutil.TempFile(tmpdir, "data.yaml")
+	if err != nil {
+		t.Errorf("TempFile(%s) error: %s", file.Name(), err)
+	}
+
+	if err := SaveDataToFile(file.Name()); err != nil {
+		t.Errorf("SaveToFile(%s) error: %s", file.Name(), err)
+	}
+	if err := LoadDataFromFile(file.Name()); err != nil {
+		t.Errorf("LoadFromFile(%s) error: %s", file.Name(), err)
+	}
+
+	if err := SaveDataToFile(file.Name()); err != nil {
+		t.Errorf("SaveToFile(%s) afterLoad error: %s", file.Name(), err)
 	}
 
 	if reflect.DeepEqual(resultData["Test1 Name"], r[0]) {
-		t.Errorf("LoadFromFile(\"%s\") = %v, expected %v", filename, resultData["Test1 Name"], r[0])
+		t.Errorf("LoadFromFile(\"%s\") = %v, expected %v", file.Name(), resultData["Test1 Name"], r[0])
 	}
 
-	if err := os.RemoveAll("/tmp/data.yaml"); err != nil {
-		t.Errorf("Remove(\"/tmp/data.yaml\") = %v, expected nil", err)
+	if err := os.RemoveAll(tmpdir); err != nil {
+		t.Errorf("RemoveAll(\"%s\") = %v, expected nil", tmpdir, err)
 	}
 }

--- a/probe/results_test.go
+++ b/probe/results_test.go
@@ -37,11 +37,11 @@ func TestAll(t *testing.T) {
 
 	// ensure we dont save or load from '-'
 	if err := SaveDataToFile("-"); err != nil {
-		t.Errorf("SaveToFile(%s) error: %s", filename, err)
+		t.Errorf("SaveToFile(-) error: %s", err)
 	}
 
 	if err := LoadDataFromFile("-"); err != nil {
-		t.Errorf("LoadFromFile(%s) error: %s", filename, err)
+		t.Errorf("LoadFromFile(-) error: %s", err)
 	}
 
 	filename := "/tmp/data.yaml"


### PR DESCRIPTION
This PR does
* [x] removes the `Join(dir,'data',file)` so that our `data.yaml` file location is predictable
* [x] Changes the decision tree logic for the `data.yaml` file based on the specifications agreed with @haoel 
* [x] disables logging when conf.Settings.SLAReport.DataFile is explicitly set to `"-"`
* [x] updates SLA data Persistence section to document the behavior of `data: "-"`
* [x] merge a duplicate readme notice
* [x] Update global.DefaultDataFile to `data/data.yaml` so that by default we use a sub-folder for the data files

Cases 
* Case One: No data file is configured, then we use the $CWD/data.yaml as the default.
* Case Two: data file name configured, but not configured the directory, such as: `data: mydatafile.yaml`, we use the `$CWD/mydatafile.yaml`
* Case Three: the full path has been configured. we just simply use the full path.
* Case Four: the disable flag configured `-` eg `data : -` , then we disable the data file.
