### PR TITLE
refactor: return explicitly when no need to clean backup files

### DIFF
--- a/probe/data.go
+++ b/probe/data.go
@@ -130,6 +130,7 @@ func CleanDataFile(filename string, backups int) {
 	// if backups is not exceed the max number of backup files, return
 	if len(matches) <= backups {
 		log.Debugf("No need to clean data file (%d - %d) ", backups, len(matches))
+		return
 	}
 
 	// remove the oldest backup files


### PR DESCRIPTION
When the number of existing data files is less than the backup limit, `probe.CleanDataFile` does not need to perform any action. Currently, this condition is covered by the later for loop condition, i.e., `len(matches)-backups`.

I added the explicit return to avoid sorting the existing data file names.