### PR TITLE
(minor) ci workflow restore GITHUB_WORKSPACE permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ env:
   GO_VERSION: 1.18
 
 jobs:
-  
+
   lint:
     name: Code Lint
     runs-on: ubuntu-latest
@@ -19,13 +19,17 @@ jobs:
       - name: Checkout Source Code
         uses: actions/checkout@v3
       # https://github.com/reviewdog/reviewdog/issues/1158
-      - name: "Give Permissions" 
+      # Permissions need to match container user
+      - name: "Give Permissions"
         run: |
-          sudo chown -R root:root $GITHUB_WORKSPACE 
+          sudo chown -R root $GITHUB_WORKSPACE
       - name: Spelling Check
         uses: reviewdog/action-misspell@v1.10.1
       - name: Revive Action
         uses: morphy2k/revive-action@v2.3.1
+      - name: "Restore Permissions"
+        run: |
+          sudo chown -R $(id -u) $GITHUB_WORKSPACE
       - name: Check formatting
         run: test -z $(gofmt -l .) || (gofmt -l . && exit 1)
 

--- a/probe/client/postgres/postgres.go
+++ b/probe/client/postgres/postgres.go
@@ -30,11 +30,14 @@ import (
 // Kind is the type of driver
 const Kind string = "PostgreSQL"
 
+// revive:disable
 // PostgreSQL is the PostgreSQL client
 type PostgreSQL struct {
 	conf.Options  `yaml:",inline"`
 	ClientOptions []pgdriver.Option `yaml:"-"`
 }
+
+// revive:enable
 
 // New create a PostgreSQL client
 func New(opt conf.Options) PostgreSQL {


### PR DESCRIPTION
This PR 
* Silences the stutters warning we receive from the Postgres probe
* restores the permissions for `GITHUB_WORKSPACE` after the checks to get rid of the following notice.

![image](https://user-images.githubusercontent.com/4373752/169654203-25d8657b-d0d2-4634-aeff-b14ba70dcb60.png)
