### PR TITLE
Refactoring the Notify interface to align with Probe interface

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -108,7 +108,7 @@ func (c *Channel) SetNotify(n notify.Notify) {
 	if n == nil {
 		return
 	}
-	c.Notifiers[n.GetName()] = n
+	c.Notifiers[n.Name()] = n
 }
 
 var dryNotify bool

--- a/channel/manager.go
+++ b/channel/manager.go
@@ -43,9 +43,11 @@ func SetChannel(name string) {
 }
 
 // SetProbers sets the probers
-func SetProbers(channel string, probers []probe.Prober) {
+func SetProbers(probers []probe.Prober) {
 	for _, p := range probers {
-		SetProber(channel, p)
+		for _, channel := range p.Channels() {
+			SetProber(channel, p)
+		}
 	}
 }
 
@@ -60,9 +62,11 @@ func SetProber(channel string, p probe.Prober) {
 }
 
 // SetNotifiers set a notify to the channel
-func SetNotifiers(channel string, notifiers []notify.Notify) {
+func SetNotifiers(notifiers []notify.Notify) {
 	for _, n := range notifiers {
-		SetNotify(channel, n)
+		for _, channel := range n.Channels() {
+			SetNotify(channel, n)
+		}
 	}
 }
 
@@ -86,7 +90,7 @@ func GetNotifiers(channel []string) map[string]notify.Notify {
 			continue
 		}
 		for _, n := range ch.Notifiers {
-			notifiers[n.GetName()] = n
+			notifiers[n.Name()] = n
 		}
 	}
 	return notifiers

--- a/cmd/easeprobe/channel.go
+++ b/cmd/easeprobe/channel.go
@@ -40,11 +40,11 @@ func configChannels(probers []probe.Prober, notifiers []notify.Notify) {
 	// set the notify to channels
 	for i := 0; i < len(notifiers); i++ {
 		n := notifiers[i]
-		if len(n.GetChannels()) <= 0 {
+		if len(n.Channels()) <= 0 {
 			channel.SetNotify(global.DefaultChannelName, n)
 			continue
 		}
-		for _, cName := range n.GetChannels() {
+		for _, cName := range n.Channels() {
 			channel.SetNotify(cName, n)
 		}
 	}
@@ -72,7 +72,7 @@ func checkChannels() {
 
 		log.Debugf("   Notifiers:\n")
 		for _, n := range ch.Notifiers {
-			log.Debugf("     - %s: %s\n", n.Kind(), n.GetName())
+			log.Debugf("     - %s: %s\n", n.Kind(), n.Name())
 		}
 		if len(ch.Notifiers) <= 0 {
 			log.Warnf("Channel(%s) has no notifiers!", cName)

--- a/cmd/easeprobe/report.go
+++ b/cmd/easeprobe/report.go
@@ -75,7 +75,7 @@ func scheduleSLA(probers []probe.Prober) {
 
 	log.Debugf("--------- SLA Report Notifies ---------")
 	for _, n := range notifies {
-		log.Debugf("  - %s : %s", n.Kind(), n.GetName())
+		log.Debugf("  - %s : %s", n.Kind(), n.Name())
 	}
 
 	SLAFn := func() {

--- a/notify/aws/sns.go
+++ b/notify/aws/sns.go
@@ -38,17 +38,17 @@ type SNSNotifyConfig struct {
 
 // Kind return the type of Notify
 func (c *SNSNotifyConfig) Kind() string {
-	return c.MyKind
+	return c.NotifyKind
 }
 
 // Config configures the slack notification
 func (c *SNSNotifyConfig) Config(gConf global.NotifySettings) error {
-	c.MyKind = "AWS-SNS"
+	c.NotifyKind = "AWS-SNS"
 	if c.Format == report.Unknown {
 		c.Format = report.Text
 	}
-	c.DefaultNotify.Format = c.Format
-	c.SendFunc = c.SendSNS
+	c.DefaultNotify.NotifyFormat = c.Format
+	c.NotifySendFunc = c.SendSNS
 
 	if err := c.Options.Config(gConf); err != nil {
 		return err
@@ -57,7 +57,7 @@ func (c *SNSNotifyConfig) Config(gConf global.NotifySettings) error {
 	c.client = sns.New(c.session)
 	c.context = context.Background()
 
-	log.Debugf("Notification [%s] - [%s] configuration: %+v", c.MyKind, c.Name, c)
+	log.Debugf("Notification [%s] - [%s] configuration: %+v", c.NotifyKind, c.NotifyName, c)
 	return nil
 }
 
@@ -78,6 +78,6 @@ func (c *SNSNotifyConfig) SendSNSNotification(msg string) error {
 	if err != nil {
 		return err
 	}
-	log.Debugf("[%s / %s] Message ID = %s", c.Kind(), c.Name, *res.MessageId)
+	log.Debugf("[%s / %s] Message ID = %s", c.Kind(), c.NotifyName, *res.MessageId)
 	return nil
 }

--- a/notify/dingtalk/dingtalk.go
+++ b/notify/dingtalk/dingtalk.go
@@ -36,18 +36,13 @@ type NotifyConfig struct {
 	WebhookURL         string `yaml:"webhook"`
 }
 
-// Kind return the type of Notify
-func (c *NotifyConfig) Kind() string {
-	return c.MyKind
-}
-
 // Config configures the dingtalk notification
 func (c *NotifyConfig) Config(gConf global.NotifySettings) error {
-	c.MyKind = "dingtalk"
-	c.Format = report.Markdown
-	c.SendFunc = c.SendDingtalkNotification
+	c.NotifyKind = "dingtalk"
+	c.NotifyFormat = report.Markdown
+	c.NotifySendFunc = c.SendDingtalkNotification
 	c.DefaultNotify.Config(gConf)
-	log.Debugf("Notification [%s] - [%s] configuration: %+v", c.MyKind, c.Name, c)
+	log.Debugf("Notification [%s] - [%s] configuration: %+v", c.NotifyKind, c.NotifyName, c)
 	return nil
 }
 
@@ -62,7 +57,7 @@ func (c *NotifyConfig) SendDingtalkNotification(title, msg string) error {
 		"msgtype": "markdown",
 		"markdown": {
 			"title": "%s",
-			"text": "%s" 
+			"text": "%s"
 		}
 	}
 	`, title, msg)

--- a/notify/discord/discord.go
+++ b/notify/discord/discord.go
@@ -110,14 +110,9 @@ type NotifyConfig struct {
 	Thumbnail          string `yaml:"thumbnail"`
 }
 
-// Kind return the type of Notify
-func (c *NotifyConfig) Kind() string {
-	return c.MyKind
-}
-
 // Config configures the log files
 func (c *NotifyConfig) Config(gConf global.NotifySettings) error {
-	c.MyKind = "discord"
+	c.NotifyKind = "discord"
 	c.DefaultNotify.Config(gConf)
 
 	if len(strings.TrimSpace(c.Username)) <= 0 {
@@ -132,7 +127,7 @@ func (c *NotifyConfig) Config(gConf global.NotifySettings) error {
 		c.Thumbnail = global.GetEaseProbe().IconURL
 	}
 
-	log.Debugf("Notification [%s] - [%s] configuration: %+v", c.MyKind, c.Name, c)
+	log.Debugf("Notification [%s] - [%s] configuration: %+v", c.NotifyKind, c.NotifyName, c)
 	return nil
 }
 
@@ -192,8 +187,8 @@ func (c *NotifyConfig) Notify(result probe.Result) {
 		return c.SendDiscordNotification(discord)
 	}
 
-	err := global.DoRetry(c.Kind(), c.Name, tag, c.Retry, fn)
-	report.LogSend(c.Kind(), c.Name, tag, result.Name, err)
+	err := global.DoRetry(c.Kind(), c.NotifyName, tag, c.Retry, fn)
+	report.LogSend(c.Kind(), c.NotifyName, tag, result.Name, err)
 }
 
 // NewEmbed new a embed object from a result
@@ -300,11 +295,11 @@ func (c *NotifyConfig) NotifyStat(probers []probe.Prober) {
 			return c.SendDiscordNotification(discord)
 		}
 
-		err := global.DoRetry(c.Kind(), c.Name, tag, c.Retry, fn)
+		err := global.DoRetry(c.Kind(), c.NotifyName, tag, c.Retry, fn)
 		if err != nil {
-			log.Errorf("[%s / %s / %s] - failed to send part [%d/%d]! (%v)", c.Kind(), c.Name, tag, idx+1, total, err)
+			log.Errorf("[%s / %s / %s] - failed to send part [%d/%d]! (%v)", c.Kind(), c.NotifyName, tag, idx+1, total, err)
 		} else {
-			log.Infof("[%s / %s / %s] - successfully sent part [%d/%d]!", c.Kind(), c.Name, tag, idx+1, total)
+			log.Infof("[%s / %s / %s] - successfully sent part [%d/%d]!", c.Kind(), c.NotifyName, tag, idx+1, total)
 		}
 
 	}
@@ -318,7 +313,7 @@ func (c *NotifyConfig) DryNotify(result probe.Result) {
 		log.Errorf("error : %v", err)
 		return
 	}
-	log.Infof("[%s / %s ] Dry notify - %s", c.Kind(), c.Name, string(json))
+	log.Infof("[%s / %s ] Dry notify - %s", c.Kind(), c.NotifyName, string(json))
 }
 
 // DryNotifyStat just log the notification message
@@ -329,7 +324,7 @@ func (c *NotifyConfig) DryNotifyStat(probers []probe.Prober) {
 		log.Errorf("error : %v", err)
 		return
 	}
-	log.Infof("[%s / %s ] Dry notify - %s", c.Kind(), c.Name, string(json))
+	log.Infof("[%s / %s ] Dry notify - %s", c.Kind(), c.NotifyName, string(json))
 }
 
 // SendDiscordNotification will post to an 'Incoming Webhook' url setup in Discrod Apps.

--- a/notify/email/email.go
+++ b/notify/email/email.go
@@ -40,18 +40,13 @@ type NotifyConfig struct {
 	From               string `yaml:"from"`
 }
 
-// Kind return the type of Notify
-func (c *NotifyConfig) Kind() string {
-	return c.MyKind
-}
-
 // Config configures the log files
 func (c *NotifyConfig) Config(gConf global.NotifySettings) error {
-	c.MyKind = "email"
-	c.Format = report.HTML
-	c.SendFunc = c.SendMail
+	c.NotifyKind = "email"
+	c.NotifyFormat = report.HTML
+	c.NotifySendFunc = c.SendMail
 	c.DefaultNotify.Config(gConf)
-	log.Debugf("Notification [%s] - [%s] configuration: %+v", c.MyKind, c.Name, c)
+	log.Debugf("Notification [%s] - [%s] configuration: %+v", c.NotifyKind, c.NotifyName, c)
 	return nil
 }
 

--- a/notify/lark/lark.go
+++ b/notify/lark/lark.go
@@ -36,18 +36,13 @@ type NotifyConfig struct {
 	WebhookURL         string `yaml:"webhook"`
 }
 
-// Kind return the type of Notify
-func (c *NotifyConfig) Kind() string {
-	return c.MyKind
-}
-
 // Config configures the slack notification
 func (c *NotifyConfig) Config(gConf global.NotifySettings) error {
-	c.MyKind = "lark"
-	c.Format = report.Lark
-	c.SendFunc = c.SendLark
+	c.NotifyKind = "lark"
+	c.NotifyFormat = report.Lark
+	c.NotifySendFunc = c.SendLark
 	c.DefaultNotify.Config(gConf)
-	log.Debugf("Notification [%s] - [%s] configuration: %+v", c.MyKind, c.Name, c)
+	log.Debugf("Notification [%s] - [%s] configuration: %+v", c.NotifyKind, c.NotifyName, c)
 	return nil
 }
 

--- a/notify/log/log.go
+++ b/notify/log/log.go
@@ -34,17 +34,12 @@ type NotifyConfig struct {
 	File               string `yaml:"file"`
 }
 
-// Kind return the type of Notify
-func (c *NotifyConfig) Kind() string {
-	return c.MyKind
-}
-
 // Config configures the log files
 func (c *NotifyConfig) Config(global global.NotifySettings) error {
-	c.MyKind = "log"
-	c.Format = report.Text
+	c.NotifyKind = "log"
+	c.NotifyFormat = report.Text
 	if c.Dry {
-		logrus.Infof("Notification [%s] - [%s] is running on Dry mode!", c.MyKind, c.Name)
+		logrus.Infof("Notification [%s] - [%s] is running on Dry mode!", c.NotifyKind, c.NotifyName)
 		log.SetOutput(os.Stdout)
 		return nil
 	}
@@ -55,8 +50,8 @@ func (c *NotifyConfig) Config(global global.NotifySettings) error {
 	}
 	log.SetOutput(file)
 
-	logrus.Infof("Notification [%s] - [%s] is configured!", c.Kind(), c.Name)
-	logrus.Debugf("Notification [%s] - [%s] configuration: %+v", c.Kind(), c.Name, c)
+	logrus.Infof("Notification [%s] - [%s] is configured!", c.Kind(), c.NotifyName)
+	logrus.Debugf("Notification [%s] - [%s] configuration: %+v", c.Kind(), c.NotifyName, c)
 	return nil
 }
 

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -51,8 +51,8 @@ type Config struct {
 // Notify is the configuration of the Notify
 type Notify interface {
 	Kind() string
-	GetName() string
-	GetChannels() []string
+	Name() string
+	Channels() []string
 	Config(global.NotifySettings) error
 	Notify(probe.Result)
 	NotifyStat([]probe.Prober)

--- a/notify/slack/slack.go
+++ b/notify/slack/slack.go
@@ -35,18 +35,13 @@ type NotifyConfig struct {
 	WebhookURL         string `yaml:"webhook"`
 }
 
-// Kind return the type of Notify
-func (c *NotifyConfig) Kind() string {
-	return c.MyKind
-}
-
 // Config configures the slack notification
 func (c *NotifyConfig) Config(gConf global.NotifySettings) error {
-	c.MyKind = "slack"
-	c.Format = report.Slack
-	c.SendFunc = c.SendSlack
+	c.NotifyKind = "slack"
+	c.NotifyFormat = report.Slack
+	c.NotifySendFunc = c.SendSlack
 	c.DefaultNotify.Config(gConf)
-	log.Debugf("Notification [%s] - [%s] configuration: %+v", c.MyKind, c.Name, c)
+	log.Debugf("Notification [%s] - [%s] configuration: %+v", c.NotifyKind, c.NotifyName, c)
 	return nil
 }
 

--- a/notify/sms/conf/conf.go
+++ b/notify/sms/conf/conf.go
@@ -26,7 +26,6 @@ import (
 
 // Provider Interface
 type Provider interface {
-	Kind() string
 	Notify(string, string) error
 }
 

--- a/notify/sms/nexmo/nexmo.go
+++ b/notify/sms/nexmo/nexmo.go
@@ -28,9 +28,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Kind is the type of Provider
-const Kind string = "Nexmo"
-
 // Nexmo is the Nexmo sms provider
 type Nexmo struct {
 	conf.Options `yaml:",inline"`
@@ -41,11 +38,6 @@ func New(opt conf.Options) *Nexmo {
 	return &Nexmo{
 		Options: opt,
 	}
-}
-
-// Kind return the type of Notify
-func (c Nexmo) Kind() string {
-	return Kind
 }
 
 // Notify return the type of Notify

--- a/notify/sms/sms.go
+++ b/notify/sms/sms.go
@@ -19,6 +19,7 @@ package sms
 
 import (
 	"errors"
+
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/notify/sms/conf"
 	"github.com/megaease/easeprobe/notify/sms/nexmo"
@@ -36,19 +37,15 @@ type NotifyConfig struct {
 	Provider conf.Provider `yaml:"-"`
 }
 
-// Kind return the probe kind
-func (c *NotifyConfig) Kind() string {
-	return c.MyKind
-}
-
 // Config Sms Config Object
 func (c *NotifyConfig) Config(gConf global.NotifySettings) error {
-	c.Format = report.SMS
+	c.NotifyKind = conf.ProviderMap[c.ProviderType]
+	c.NotifyFormat = report.SMS
 	c.DefaultNotify.Config(gConf)
 	c.configSMSDriver()
-	c.SendFunc = c.DoNotify
+	c.NotifySendFunc = c.DoNotify
 
-	log.Debugf("Notification [%s] - [%s] configuration: %+v", c.MyKind, c.Name, c)
+	log.Debugf("Notification [%s] - [%s] configuration: %+v", c.NotifyKind, c.NotifyName, c)
 	return nil
 }
 

--- a/notify/sms/twilio/twilio.go
+++ b/notify/sms/twilio/twilio.go
@@ -28,9 +28,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Kind is the type of provider
-const Kind string = "Twilio"
-
 // Twilio is the Twilio sms provider
 type Twilio struct {
 	conf.Options `yaml:",inline"`
@@ -41,11 +38,6 @@ func New(opt conf.Options) *Twilio {
 	return &Twilio{
 		Options: opt,
 	}
-}
-
-// Kind return the type of Notify
-func (c Twilio) Kind() string {
-	return Kind
 }
 
 // Notify return the type of Notify

--- a/notify/sms/yunpian/yunpian.go
+++ b/notify/sms/yunpian/yunpian.go
@@ -28,9 +28,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Kind is the type of driver
-const Kind string = "Yunpian"
-
 // Yunpian is the Yunpian sms provider
 type Yunpian struct {
 	conf.Options `yaml:",inline"`
@@ -41,11 +38,6 @@ func New(opt conf.Options) *Yunpian {
 	return &Yunpian{
 		Options: opt,
 	}
-}
-
-// Kind return the type of Notify
-func (c Yunpian) Kind() string {
-	return Kind
 }
 
 // Notify return the type of Notify

--- a/notify/teams/teams.go
+++ b/notify/teams/teams.go
@@ -35,20 +35,15 @@ type NotifyConfig struct {
 	client goteamsnotify.API
 }
 
-// Kind return the type of Notify
-func (c *NotifyConfig) Kind() string {
-	return c.MyKind
-}
-
 // Config configures the teams notification
 func (c *NotifyConfig) Config(gConf global.NotifySettings) error {
-	c.MyKind = "teams"
-	c.Format = report.MarkdownSocial
-	c.SendFunc = c.SendTeamsMessage
+	c.NotifyKind = "teams"
+	c.NotifyFormat = report.MarkdownSocial
+	c.NotifySendFunc = c.SendTeamsMessage
 	c.DefaultNotify.Config(gConf)
 
 	c.client = goteamsnotify.NewClient()
-	log.Debugf("Notification [%s] - [%s] configuration: %+v", c.MyKind, c.Name, c)
+	log.Debugf("Notification [%s] - [%s] configuration: %+v", c.NotifyKind, c.NotifyName, c)
 	return nil
 }
 

--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -36,18 +36,13 @@ type NotifyConfig struct {
 	ChatID             string `yaml:"chat_id"`
 }
 
-// Kind return the type of Notify
-func (c *NotifyConfig) Kind() string {
-	return c.MyKind
-}
-
 // Config configures the telegram configuration
 func (c *NotifyConfig) Config(gConf global.NotifySettings) error {
-	c.MyKind = "telegram"
-	c.Format = report.Markdown
-	c.SendFunc = c.SendTelegram
+	c.NotifyKind = "telegram"
+	c.NotifyFormat = report.Markdown
+	c.NotifySendFunc = c.SendTelegram
 	c.DefaultNotify.Config(gConf)
-	log.Debugf("Notification [%s] - [%s] configuration: %+v", c.MyKind, c.Name, c)
+	log.Debugf("Notification [%s] - [%s] configuration: %+v", c.NotifyKind, c.NotifyName, c)
 	return nil
 }
 

--- a/notify/wecom/wecom.go
+++ b/notify/wecom/wecom.go
@@ -35,18 +35,13 @@ type NotifyConfig struct {
 	WebhookURL         string `yaml:"webhook"`
 }
 
-// Kind return the type of Notify
-func (c *NotifyConfig) Kind() string {
-	return c.MyKind
-}
-
 // Config configures the slack notification
 func (c *NotifyConfig) Config(gConf global.NotifySettings) error {
-	c.MyKind = "wecom"
-	c.Format = report.Markdown
-	c.SendFunc = c.SendWecom
+	c.NotifyKind = "wecom"
+	c.NotifyFormat = report.Markdown
+	c.NotifySendFunc = c.SendWecom
 	c.DefaultNotify.Config(gConf)
-	log.Debugf("Notification [%s] - [%s] configuration: %+v", c.MyKind, c.Name, c)
+	log.Debugf("Notification [%s] - [%s] configuration: %+v", c.NotifyKind, c.NotifyName, c)
 	return nil
 }
 
@@ -64,7 +59,7 @@ func (c *NotifyConfig) SendWecomNotification(msg string) error {
 	{
 		"msgtype": "markdown",
 		"markdown": {
-			"content": "%s" 
+			"content": "%s"
 		}
 	}
 	`, report.JSONEscape(msg))


### PR DESCRIPTION
### Rename Name() and Channels()

For the Probe interface, the method `Name()` retrieves the name, and the `Channels()` retrieve all channels. However, the Notify interface have different method `GetName()` and `GetChannels()`.

So, this PR makes us use the same naming convention. 

`GetName()` -> `Name()`
`GetChannel()` -> `Channel()`

###  Move Kind() to Base

For the `Probe` interface, the `Kind()` is implemented by the base prober, however, for the `Notify` interface, the `Kind()` is implemented by each concrete notifier. So, move the `Kind()` from the concrete notifier to the base notifier.
