### PR TITLE
add two conf/conf.go test cases and update isExternalURL

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -20,6 +20,7 @@ package conf
 import (
 	"io/ioutil"
 	httpClient "net/http"
+	netUrl "net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -135,8 +136,18 @@ type Conf struct {
 	Settings Settings        `yaml:"settings"`
 }
 
+// Check if string is a url
 func isExternalURL(url string) bool {
-	return strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://")
+	if _, err := netUrl.ParseRequestURI(url); err != nil {
+		return false
+	}
+
+	parts, err := netUrl.Parse(url)
+	if err != nil || parts.Host == "" || !strings.HasPrefix(parts.Scheme, "http") {
+		return false
+	}
+
+	return true
 }
 
 func getYamlFileFromInternet(url string) ([]byte, error) {

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -139,11 +139,13 @@ type Conf struct {
 // Check if string is a url
 func isExternalURL(url string) bool {
 	if _, err := netUrl.ParseRequestURI(url); err != nil {
+		log.Debugf("ParseRequestedURI: %s failed to parse with error %v", url, err)
 		return false
 	}
 
 	parts, err := netUrl.Parse(url)
 	if err != nil || parts.Host == "" || !strings.HasPrefix(parts.Scheme, "http") {
+		log.Debugf("Parse: %s failed Scheme: %s, Host: %s (err: %v)", url, parts.Scheme, parts.Host, err)
 		return false
 	}
 

--- a/conf/conf_test.go
+++ b/conf/conf_test.go
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package conf
+
+import (
+	"testing"
+)
+
+func testisExternalURL(url string, expects bool, t *testing.T) {
+	if got := isExternalURL(url); got != expects {
+		t.Errorf("isExternalURL(\"%s\") = %v, expected %v", url, got, expects)
+	}
+}
+
+func TestPathAndURL(t *testing.T) {
+	testisExternalURL("/tmp", false, t)
+	testisExternalURL("//tmp", false, t)
+	testisExternalURL("file:///tmp", false, t)
+	testisExternalURL("http://", false, t)
+}

--- a/conf/conf_test.go
+++ b/conf/conf_test.go
@@ -18,6 +18,8 @@
 package conf
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 )
 
@@ -32,4 +34,36 @@ func TestPathAndURL(t *testing.T) {
 	testisExternalURL("//tmp", false, t)
 	testisExternalURL("file:///tmp", false, t)
 	testisExternalURL("http://", false, t)
+	testisExternalURL("https://", false, t)
+	testisExternalURL("hTtP://", false, t)
+	testisExternalURL("http", false, t)
+	testisExternalURL("https", false, t)
+	testisExternalURL("ftp", false, t)
+	testisExternalURL("hTtP://127.0.0.1", true, t)
+	testisExternalURL("localhost", false, t)
+	testisExternalURL("ftp://127.0.0.1", false, t)
+}
+
+func TestGetYamlFileFromFile(t *testing.T) {
+	//content := []byte("temporary file's content")
+
+	if _, err := getYamlFileFromFile("/tmp/nonexistent"); err == nil {
+		t.Errorf("getYamlFileFromFile(\"/tmp/nonexistent\") = nil, expected error")
+	}
+
+	tmpfile, err := ioutil.TempFile("", "invalid*.yaml")
+	if err != nil {
+		t.Errorf("TempFile(\"invalid*.yaml\") %v", err)
+	}
+
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	// test empty file
+	data, err := getYamlFileFromFile(tmpfile.Name())
+	if err != nil {
+		t.Errorf("getYamlFileFromFile(\"%s\") = %v, expected nil", tmpfile.Name(), err)
+	}
+	if string(data) != "" {
+		t.Errorf("getYamlFileFromFile(\"%s\") got data %s, expected nil", tmpfile.Name(), data)
+	}
 }

--- a/conf/conf_test.go
+++ b/conf/conf_test.go
@@ -45,8 +45,6 @@ func TestPathAndURL(t *testing.T) {
 }
 
 func TestGetYamlFileFromFile(t *testing.T) {
-	//content := []byte("temporary file's content")
-
 	if _, err := getYamlFileFromFile("/tmp/nonexistent"); err == nil {
 		t.Errorf("getYamlFileFromFile(\"/tmp/nonexistent\") = nil, expected error")
 	}
@@ -63,6 +61,8 @@ func TestGetYamlFileFromFile(t *testing.T) {
 	if err != nil {
 		t.Errorf("getYamlFileFromFile(\"%s\") = %v, expected nil", tmpfile.Name(), err)
 	}
+
+	//confirm we read empty data
 	if string(data) != "" {
 		t.Errorf("getYamlFileFromFile(\"%s\") got data %s, expected nil", tmpfile.Name(), data)
 	}


### PR DESCRIPTION
This PR adds test cases for `conf/conf.go` and changes the detection method of isExternalUrl 
* [x] conf/isExternalURL
* [x] conf/getYamlFileFromFile

edit: _I changed the scope of the PR to only include 1 module at a time, so that fixes for the test cases can also be included as pair_