### PR TITLE
Remove refresh time calculation from probe, and add the refresh parameter in URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Check the  [Notification Configuration](#37-notification-configuration) to see h
 
   The EaseProbe would listen on the `0.0.0.0:8181` port by default. And you can access the Live SLA report by the following URL:
 
-  - HTML: `http://localhost:8181/`
+  - HTML: `http://localhost:8181/` or `http://localhost:8181/?refersh=30s`
   - JSON: `http://localhost:8181/api/v1/sla`
 
   Refer to the [Global Setting Configuration](#38-global-setting-configuration) to see how to configure the access log.


### PR DESCRIPTION
- remove the code that calculates the auto-refresh time from the probes.
- Add the refresh parameter in URL - `http://localhost:8181/?refersh=30s`

fix issue #93 