### PR TITLE
Versionizing the binary, config, data file

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ There are some administration configuration options:
 You can get started with EaseProbe, by any of the following methods:
 * download the release for your platform from https://github.com/megaease/easeprobe/releases
 * use the available EaseProbe docker image `docker run -it megaease/easeprobe`
-* build easeprobe from sources
+* build `easeprobe` from sources
 
 ### 2.1 Build
 
@@ -319,6 +319,7 @@ $ build/bin/easeprobe -f config.yaml
 * `-d` dry run. Can also be achieved by setting the environment variable `PROBE_DRY`
 
 ## 3. Configuration
+
 EaseProbe can be configured by supplying a yaml file or URL to fetch configuration settings from.
 By default EaseProbe will look for its `config.yaml` on the current folder, this can be changed by supplying the `-f` parameter.
 
@@ -328,14 +329,21 @@ easeprobe -f https://example.com/config
 ```
 
 The following environment variables can be used to fine-tune the request to the configuration file
+
 * `HTTP_AUTHORIZATION`
 * `HTTP_TIMEOUT`
+
+And the configuration file should be versioned, the version should be aligned with the EaseProbe binary version.
+
+```yaml
+version: v1.4.0
+```
 
 The following example configurations illustrate the EaseProbe supported features.
 
 **Notes**: All probes have the following options:
 
-- `timeout` - the maximum time to wait for the probe to complete. default : `30s`.
+- `timeout` - the maximum time to wait for the probe to complete. default: `30s`.
 - `interval` - the interval time to run the probe. default: `1m`.
 
 

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ The following environment variables can be used to fine-tune the request to the 
 And the configuration file should be versioned, the version should be aligned with the EaseProbe binary version.
 
 ```yaml
-version: v1.4.0
+version: v1.5.0
 ```
 
 The following example configurations illustrate the EaseProbe supported features.

--- a/cmd/easeprobe/main.go
+++ b/cmd/easeprobe/main.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"os/signal"
 	"strings"
@@ -48,7 +49,13 @@ func main() {
 
 	dryNotify := flag.Bool("d", os.Getenv("PROBE_DRY") == "true", "dry notification mode")
 	yamlFile := flag.String("f", getEnvOrDefault("PROBE_CONFIG", "config.yaml"), "configuration file")
+	version := flag.Bool("v", false, "prints version")
 	flag.Parse()
+
+	if *version {
+		fmt.Println(global.DefaultProg, global.Ver)
+		os.Exit(0)
+	}
 
 	c, err := conf.New(yamlFile)
 	if err != nil {

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -126,6 +126,7 @@ type Settings struct {
 
 // Conf is Probe configuration
 type Conf struct {
+	Version  string          `yaml:"version"`
 	HTTP     []http.HTTP     `yaml:"http"`
 	TCP      []tcp.TCP       `yaml:"tcp"`
 	Shell    []shell.Shell   `yaml:"shell"`

--- a/probe/data.go
+++ b/probe/data.go
@@ -132,7 +132,7 @@ func LoadDataFromFile(filename string) error {
 				if err := yaml.Unmarshal(valueBytes, &metaData); err != nil {
 					log.Warnf("Load meta data error: %v", err)
 				} else {
-					log.Debug("Load meta data: %s", metaData.Name, metaData.Ver)
+					log.Debugf("Load meta data: name[%s], version[%s]", metaData.Name, metaData.Ver)
 				}
 			} else {
 				if err := yaml.Unmarshal(valueBytes, &resultData); err != nil {

--- a/probe/data.go
+++ b/probe/data.go
@@ -171,7 +171,7 @@ func LoadDataFromFile(filename string) error {
 	time = strings.Replace(time, ":", "_", -1)
 	metaData.backup = filename + "-" + time
 	if err := os.Rename(filename, metaData.backup); err != nil {
-		return err
+		log.Warnf("Backup data file error: %v", err)
 	}
 
 	return nil

--- a/probe/data.go
+++ b/probe/data.go
@@ -166,9 +166,13 @@ func LoadDataFromFile(filename string) error {
 	SetMetaData(metaData.Name, global.Ver)
 
 	// backup the current data file
-	time := time.Now().UTC().Format(time.RFC3339)
+	time := time.Now().UTC().Format(time.RFC3339Nano)
+	// replace ":" to "_" for windows platform compliance
+	time = strings.Replace(time, ":", "_", -1)
 	metaData.backup = filename + "-" + time
-	os.Rename(filename, metaData.backup)
+	if err := os.Rename(filename, metaData.backup); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/probe/data_test.go
+++ b/probe/data_test.go
@@ -180,23 +180,35 @@ func TestCleanDataFile(t *testing.T) {
 }
 
 func TestMetaData(t *testing.T) {
-	// no meta
 	file := "data/data.yaml"
+	// case one: first time to write the data
+	newDataFile(file)
+	if err := LoadDataFromFile(file); err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, metaData.Name, global.DefaultProg)
+	assert.Equal(t, global.Ver, metaData.Ver)
+	removeAll("data/")
+
+	// case two: the data file has no meta
+	file = "data/data.yaml"
 	newDataFileWithOutMeta(file)
 	if err := LoadDataFromFile(file); err != nil {
 		t.Error(err)
 	}
 	assert.Equal(t, metaData.Name, global.DefaultProg)
 	assert.Equal(t, metaData.Ver, global.Ver)
+	removeAll("data/")
 
-	// with meta
-	SetMetaData("myprog", "1.0.0")
-	SaveDataToFile(file)
+	// case three: the data file has meta
+	SetMetaData("myprog", "v1.0.0")
+	newDataFile(file)
 	if err := LoadDataFromFile(file); err != nil {
 		t.Error(err)
 	}
 	assert.Equal(t, metaData.Name, "myprog")
 	assert.Equal(t, metaData.Ver, global.Ver)
+	assert.Equal(t, metaData.ver, "v1.0.0")
 
 	removeAll("data/")
 }

--- a/probe/data_test.go
+++ b/probe/data_test.go
@@ -139,7 +139,7 @@ func TestLoadDataFile(t *testing.T) {
 	// create data file
 	newDataFile(file)
 	if err := LoadDataFromFile(file); err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	assert.True(t, isDataFileExisted(metaData.backup))
@@ -162,9 +162,8 @@ func TestCleanDataFile(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		newDataFile(file)
 		if err := LoadDataFromFile(file); err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
-		time.Sleep(time.Second)
 	}
 	assert.Equal(t, n, numOfBackup(file))
 

--- a/probe/data_test.go
+++ b/probe/data_test.go
@@ -1,0 +1,203 @@
+package probe
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/megaease/easeprobe/global"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+var testResults = []Result{
+	{
+		Name:             "Probe Result - HTTP",
+		Endpoint:         "https://www.example.com",
+		StartTime:        time.Now().UTC(),
+		StartTimestamp:   time.Now().UnixMilli(),
+		RoundTripTime:    478783 * time.Microsecond,
+		Status:           StatusUp,
+		PreStatus:        StatusDown,
+		Message:          "Success (http): HTTP Status Code is 200",
+		LatestDownTime:   time.Time{},
+		RecoveryDuration: 200 * time.Second,
+		Stat: Stat{
+			Since: time.Now().UTC(),
+			Total: 100,
+			Status: map[Status]int64{
+				StatusUp:   70,
+				StatusDown: 30,
+			},
+			UpTime:   70 * time.Minute,
+			DownTime: 30 * time.Minute,
+		},
+	},
+	{
+		Name:             "Probe Result - Host",
+		Endpoint:         "CPU: 0.15, Mem: 0.10, Disk: 0.90",
+		StartTime:        time.Now().UTC(),
+		StartTimestamp:   time.Now().UnixMilli(),
+		RoundTripTime:    283455 * time.Millisecond,
+		Status:           StatusDown,
+		PreStatus:        StatusUp,
+		Message:          "Error (host/server): CPU Busy! | Memory Shortage! ( CPU: 37.10% - Memory: 49.45% - Disk: 64.00% )",
+		LatestDownTime:   time.Time{},
+		RecoveryDuration: 5 * time.Minute,
+		Stat: Stat{
+			Since: time.Now().UTC(),
+			Total: 300,
+			Status: map[Status]int64{
+				StatusInit: 1,
+				StatusUp:   270,
+				StatusDown: 30,
+			},
+			UpTime:   270 * time.Minute,
+			DownTime: 30 * time.Minute,
+		},
+	},
+}
+
+func newDataFile(file string) error {
+	makeAll(file)
+	SetResultsData(testResults)
+	return SaveDataToFile(file)
+}
+
+func newDataFileWithOutMeta(file string) error {
+	makeAll(file)
+	SetResultsData(testResults)
+	buf, err := yaml.Marshal(resultData)
+	if err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(file, []byte(buf), 0644); err != nil {
+		return err
+	}
+	return nil
+}
+
+func isDataFileExisted(file string) bool {
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
+func removeDataFile(file string) {
+	os.Remove(file)
+}
+
+func makeAll(file string) {
+	dir, _ := filepath.Split(file)
+	os.MkdirAll(dir, 0755)
+}
+
+func removeAll(file string) {
+	os.RemoveAll(file)
+}
+
+func checkData(t *testing.T) {
+	for _, r := range testResults {
+		assert.Equal(t, r, *resultData[r.Name])
+	}
+}
+
+func TestNewDataFile(t *testing.T) {
+	//disable data file
+	newDataFile("-")
+	assert.False(t, isDataFileExisted("-"))
+
+	//default data file
+	file := global.DefaultDataFile
+	newDataFile(file)
+	assert.True(t, isDataFileExisted(file))
+	removeAll("data/")
+
+	//default data file
+	file = "data.yaml"
+	newDataFile(file)
+	assert.True(t, isDataFileExisted(file))
+	removeAll(file)
+
+	//custom data file
+	file = "x/y/z/mydata.yaml"
+	makeAll(file)
+	newDataFile(file)
+	assert.True(t, isDataFileExisted(file))
+	removeAll("x/")
+}
+
+func TestLoadDataFile(t *testing.T) {
+	// no data file
+	file := "data.yaml"
+	err := LoadDataFromFile(file)
+	assert.True(t, err != nil)
+
+	// create data file
+	newDataFile(file)
+	if err := LoadDataFromFile(file); err != nil {
+		t.Error(err)
+	}
+
+	assert.True(t, isDataFileExisted(metaData.backup))
+	removeAll(metaData.backup)
+	checkData(t)
+}
+
+func numOfBackup(file string) int {
+	files, _ := filepath.Glob(file + "-*")
+	return len(files)
+}
+
+func TestCleanDataFile(t *testing.T) {
+
+	file := "data/data.yaml"
+	assert.Equal(t, 0, numOfBackup(file))
+
+	// create data file with backups
+	n := 5
+	for i := 0; i < 5; i++ {
+		newDataFile(file)
+		if err := LoadDataFromFile(file); err != nil {
+			t.Error(err)
+		}
+		time.Sleep(time.Second)
+	}
+	assert.Equal(t, n, numOfBackup(file))
+
+	n = 3
+	CleanDataFile(file, n)
+	assert.Equal(t, n, numOfBackup(file))
+
+	n = 0
+	CleanDataFile(file, n)
+	assert.Equal(t, n, numOfBackup(file))
+
+	// clean data file
+	removeAll("data/")
+}
+
+func TestMetaData(t *testing.T) {
+	// no meta
+	file := "data/data.yaml"
+	newDataFileWithOutMeta(file)
+	if err := LoadDataFromFile(file); err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, metaData.Name, global.DefaultProg)
+	assert.Equal(t, metaData.Ver, global.Ver)
+
+	// with meta
+	SetMetaData("myprog", "1.0.0")
+	SaveDataToFile(file)
+	if err := LoadDataFromFile(file); err != nil {
+		t.Error(err)
+	}
+	assert.Equal(t, metaData.Name, "myprog")
+	assert.Equal(t, metaData.Ver, global.Ver)
+
+	removeAll("data/")
+}


### PR DESCRIPTION
fixes #98 

- [x] easeprobe -v
```shell
$ ./easeprobe -v                                                                                                                                  ─╯
EaseProbe v1.5.0
```
- [x] easeprobe -h

```shell
$ ./easeprobe -h                                                                                                                                  ─╯
Usage of build/bin/easeprobe:
  -d    dry notification mode
  -f string
        configuration file (default "config.yaml")
  -v    prints version
```

- [x] config.yaml

```yaml
version : 1.5.0
```

- [x] data.yaml 

```yaml
---
name: EaseProbe
version: v1.5.0
---
Probe:
   ...
  ....
```