### PR TITLE
Unit Test Cases for All Probers

### DIFF
--- a/channel/manager_test.go
+++ b/channel/manager_test.go
@@ -33,14 +33,14 @@ import (
 )
 
 type dummyProber struct {
-	baseProbe.DefaultOptions
+	baseProbe.DefaultProbe
 }
 
 func (d *dummyProber) Config(gConf global.ProbeSettings) error {
 	d.ProbeTimeout = gConf.Timeout
 	d.ProbeTimeInterval = gConf.Interval
 	status := true
-	d.DefaultOptions.Config(gConf, d.ProbeKind, d.ProbeTag, d.ProbeName, d.ProbeName,
+	d.DefaultProbe.Config(gConf, d.ProbeKind, d.ProbeTag, d.ProbeName, d.ProbeName,
 		func() (bool, string) {
 			switch d.ProbeName {
 			case "dummy-X":
@@ -55,7 +55,7 @@ func (d *dummyProber) Config(gConf global.ProbeSettings) error {
 
 func newDummyProber(kind, tag, name string, channels []string) *dummyProber {
 	return &dummyProber{
-		DefaultOptions: baseProbe.DefaultOptions{
+		DefaultProbe: baseProbe.DefaultProbe{
 			ProbeKind:         kind,
 			ProbeTag:          tag,
 			ProbeName:         name,

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -1,4 +1,3 @@
-//go: build windows
 //go:build windows
 // +build windows
 

--- a/global/easeprobe.go
+++ b/global/easeprobe.go
@@ -50,6 +50,9 @@ func InitEaseProbe(name, icon string) {
 
 // GetEaseProbe return the EaseProbe
 func GetEaseProbe() *EaseProbe {
+	if easeProbe == nil {
+		InitEaseProbe(DefaultProg, DefaultIconURL)
+	}
 	return easeProbe
 }
 

--- a/global/easeprobe_test.go
+++ b/global/easeprobe_test.go
@@ -27,8 +27,12 @@ import (
 )
 
 func TestEaseProbe(t *testing.T) {
-	InitEaseProbe("test", "icon")
 	e := GetEaseProbe()
+	assert.Equal(t, DefaultProg, e.Name)
+	assert.Equal(t, DefaultIconURL, e.IconURL)
+
+	InitEaseProbe("test", "icon")
+	e = GetEaseProbe()
 	assert.Equal(t, "test", e.Name)
 	assert.Equal(t, "icon", e.IconURL)
 	assert.Equal(t, Ver, e.Version)

--- a/global/global.go
+++ b/global/global.go
@@ -117,6 +117,15 @@ func normalize[T constraints.Ordered](global, local, valid, _default T) T {
 	return local
 }
 
+// ReverseMap just reverse the map from [key, value] to [value, key]
+func ReverseMap[K comparable, V comparable](m map[K]V) map[V]K {
+	n := make(map[V]K, len(m))
+	for k, v := range m {
+		n[v] = k
+	}
+	return n
+}
+
 // Config return a tls.Config object
 func (t *TLS) Config() (*tls.Config, error) {
 	if len(t.CA) <= 0 || len(t.Cert) <= 0 || len(t.Key) <= 0 {

--- a/global/global_test.go
+++ b/global/global_test.go
@@ -37,6 +37,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestReverseMap(t *testing.T) {
+	m := map[int]string{
+		1: "a",
+		2: "b",
+		3: "c",
+	}
+	n := ReverseMap(m)
+	assert.Equal(t, 1, n["a"])
+	assert.Equal(t, 2, n["b"])
+	assert.Equal(t, 3, n["c"])
+}
+
 func makeCA(path string, subject *pkix.Name) (*x509.Certificate, *rsa.PrivateKey, error) {
 	// creating a CA which will be used to sign all of our certificates using the x509 package from the Go Standard Library
 	caCert := &x509.Certificate{

--- a/notify/discord/discord.go
+++ b/notify/discord/discord.go
@@ -215,7 +215,7 @@ func (c *NotifyConfig) NewField(result probe.Result, inline bool) Fields {
 		"\n>\t`%s ` \n\n"
 
 	desc := fmt.Sprintf(message, result.Endpoint,
-		result.Stat.UpTime.Round(time.Second), result.Stat.DownTime.Round(time.Second), report.SLAPercent(&result),
+		result.Stat.UpTime.Round(time.Second), result.Stat.DownTime.Round(time.Second), result.SLAPercent(),
 		result.Stat.Total, report.SLAStatusText(result.Stat, report.Markdown),
 		result.StartTime.UTC().Format(result.TimeFormat), result.Status.Emoji()+" "+result.Status.String(),
 		result.Message)

--- a/notify/sms/conf/conf.go
+++ b/notify/sms/conf/conf.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/notify/base"
 )
 
@@ -62,15 +63,7 @@ type Options struct {
 }
 
 // ProviderTypeMap is the map of provider [name, provider]
-var ProviderTypeMap = reverseMap(ProviderMap)
-
-func reverseMap(m map[ProviderType]string) map[string]ProviderType {
-	n := make(map[string]ProviderType, len(m))
-	for k, v := range m {
-		n[v] = k
-	}
-	return n
-}
+var ProviderTypeMap = global.ReverseMap(ProviderMap)
 
 // String convert the DriverType to string
 func (d ProviderType) String() string {

--- a/probe/base/base.go
+++ b/probe/base/base.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe"
-	"github.com/megaease/easeprobe/report"
 	"github.com/prometheus/client_golang/prometheus"
 
 	log "github.com/sirupsen/logrus"
@@ -175,7 +174,7 @@ func (d *DefaultOptions) ExportMetrics() {
 
 	d.metrics.SLA.With(prometheus.Labels{
 		"name": d.ProbeName,
-	}).Set(float64(report.SLAPercent(d.ProbeResult)))
+	}).Set(float64(d.ProbeResult.SLAPercent()))
 }
 
 // DownTimeCalculation calculate the down time

--- a/probe/base/base.go
+++ b/probe/base/base.go
@@ -37,8 +37,8 @@ const (
 // ProbeFuncType is the probe function type
 type ProbeFuncType func() (bool, string)
 
-// DefaultOptions is the default options for all probe
-type DefaultOptions struct {
+// DefaultProbe is the default options for all probe
+type DefaultProbe struct {
 	ProbeKind         string        `yaml:"-"`
 	ProbeTag          string        `yaml:"-"`
 	ProbeName         string        `yaml:"name"`
@@ -51,37 +51,37 @@ type DefaultOptions struct {
 }
 
 // Kind return the probe kind
-func (d *DefaultOptions) Kind() string {
+func (d *DefaultProbe) Kind() string {
 	return d.ProbeKind
 }
 
 // Name return the probe name
-func (d *DefaultOptions) Name() string {
+func (d *DefaultProbe) Name() string {
 	return d.ProbeName
 }
 
 // Channels return the probe channels
-func (d *DefaultOptions) Channels() []string {
+func (d *DefaultProbe) Channels() []string {
 	return d.ProbeChannels
 }
 
 // Timeout get the probe timeout
-func (d *DefaultOptions) Timeout() time.Duration {
+func (d *DefaultProbe) Timeout() time.Duration {
 	return d.ProbeTimeout
 }
 
 // Interval get the probe interval
-func (d *DefaultOptions) Interval() time.Duration {
+func (d *DefaultProbe) Interval() time.Duration {
 	return d.ProbeTimeInterval
 }
 
 // Result get the probe result
-func (d *DefaultOptions) Result() *probe.Result {
+func (d *DefaultProbe) Result() *probe.Result {
 	return d.ProbeResult
 }
 
 // Config default config
-func (d *DefaultOptions) Config(gConf global.ProbeSettings,
+func (d *DefaultProbe) Config(gConf global.ProbeSettings,
 	kind, tag, name, endpoint string, fn ProbeFuncType) error {
 
 	d.ProbeKind = kind
@@ -113,7 +113,7 @@ func (d *DefaultOptions) Config(gConf global.ProbeSettings,
 }
 
 // Probe return the checking result
-func (d *DefaultOptions) Probe() probe.Result {
+func (d *DefaultProbe) Probe() probe.Result {
 	if d.ProbeFunc == nil {
 		return *d.ProbeResult
 	}
@@ -153,7 +153,7 @@ func (d *DefaultOptions) Probe() probe.Result {
 }
 
 // ExportMetrics export the metrics
-func (d *DefaultOptions) ExportMetrics() {
+func (d *DefaultProbe) ExportMetrics() {
 	d.metrics.Total.With(prometheus.Labels{
 		"name":   d.ProbeName,
 		"status": d.ProbeResult.Status.String(),
@@ -178,7 +178,7 @@ func (d *DefaultOptions) ExportMetrics() {
 }
 
 // DownTimeCalculation calculate the down time
-func (d *DefaultOptions) DownTimeCalculation(status probe.Status) {
+func (d *DefaultProbe) DownTimeCalculation(status probe.Status) {
 
 	// Status from UP to DOWN - Failure
 	if d.ProbeResult.PreStatus != probe.StatusDown && status == probe.StatusDown {

--- a/probe/base/base_test.go
+++ b/probe/base/base_test.go
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package base
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/probe"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	status = false
+	msg    = map[bool]string{
+		true:  "success",
+		false: "failed",
+	}
+	pStatus = map[bool]probe.Status{
+		true:  probe.StatusUp,
+		false: probe.StatusDown,
+	}
+)
+
+type dummyProber struct {
+	DefaultProbe
+}
+
+func (d *dummyProber) Config(g global.ProbeSettings) error {
+	d.DefaultProbe.Config(g, d.ProbeKind, d.ProbeTag, d.ProbeName, "endpoint", d.DoProbe)
+	return nil
+}
+func (d *dummyProber) DoProbe() (bool, string) {
+	status = rand.Int()%2 == 0
+	return status, msg[status]
+}
+
+func newDummyProber(name string) *dummyProber {
+	return &dummyProber{
+		DefaultProbe: DefaultProbe{
+			ProbeKind:         "dummy",
+			ProbeTag:          "tag",
+			ProbeName:         name,
+			ProbeTimeout:      0,
+			ProbeTimeInterval: 0,
+			ProbeFunc:         nil,
+			ProbeResult:       &probe.Result{},
+		},
+	}
+}
+
+func TestBase(t *testing.T) {
+	global.InitEaseProbe("DummyProbe", "icon")
+	p := newDummyProber("probe")
+	p.Config(global.ProbeSettings{})
+	assert.Equal(t, "dummy", p.Kind())
+	assert.Equal(t, "probe", p.Name())
+	assert.Equal(t, []string{global.DefaultChannelName}, p.Channels())
+	assert.Equal(t, global.DefaultTimeOut, p.Timeout())
+	assert.Equal(t, global.DefaultProbeInterval, p.Interval())
+	assert.Equal(t, probe.StatusInit, p.Result().Status)
+
+	p.ProbeTag = ""
+	p.Config(global.ProbeSettings{})
+	assert.Equal(t, "dummy", p.Kind())
+	assert.Equal(t, "probe", p.Name())
+
+	for i := 0; i < 10; i++ {
+		p.Probe()
+		preStatus := p.Result().Status
+		assert.Equal(t, pStatus[status], preStatus)
+		assert.Contains(t, p.Result().Message, msg[status])
+
+		p.ProbeTag = "tag"
+		p.Probe()
+		assert.Equal(t, preStatus, p.Result().PreStatus)
+		assert.Equal(t, pStatus[status], p.Result().Status)
+	}
+
+}

--- a/probe/base/base_test.go
+++ b/probe/base/base_test.go
@@ -93,4 +93,8 @@ func TestBase(t *testing.T) {
 		assert.Equal(t, pStatus[status], p.Result().Status)
 	}
 
+
+	p.ProbeFunc = nil
+	r := p.Probe()
+	assert.Equal(t, *p.ProbeResult, r)
 }

--- a/probe/base/base_test.go
+++ b/probe/base/base_test.go
@@ -93,7 +93,6 @@ func TestBase(t *testing.T) {
 		assert.Equal(t, pStatus[status], p.Result().Status)
 	}
 
-
 	p.ProbeFunc = nil
 	r := p.Probe()
 	assert.Equal(t, *p.ProbeResult, r)

--- a/probe/client/client.go
+++ b/probe/client/client.go
@@ -43,7 +43,7 @@ func (c *Client) Config(gConf global.ProbeSettings) error {
 	kind := "client"
 	tag := c.DriverType.String()
 	name := c.ProbeName
-	c.DefaultOptions.Config(gConf, kind, tag, name, c.Host, c.DoProbe)
+	c.DefaultProbe.Config(gConf, kind, tag, name, c.Host, c.DoProbe)
 	c.configClientDriver()
 
 	log.Debugf("[%s] configuration: %+v, %+v", c.ProbeKind, c, c.Result())

--- a/probe/client/client_test.go
+++ b/probe/client/client_test.go
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/probe/client/conf"
+	"github.com/megaease/easeprobe/probe/client/kafka"
+	"github.com/megaease/easeprobe/probe/client/mongo"
+	"github.com/megaease/easeprobe/probe/client/mysql"
+	"github.com/megaease/easeprobe/probe/client/postgres"
+	"github.com/megaease/easeprobe/probe/client/redis"
+	"github.com/megaease/easeprobe/probe/client/zookeeper"
+	"github.com/stretchr/testify/assert"
+)
+
+func newDummyClient(driver conf.DriverType) Client {
+	return Client{
+		Options: conf.Options{
+			Host:       "example.com:1234",
+			DriverType: driver,
+			Username:   "user",
+			Password:   "pass",
+			TLS:        global.TLS{},
+		},
+		client: nil,
+	}
+}
+
+func MockProbe[T any](c T) {
+	monkey.PatchInstanceMethod(reflect.TypeOf(c), "Probe", func(_ T) (bool, string) {
+		return true, "Successfully"
+	})
+}
+
+func TestClient(t *testing.T) {
+	global.InitEaseProbe("DummyProbe", "icon")
+	clients := []Client{
+		newDummyClient(conf.MySQL),
+		newDummyClient(conf.PostgreSQL),
+		newDummyClient(conf.Redis),
+		newDummyClient(conf.Mongo),
+		newDummyClient(conf.Kafka),
+		newDummyClient(conf.Zookeeper),
+	}
+
+	for _, client := range clients {
+		err := client.Config(global.ProbeSettings{})
+		assert.Nil(t, err)
+		assert.Equal(t, "client", client.ProbeKind)
+		assert.Equal(t, client.DriverType.String(), client.ProbeTag)
+
+		switch client.DriverType {
+		case conf.MySQL:
+			MockProbe(mysql.MySQL{})
+		case conf.PostgreSQL:
+			MockProbe(postgres.PostgreSQL{})
+		case conf.Redis:
+			MockProbe(redis.Redis{})
+		case conf.Mongo:
+			MockProbe(mongo.Mongo{})
+		case conf.Kafka:
+			MockProbe(kafka.Kafka{})
+		case conf.Zookeeper:
+			MockProbe(zookeeper.Zookeeper{})
+		}
+		s, m := client.DoProbe()
+		assert.True(t, s)
+		assert.Contains(t, m, "Successfully")
+	}
+
+	u := newDummyClient(conf.Unknown)
+	u.Config(global.ProbeSettings{})
+	s, m := u.DoProbe()
+	assert.False(t, s)
+	assert.Contains(t, m, "Wrong Driver Type")
+
+	monkey.UnpatchAll()
+}

--- a/probe/client/conf/conf.go
+++ b/probe/client/conf/conf.go
@@ -59,7 +59,7 @@ var DriverMap = map[DriverType]string{
 
 // Options implements the configuration for native client
 type Options struct {
-	base.DefaultOptions `yaml:",inline"`
+	base.DefaultProbe `yaml:",inline"`
 
 	Host       string     `yaml:"host"`
 	DriverType DriverType `yaml:"driver"`

--- a/probe/client/kafka/kafka_test.go
+++ b/probe/client/kafka/kafka_test.go
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/probe/client/conf"
+	"github.com/segmentio/kafka-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKaf(t *testing.T) {
+	conf := conf.Options{
+		Host:       "example.com",
+		DriverType: conf.Kafka,
+		Username:   "root",
+		Password:   "pass",
+		TLS:        global.TLS{},
+	}
+
+	kaf := New(conf)
+	assert.Equal(t, "Kafka", kaf.Kind())
+
+	var dialer *kafka.Dialer
+	monkey.PatchInstanceMethod(reflect.TypeOf(dialer), "DialContext", func(_ *kafka.Dialer, _ context.Context, _ string, _ string) (*kafka.Conn, error) {
+		return &kafka.Conn{}, nil
+	})
+	var conn *kafka.Conn
+	monkey.PatchInstanceMethod(reflect.TypeOf(conn), "ReadPartitions", func(k *kafka.Conn, topics ...string) ([]kafka.Partition, error) {
+		return []kafka.Partition{{Topic: "topic1", ID: 1}, {Topic: "topic2", ID: 2}}, nil
+	})
+	monkey.PatchInstanceMethod(reflect.TypeOf(conn), "Close", func(_ *kafka.Conn) error {
+		return nil
+	})
+
+	s, m := kaf.Probe()
+	assert.True(t, s)
+	assert.Contains(t, m, "Successfully")
+
+	// TLS test
+	kaf.Password = ""
+	s, m = kaf.Probe()
+	assert.True(t, s)
+	assert.Contains(t, m, "Successfully")
+
+	monkey.UnpatchAll()
+}
+
+func TestKafkaFailed(t *testing.T) {
+	conf := conf.Options{
+		Host:       "example.com",
+		DriverType: conf.Kafka,
+		TLS: global.TLS{
+			CA:   "kafka.ca",
+			Cert: "kafka.cert",
+			Key:  "kafka.pem",
+		},
+	}
+
+	kaf := New(conf)
+	//TLS failed
+	assert.Nil(t, kaf.tls)
+	assert.Equal(t, "Kafka", kaf.Kind())
+
+	var dialer *kafka.Dialer
+	monkey.PatchInstanceMethod(reflect.TypeOf(dialer), "DialContext", func(_ *kafka.Dialer, _ context.Context, _ string, _ string) (*kafka.Conn, error) {
+		return &kafka.Conn{}, nil
+	})
+	var conn *kafka.Conn
+	monkey.PatchInstanceMethod(reflect.TypeOf(conn), "ReadPartitions", func(k *kafka.Conn, topics ...string) ([]kafka.Partition, error) {
+		return []kafka.Partition{}, fmt.Errorf("get topics error")
+	})
+	monkey.PatchInstanceMethod(reflect.TypeOf(conn), "Close", func(_ *kafka.Conn) error {
+		return nil
+	})
+
+	s, m := kaf.Probe()
+	assert.False(t, s)
+	assert.Contains(t, m, "get topics error")
+
+	monkey.PatchInstanceMethod(reflect.TypeOf(dialer), "DialContext", func(_ *kafka.Dialer, _ context.Context, _ string, _ string) (*kafka.Conn, error) {
+		return nil, fmt.Errorf("connection error")
+	})
+	s, m = kaf.Probe()
+	assert.False(t, s)
+	assert.Contains(t, m, "connection error")
+}

--- a/probe/client/mongo/mongo_test.go
+++ b/probe/client/mongo/mongo_test.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/probe/client/conf"
+	"github.com/stretchr/testify/assert"
+
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
+)
+
+func TestMongo(t *testing.T) {
+	conf := conf.Options{
+		Host:       "example.com",
+		DriverType: conf.Mongo,
+		Username:   "username",
+		Password:   "password",
+		TLS: global.TLS{
+			CA:   "ca",
+			Cert: "cert",
+			Key:  "key",
+		},
+	}
+
+	mg := New(conf)
+	assert.Equal(t, "Mongo", mg.Kind())
+	connStr := fmt.Sprintf("mongodb://%s:%s@%s/?connectTimeoutMS=%d",
+		conf.Username, conf.Password, conf.Host, conf.Timeout().Milliseconds())
+	assert.Equal(t, connStr, mg.ConnStr)
+	assert.Nil(t, mg.ClientOpt.TLSConfig)
+
+	monkey.Patch(mongo.Connect, func(ctx context.Context, opts ...*options.ClientOptions) (*mongo.Client, error) {
+		return &mongo.Client{}, nil
+	})
+	var client *mongo.Client
+	monkey.PatchInstanceMethod(reflect.TypeOf(client), "Disconnect", func(_ *mongo.Client, _ context.Context) error {
+		return nil
+	})
+	monkey.PatchInstanceMethod(reflect.TypeOf(client), "Ping", func(_ *mongo.Client, ctx context.Context, rp *readpref.ReadPref) error {
+		return nil
+	})
+
+	s, m := mg.Probe()
+	assert.True(t, s)
+	assert.Contains(t, m, "Successfully")
+
+	conf.Password = ""
+	mg = New(conf)
+	connStr = fmt.Sprintf("mongodb://%s/?connectTimeoutMS=%d",
+		conf.Host, conf.Timeout().Milliseconds())
+	assert.Equal(t, connStr, mg.ConnStr)
+
+	s, m = mg.Probe()
+	assert.True(t, s)
+	assert.Contains(t, m, "Successfully")
+
+	var tc *global.TLS
+	monkey.PatchInstanceMethod(reflect.TypeOf(tc), "Config", func(_ *global.TLS) (*tls.Config, error) {
+		return &tls.Config{}, nil
+	})
+
+	mg = New(conf)
+	assert.Equal(t, "Mongo", mg.Kind())
+	assert.Equal(t, connStr, mg.ConnStr)
+	assert.NotNil(t, mg.ClientOpt.TLSConfig)
+
+	s, m = mg.Probe()
+	assert.True(t, s)
+	assert.Contains(t, m, "Successfully")
+
+	//Ping Error
+	monkey.PatchInstanceMethod(reflect.TypeOf(client), "Ping", func(_ *mongo.Client, ctx context.Context, rp *readpref.ReadPref) error {
+		return fmt.Errorf("ping error")
+	})
+	s, m = mg.Probe()
+	assert.False(t, s)
+	assert.Contains(t, m, "ping error")
+
+	//Connect Error
+	monkey.Patch(mongo.Connect, func(ctx context.Context, opts ...*options.ClientOptions) (*mongo.Client, error) {
+		return nil, fmt.Errorf("connect error")
+	})
+	s, m = mg.Probe()
+	assert.False(t, s)
+	assert.Contains(t, m, "connect error")
+
+	monkey.UnpatchAll()
+}

--- a/probe/client/mysql/mysql_test.go
+++ b/probe/client/mysql/mysql_test.go
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mysql
+
+import (
+	"crypto/tls"
+	"database/sql"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"bou.ke/monkey"
+	"github.com/go-sql-driver/mysql"
+	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/probe/client/conf"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMySQL(t *testing.T) {
+	conf := conf.Options{
+		Host:       "example.com",
+		DriverType: conf.MySQL,
+		Username:   "username",
+		Password:   "password",
+		TLS: global.TLS{
+			CA:   "ca",
+			Cert: "cert",
+			Key:  "key",
+		},
+	}
+
+	my := New(conf)
+	assert.Equal(t, "MySQL", my.Kind())
+	connStr := fmt.Sprintf("%s:%s@tcp(%s)/?timeout=%s",
+		conf.Username, conf.Password, conf.Host, conf.Timeout().Round(time.Second))
+	assert.Equal(t, connStr, my.ConnStr)
+
+	conf.Password = ""
+	my = New(conf)
+	connStr = fmt.Sprintf("%s@tcp(%s)/?timeout=%s",
+		conf.Username, conf.Host, conf.Timeout().Round(time.Second))
+	assert.Equal(t, connStr, my.ConnStr)
+
+	monkey.Patch(sql.Open, func(driverName, dataSourceName string) (*sql.DB, error) {
+		return &sql.DB{}, nil
+	})
+	var db *sql.DB
+	monkey.PatchInstanceMethod(reflect.TypeOf(db), "Close", func(_ *sql.DB) error {
+		return nil
+	})
+	monkey.PatchInstanceMethod(reflect.TypeOf(db), "Ping", func(_ *sql.DB) error {
+		return nil
+	})
+	monkey.PatchInstanceMethod(reflect.TypeOf(db), "Query", func(_ *sql.DB, query string, args ...interface{}) (*sql.Rows, error) {
+		return &sql.Rows{}, nil
+	})
+	var r *sql.Rows
+	monkey.PatchInstanceMethod(reflect.TypeOf(r), "Close", func(_ *sql.Rows) error {
+		return nil
+	})
+
+	s, m := my.Probe()
+	assert.True(t, s)
+	assert.Contains(t, m, "Successfully")
+
+	// TLS config success
+	var tc *global.TLS
+	monkey.PatchInstanceMethod(reflect.TypeOf(tc), "Config", func(_ *global.TLS) (*tls.Config, error) {
+		return &tls.Config{}, nil
+	})
+	monkey.Patch(mysql.RegisterTLSConfig, func(name string, config *tls.Config) error {
+		return nil
+	})
+
+	my = New(conf)
+	assert.NotNil(t, my.tls)
+	s, m = my.Probe()
+	assert.True(t, s)
+	assert.Contains(t, m, "Successfully")
+
+	//  Query error
+	monkey.PatchInstanceMethod(reflect.TypeOf(db), "Query", func(_ *sql.DB, query string, args ...interface{}) (*sql.Rows, error) {
+		return nil, fmt.Errorf("query error")
+	})
+	s, m = my.Probe()
+	assert.False(t, s)
+	assert.Contains(t, m, "query error")
+
+	// Ping error
+	monkey.PatchInstanceMethod(reflect.TypeOf(db), "Ping", func(_ *sql.DB) error {
+		return fmt.Errorf("ping error")
+	})
+	s, m = my.Probe()
+	assert.False(t, s)
+	assert.Contains(t, m, "ping error")
+
+	// Connect error
+	monkey.Patch(sql.Open, func(driverName, dataSourceName string) (*sql.DB, error) {
+		return nil, fmt.Errorf("connect error")
+	})
+	s, m = my.Probe()
+	assert.False(t, s)
+	assert.Contains(t, m, "connect error")
+
+}

--- a/probe/client/postgres/postgres.go
+++ b/probe/client/postgres/postgres.go
@@ -75,6 +75,9 @@ func (r PostgreSQL) Kind() string {
 // Probe do the health check
 func (r PostgreSQL) Probe() (bool, string) {
 	db := sql.OpenDB(pgdriver.NewConnector(r.ClientOptions...))
+	if db == nil {
+		return false, "OpenDB error"
+	}
 	defer db.Close()
 
 	if err := db.Ping(); err != nil {
@@ -82,9 +85,11 @@ func (r PostgreSQL) Probe() (bool, string) {
 	}
 
 	// run a SQL to test
-	if _, err := db.Query(`SELECT 1`); err != nil {
+	row, err := db.Query(`SELECT 1`)
+	if err != nil {
 		return false, err.Error()
 	}
+	row.Close()
 
 	return true, "Check PostgreSQL Server Successfully!"
 }

--- a/probe/client/postgres/postgres_test.go
+++ b/probe/client/postgres/postgres_test.go
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package postgres
+
+import (
+	"crypto/tls"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/probe/client/conf"
+	"github.com/stretchr/testify/assert"
+	"github.com/uptrace/bun/driver/pgdriver"
+)
+
+func TestPostgreSQL(t *testing.T) {
+	conf := conf.Options{
+		Host:       "example.com",
+		DriverType: conf.PostgreSQL,
+		Username:   "username",
+		Password:   "password",
+		TLS: global.TLS{
+			CA:   "ca",
+			Cert: "cert",
+			Key:  "key",
+		},
+	}
+
+	pg := New(conf)
+	assert.Equal(t, "PostgreSQL", pg.Kind())
+	pgd := pgdriver.NewConnector(pg.ClientOptions...)
+	assert.Equal(t, conf.Host, pgd.Config().Addr)
+	assert.Equal(t, conf.Username, pgd.Config().User)
+	assert.Equal(t, conf.Password, pgd.Config().Password)
+	assert.Equal(t, conf.Timeout(), pgd.Config().DialTimeout)
+	assert.Equal(t, conf.Timeout(), pgd.Config().ReadTimeout)
+	assert.Equal(t, conf.Timeout(), pgd.Config().WriteTimeout)
+	assert.Nil(t, pgd.Config().TLSConfig.ClientCAs)
+
+	monkey.Patch(sql.OpenDB, func(c driver.Connector) *sql.DB {
+		return &sql.DB{}
+	})
+
+	var db *sql.DB
+	monkey.PatchInstanceMethod(reflect.TypeOf(db), "Ping", func(_ *sql.DB) error {
+		return nil
+	})
+	monkey.PatchInstanceMethod(reflect.TypeOf(db), "Close", func(_ *sql.DB) error {
+		return nil
+	})
+	monkey.PatchInstanceMethod(reflect.TypeOf(db), "Query", func(_ *sql.DB, query string, args ...interface{}) (*sql.Rows, error) {
+		return &sql.Rows{}, nil
+	})
+	var r *sql.Rows
+	monkey.PatchInstanceMethod(reflect.TypeOf(r), "Close", func(_ *sql.Rows) error {
+		return nil
+	})
+
+	s, m := pg.Probe()
+	assert.True(t, s)
+	assert.Contains(t, m, "Successfully")
+
+	// TLS config success
+	var tc *global.TLS
+	monkey.PatchInstanceMethod(reflect.TypeOf(tc), "Config", func(_ *global.TLS) (*tls.Config, error) {
+		return &tls.Config{}, nil
+	})
+
+	pg = New(conf)
+	pgd = pgdriver.NewConnector(pg.ClientOptions...)
+	assert.True(t, pgd.Config().TLSConfig.InsecureSkipVerify)
+
+	// Query error
+	monkey.PatchInstanceMethod(reflect.TypeOf(db), "Query", func(_ *sql.DB, query string, args ...interface{}) (*sql.Rows, error) {
+		return nil, fmt.Errorf("query error")
+	})
+	s, m = pg.Probe()
+	assert.False(t, s)
+	assert.Contains(t, m, "query error")
+
+	// Ping error
+	monkey.PatchInstanceMethod(reflect.TypeOf(db), "Ping", func(_ *sql.DB) error {
+		return fmt.Errorf("ping error")
+	})
+	s, m = pg.Probe()
+	assert.False(t, s)
+	assert.Contains(t, m, "ping error")
+
+	// OpenDB error
+	monkey.Patch(sql.OpenDB, func(c driver.Connector) *sql.DB {
+		return nil
+	})
+	s, m = pg.Probe()
+	assert.False(t, s)
+	assert.Contains(t, m, "OpenDB error")
+
+	monkey.UnpatchAll()
+
+}

--- a/probe/client/redis/redis_test.go
+++ b/probe/client/redis/redis_test.go
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package redis
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/go-redis/redis/v8"
+	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/probe/client/conf"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedis(t *testing.T) {
+	conf := conf.Options{
+		Host:       "example.com",
+		DriverType: conf.Redis,
+		Username:   "username",
+		Password:   "password",
+		TLS: global.TLS{
+			CA:   "ca",
+			Cert: "cert",
+			Key:  "key",
+		},
+	}
+
+	r := New(conf)
+	assert.Equal(t, "Redis", r.Kind())
+	assert.Nil(t, r.tls)
+
+	var client *redis.Client
+	monkey.PatchInstanceMethod(reflect.TypeOf(client), "Ping", func(_ *redis.Client, ctx context.Context) *redis.StatusCmd {
+		return &redis.StatusCmd{}
+	})
+	monkey.PatchInstanceMethod(reflect.TypeOf(client), "Close", func(_ *redis.Client) error {
+		return nil
+	})
+	var statusCmd *redis.StatusCmd
+	monkey.PatchInstanceMethod(reflect.TypeOf(statusCmd), "Result", func(_ *redis.StatusCmd) (string, error) {
+		return "PONG", nil
+	})
+
+	s, m := r.Probe()
+	assert.True(t, s)
+	assert.Contains(t, m, "Successfully")
+
+	// TLS config success
+	var tc *global.TLS
+	monkey.PatchInstanceMethod(reflect.TypeOf(tc), "Config", func(_ *global.TLS) (*tls.Config, error) {
+		return &tls.Config{}, nil
+	})
+	r = New(conf)
+	assert.NotNil(t, r.tls)
+
+	s, m = r.Probe()
+	assert.True(t, s)
+	assert.Contains(t, m, "Successfully")
+
+	// Ping error
+	monkey.PatchInstanceMethod(reflect.TypeOf(statusCmd), "Result", func(_ *redis.StatusCmd) (string, error) {
+		return "", fmt.Errorf("ping error")
+	})
+	s, m = r.Probe()
+	assert.False(t, s)
+	assert.Contains(t, m, "ping error")
+
+	monkey.UnpatchAll()
+
+}

--- a/probe/client/zookeeper/zookeeper.go
+++ b/probe/client/zookeeper/zookeeper.go
@@ -28,7 +28,7 @@ import (
 )
 
 // Kind is the type of driver
-const Kind string = "Zookeeper"
+const Kind string = "ZooKeeper"
 
 // Zookeeper is the Zookeeper client
 type Zookeeper struct {
@@ -63,12 +63,8 @@ func (z Zookeeper) Probe() (bool, string) {
 		err  error
 	)
 
-	if dialer := getDialer(z); dialer != nil {
-		conn, _, err = zk.Connect([]string{z.Host}, z.Timeout(), zk.WithLogInfo(false), zk.WithDialer(dialer))
-	} else {
-		conn, _, err = zk.Connect([]string{z.Host}, z.Timeout(), zk.WithLogInfo(false))
-	}
-
+	dialer := getDialer(z)
+	conn, _, err = zk.ConnectWithDialer([]string{z.Host}, z.Timeout(), dialer)
 	if err != nil {
 		return false, err.Error()
 	}
@@ -84,7 +80,7 @@ func (z Zookeeper) Probe() (bool, string) {
 
 func getDialer(z Zookeeper) func(network string, address string, _ time.Duration) (net.Conn, error) {
 	if z.tls == nil {
-		return nil
+		return net.DialTimeout
 	}
 
 	return func(network, address string, _ time.Duration) (net.Conn, error) {

--- a/probe/client/zookeeper/zookeeper_test.go
+++ b/probe/client/zookeeper/zookeeper_test.go
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zookeeper
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"reflect"
+	"testing"
+	"time"
+
+	"bou.ke/monkey"
+	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/probe/client/conf"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/go-zookeeper/zk"
+)
+
+func TestZooKeeper(t *testing.T) {
+	conf := conf.Options{
+		Host:       "127.0.0.0:2181",
+		DriverType: conf.Redis,
+		Username:   "username",
+		Password:   "password",
+		TLS: global.TLS{
+			CA:   "ca",
+			Cert: "cert",
+			Key:  "key",
+		},
+	}
+
+	z := New(conf)
+	assert.Equal(t, "ZooKeeper", z.Kind())
+
+	monkey.Patch(net.DialTimeout, func(network, address string, timeout time.Duration) (net.Conn, error) {
+		return &net.TCPConn{}, nil
+	})
+
+	var conn *zk.Conn
+	monkey.PatchInstanceMethod(reflect.TypeOf(conn), "Get", func(_ *zk.Conn, path string) ([]byte, *zk.Stat, error) {
+		return []byte("test"), &zk.Stat{}, nil
+	})
+	monkey.PatchInstanceMethod(reflect.TypeOf(conn), "Close", func(_ *zk.Conn) {
+		return
+	})
+
+	monkey.Patch(zk.ConnectWithDialer, func(servers []string, sessionTimeout time.Duration, dialer zk.Dialer) (*zk.Conn, <-chan zk.Event, error) {
+		return &zk.Conn{}, nil, nil
+	})
+	s, m := z.Probe()
+	assert.True(t, s)
+	assert.Contains(t, m, "Successfully")
+
+	// TLS config success
+	var tc *global.TLS
+	monkey.PatchInstanceMethod(reflect.TypeOf(tc), "Config", func(_ *global.TLS) (*tls.Config, error) {
+		return &tls.Config{}, nil
+	})
+	z = New(conf)
+	assert.NotNil(t, z.tls)
+
+	s, m = z.Probe()
+	assert.True(t, s)
+	assert.Contains(t, m, "Successfully")
+
+	// Get error
+	monkey.PatchInstanceMethod(reflect.TypeOf(conn), "Get", func(_ *zk.Conn, path string) ([]byte, *zk.Stat, error) {
+		return nil, nil, fmt.Errorf("get error")
+	})
+	s, m = z.Probe()
+	assert.False(t, s)
+	assert.Contains(t, m, "get error")
+
+	// Connect error
+	monkey.Patch(zk.ConnectWithDialer, func(servers []string, sessionTimeout time.Duration, dialer zk.Dialer) (*zk.Conn, <-chan zk.Event, error) {
+		return nil, nil, fmt.Errorf("connect error")
+	})
+	s, m = z.Probe()
+	assert.False(t, s)
+	assert.Contains(t, m, "connect error")
+
+	monkey.UnpatchAll()
+}
+
+func TestGetDialer(t *testing.T) {
+	zConf := Zookeeper{
+		Options: conf.Options{
+			Host:       "127.0.0.0:2181",
+			DriverType: conf.Redis,
+			Username:   "username",
+			Password:   "password",
+			TLS: global.TLS{
+				CA:   "ca",
+				Cert: "cert",
+				Key:  "key",
+			},
+		},
+		tls: &tls.Config{},
+	}
+
+	fn := getDialer(zConf)
+
+	monkey.Patch(net.DialTimeout, func(network, address string, timeout time.Duration) (net.Conn, error) {
+		return &net.TCPConn{}, nil
+	})
+	var tlsConn *tls.Conn
+	monkey.PatchInstanceMethod(reflect.TypeOf(tlsConn), "Handshake", func(_ *tls.Conn) error {
+		return nil
+	})
+	monkey.PatchInstanceMethod(reflect.TypeOf(tlsConn), "Close", func(_ *tls.Conn) error {
+		return nil
+	})
+
+	conn, err := fn("tcp", zConf.Host, time.Second)
+	assert.Nil(t, err)
+	assert.NotNil(t, conn)
+
+	monkey.PatchInstanceMethod(reflect.TypeOf(tlsConn), "Handshake", func(_ *tls.Conn) error {
+		return fmt.Errorf("handshake error")
+	})
+	conn, err = fn("tcp", zConf.Host, time.Second)
+	assert.Equal(t, "handshake error", err.Error())
+	assert.Nil(t, conn)
+
+	monkey.Patch(net.DialTimeout, func(network, address string, timeout time.Duration) (net.Conn, error) {
+		return nil, fmt.Errorf("dial error")
+	})
+	conn, err = fn("tcp", zConf.Host, time.Second)
+	assert.Equal(t, "dial error", err.Error())
+	assert.Nil(t, conn)
+
+}

--- a/probe/data_test.go
+++ b/probe/data_test.go
@@ -223,9 +223,10 @@ func TestMetaData(t *testing.T) {
 	if err := LoadDataFromFile(file); err != nil {
 		t.Error(err)
 	}
-	assert.Equal(t, metaData.Name, "myprog")
-	assert.Equal(t, metaData.Ver, global.Ver)
-	assert.Equal(t, metaData.ver, "v1.0.0")
+	m := GetMetaData()
+	assert.Equal(t, m.Name, "myprog")
+	assert.Equal(t, m.Ver, global.Ver)
+	assert.Equal(t, m.ver, "v1.0.0")
 
 	removeAll("data/")
 }

--- a/probe/host/host_test.go
+++ b/probe/host/host_test.go
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package host
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/probe/base"
+	"github.com/megaease/easeprobe/probe/ssh"
+	"github.com/stretchr/testify/assert"
+)
+
+func newHost(t *testing.T) *Host {
+	return &Host{
+		Servers: []Server{
+			{
+				Server: ssh.Server{
+					DefaultProbe: base.DefaultProbe{ProbeName: "dummy host"},
+					Endpoint:     ssh.Endpoint{Host: "server:22"},
+				},
+			},
+		},
+	}
+}
+
+var hostInfo = `t01
+Ubuntu
+4407 15718 28.04
+4
+  71.6 us,  1.7 sy,  0.2 ni, 26.8 id,  0.3 wa,  0.4 hi,  0.5 si,  0.6 st
+58 97 60%`
+
+func TestHostInfo(t *testing.T) {
+	host := newHost(t)
+	info, err := host.Servers[0].ParseHostInfo(hostInfo)
+	assert.Nil(t, err)
+	assert.Equal(t, "t01", info.HostName)
+	assert.Equal(t, "Ubuntu", info.OS)
+	assert.Equal(t, 4407, info.Memory.Used)
+	assert.Equal(t, 15718, info.Memory.Total)
+	assert.Equal(t, "28.04", fmt.Sprintf("%.2f", info.Memory.Usage))
+	assert.Equal(t, int64(4), info.Core)
+	assert.Equal(t, "71.60", fmt.Sprintf("%.2f", info.CPU.User))
+	assert.Equal(t, "1.70", fmt.Sprintf("%.2f", info.CPU.Sys))
+	assert.Equal(t, "0.20", fmt.Sprintf("%.2f", info.CPU.Nice))
+	assert.Equal(t, "26.80", fmt.Sprintf("%.2f", info.CPU.Idle))
+	assert.Equal(t, "0.30", fmt.Sprintf("%.2f", info.CPU.Wait))
+	assert.Equal(t, "0.40", fmt.Sprintf("%.2f", info.CPU.Hard))
+	assert.Equal(t, "0.50", fmt.Sprintf("%.2f", info.CPU.Soft))
+	assert.Equal(t, "0.60", fmt.Sprintf("%.2f", info.CPU.Steal))
+	assert.Equal(t, 58, info.Disk.Used)
+	assert.Equal(t, 97, info.Disk.Total)
+	assert.Equal(t, "60.00", fmt.Sprintf("%.2f", info.Disk.Usage))
+}
+
+func TestHost(t *testing.T) {
+	host := newHost(t)
+	for i := 0; i < len(host.Servers); i++ {
+		server := &host.Servers[i]
+		server.Config(global.ProbeSettings{})
+		assert.Equal(t, "host", server.ProbeKind)
+		assert.Equal(t, "server", server.ProbeTag)
+	}
+
+	var s *ssh.Server
+	monkey.PatchInstanceMethod(reflect.TypeOf(s), "RunSSHCmd", func(_ *ssh.Server) (string, error) {
+		return hostInfo, nil
+	})
+
+	server := &host.Servers[0]
+	status, message := server.DoProbe()
+	assert.True(t, status)
+	assert.Contains(t, message, "Fine")
+
+	server.Threshold.CPU = 0.5
+	status, message = server.DoProbe()
+	assert.False(t, status)
+	assert.Contains(t, message, "CPU Busy!")
+
+	server.Threshold.Mem = 0.2
+	status, message = server.DoProbe()
+	assert.False(t, status)
+	assert.Contains(t, message, "Memory Shortage!")
+
+	server.Threshold.Disk = 0.2
+	status, message = server.DoProbe()
+	assert.False(t, status)
+	assert.Contains(t, message, "Disk Full!")
+
+	// invalid disk format
+	hostInfo = `t01
+	Ubuntu
+	4407 15718 28.04
+	4
+	  71.6 us,  1.7 sy,  0.2 ni, 26.8 id,  0.3 wa,  0.4 hi,  0.5 si,  0.6 st
+	58`
+	status, message = server.DoProbe()
+	assert.False(t, status)
+	assert.Contains(t, message, "invalid disk output")
+
+	// invalid memory format
+	hostInfo = `t01
+	Ubuntu
+	4407 15718
+	4
+	71.6 us,  1.7 sy,  0.2 ni, 26.8 id,  0.3 wa,  0.4 hi,  0.5 si,  0.6 st
+	58 97 60%`
+	status, message = server.DoProbe()
+	assert.False(t, status)
+	assert.Contains(t, message, "invalid memory output")
+
+	// invalid cpu format
+	hostInfo = `t01
+	Ubuntu
+	4407 15718 28.04
+	4
+	71.6 us,  1.7 sy,  0.2 ni, 26.8 id
+	58 97 60%`
+	status, message = server.DoProbe()
+	assert.False(t, status)
+	assert.Contains(t, message, "invalid cpu output")
+
+	// bad format
+	monkey.PatchInstanceMethod(reflect.TypeOf(s), "RunSSHCmd", func(_ *ssh.Server) (string, error) {
+		return "", nil
+	})
+	status, message = server.DoProbe()
+	assert.False(t, status)
+	assert.Contains(t, message, "invalid output")
+
+	// run ssh failed
+	monkey.PatchInstanceMethod(reflect.TypeOf(s), "RunSSHCmd", func(_ *ssh.Server) (string, error) {
+		return "", errors.New("ssh error")
+	})
+	status, message = server.DoProbe()
+	assert.False(t, status)
+	assert.Contains(t, message, "ssh error")
+
+}

--- a/probe/http/http.go
+++ b/probe/http/http.go
@@ -34,14 +34,14 @@ import (
 
 // HTTP implements a config for HTTP.
 type HTTP struct {
-	base.DefaultOptions `yaml:",inline"`
-	URL                 string            `yaml:"url"`
-	ContentEncoding     string            `yaml:"content_encoding,omitempty"`
-	Method              string            `yaml:"method,omitempty"`
-	Headers             map[string]string `yaml:"headers,omitempty"`
-	Body                string            `yaml:"body,omitempty"`
-	Contain             string            `yaml:"contain,omitempty"`
-	NotContain          string            `yaml:"not_contain,omitempty"`
+	base.DefaultProbe `yaml:",inline"`
+	URL               string            `yaml:"url"`
+	ContentEncoding   string            `yaml:"content_encoding,omitempty"`
+	Method            string            `yaml:"method,omitempty"`
+	Headers           map[string]string `yaml:"headers,omitempty"`
+	Body              string            `yaml:"body,omitempty"`
+	Contain           string            `yaml:"contain,omitempty"`
+	NotContain        string            `yaml:"not_contain,omitempty"`
 
 	// Option - HTTP Basic Auth Credentials
 	User string `yaml:"username,omitempty"`
@@ -74,7 +74,7 @@ func (h *HTTP) Config(gConf global.ProbeSettings) error {
 	kind := "http"
 	tag := ""
 	name := h.ProbeName
-	h.DefaultOptions.Config(gConf, kind, tag, name, h.URL, h.DoProbe)
+	h.DefaultProbe.Config(gConf, kind, tag, name, h.URL, h.DoProbe)
 
 	if _, err := url.ParseRequestURI(h.URL); err != nil {
 		log.Errorf("URL is not valid - %+v url=%+v", err, h.URL)

--- a/probe/http/http_test.go
+++ b/probe/http/http_test.go
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package http
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/probe/base"
+	"github.com/stretchr/testify/assert"
+)
+
+func createHTTP() *HTTP {
+	return &HTTP{
+		DefaultProbe:    base.DefaultProbe{ProbeName: "dummy http"},
+		URL:             "http://example.com",
+		ContentEncoding: "text/json",
+		Headers:         map[string]string{"header1": "value1", "header2": "value2"},
+		Body:            "{ \"key1\": \"value1\", \"key2\": \"value2\" }",
+		Contain:         "good",
+		NotContain:      "bad",
+		User:            "user",
+		Pass:            "pass",
+		TLS: global.TLS{
+			CA:   "ca.crt",
+			Cert: "cert.crt",
+			Key:  "key.key",
+		},
+	}
+}
+func TestHTTPConfig(t *testing.T) {
+	h := createHTTP()
+	err := h.Config(global.ProbeSettings{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no such file or directory")
+
+	//TLS config success
+	var gtls *global.TLS
+	monkey.PatchInstanceMethod(reflect.TypeOf(gtls), "Config", func(_ *global.TLS) (*tls.Config, error) {
+		return &tls.Config{}, nil
+	})
+
+	h.URL = "@$186example.com"
+	err = h.Config(global.ProbeSettings{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid URI")
+	h.URL = "https://example.com"
+
+	h.SuccessCode = append(h.SuccessCode, []int{900, 999, 1000})
+	err = h.Config(global.ProbeSettings{})
+	assert.NoError(t, err)
+	assert.Equal(t, [][]int{{0, 499}}, h.SuccessCode)
+
+	err = h.Config(global.ProbeSettings{})
+	assert.NoError(t, err)
+	assert.NotNil(t, h.TLS)
+	assert.Equal(t, "GET", h.Method)
+
+	monkey.UnpatchAll()
+}
+
+func TestHTTPDoProbe(t *testing.T) {
+	// clear request
+	h := createHTTP()
+	var gtls *global.TLS
+	monkey.PatchInstanceMethod(reflect.TypeOf(gtls), "Config", func(_ *global.TLS) (*tls.Config, error) {
+		return &tls.Config{}, nil
+	})
+	err := h.Config(global.ProbeSettings{})
+	assert.NoError(t, err)
+
+	var client *http.Client
+	monkey.PatchInstanceMethod(reflect.TypeOf(client), "Do", func(_ *http.Client, req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(ioutil.NopCloser(nil)),
+		}, nil
+	})
+	monkey.Patch(ioutil.ReadAll, func(r io.Reader) ([]byte, error) {
+		return []byte("good"), nil
+	})
+
+	s, m := h.DoProbe()
+	assert.True(t, s)
+	assert.Contains(t, m, "200")
+
+	// response does not contain good string
+	monkey.Patch(ioutil.ReadAll, func(r io.Reader) ([]byte, error) {
+		return []byte("bad"), nil
+	})
+	s, m = h.DoProbe()
+	assert.False(t, s)
+	assert.Contains(t, m, "good")
+
+	// response does contain the bad string
+	h.Contain = ""
+	s, m = h.DoProbe()
+	assert.False(t, s)
+	assert.Contains(t, m, "bad")
+
+	// response is 503
+	monkey.PatchInstanceMethod(reflect.TypeOf(client), "Do", func(_ *http.Client, req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 503,
+			Body:       io.NopCloser(ioutil.NopCloser(nil)),
+		}, nil
+	})
+	s, m = h.DoProbe()
+	assert.False(t, s)
+	assert.Contains(t, m, "503")
+
+	// io read failure
+	monkey.Patch(ioutil.ReadAll, func(r io.Reader) ([]byte, error) {
+		return nil, fmt.Errorf("read error")
+	})
+	s, m = h.DoProbe()
+	assert.False(t, s)
+	assert.Contains(t, m, "read error")
+
+	// request failure
+	monkey.PatchInstanceMethod(reflect.TypeOf(client), "Do", func(_ *http.Client, req *http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("request error")
+	})
+	s, m = h.DoProbe()
+	assert.False(t, s)
+	assert.Contains(t, m, "request error")
+
+	// http new request failure
+	monkey.Patch(http.NewRequest, func(method, url string, body io.Reader) (*http.Request, error) {
+		return nil, fmt.Errorf("new request error")
+	})
+	s, m = h.DoProbe()
+	assert.False(t, s)
+	assert.Contains(t, m, "new request error")
+
+	monkey.UnpatchAll()
+}

--- a/probe/http/http_test.go
+++ b/probe/http/http_test.go
@@ -54,7 +54,6 @@ func TestHTTPConfig(t *testing.T) {
 	h := createHTTP()
 	err := h.Config(global.ProbeSettings{})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "no such file or directory")
 
 	//TLS config success
 	var gtls *global.TLS

--- a/probe/result.go
+++ b/probe/result.go
@@ -161,3 +161,16 @@ func (r *Result) DebugJSONIndent() string {
 	}
 	return string(j)
 }
+
+// SLAPercent calculate the SLAPercent
+func (r *Result) SLAPercent() float64 {
+	uptime := r.Stat.UpTime.Seconds()
+	downtime := r.Stat.DownTime.Seconds()
+	if uptime+downtime <= 0 {
+		if r.Status == StatusUp {
+			return 100
+		}
+		return 0
+	}
+	return uptime / (uptime + downtime) * 100
+}

--- a/probe/result_test.go
+++ b/probe/result_test.go
@@ -215,3 +215,25 @@ func TestDebug(t *testing.T) {
 		t.Errorf("%s != %s", str, expected)
 	}
 }
+
+func TestSLAPercent(t *testing.T) {
+	r := NewResult()
+	r.Stat.UpTime = 10 * time.Second
+	r.Stat.DownTime = 10 * time.Second
+	assert.Equal(t, float64(50), r.SLAPercent())
+
+	r.Stat.UpTime = 0
+	r.Stat.DownTime = 10 * time.Second
+	assert.Equal(t, float64(0), r.SLAPercent())
+
+	r.Stat.UpTime = 10 * time.Second
+	r.Stat.DownTime = 0
+	assert.Equal(t, float64(100), r.SLAPercent())
+
+	r.Stat.UpTime = 0
+	r.Stat.DownTime = 0
+	r.Status = StatusDown
+	assert.Equal(t, float64(0), r.SLAPercent())
+	r.Status = StatusUp
+	assert.Equal(t, float64(100), r.SLAPercent())
+}

--- a/probe/shell/shell.go
+++ b/probe/shell/shell.go
@@ -33,12 +33,12 @@ import (
 
 // Shell implements a config for shell command (os.Exec)
 type Shell struct {
-	base.DefaultOptions `yaml:",inline"`
-	Command             string   `yaml:"cmd"`
-	Args                []string `yaml:"args,omitempty"`
-	Env                 []string `yaml:"env,omitempty"`
-	Contain             string   `yaml:"contain,omitempty"`
-	NotContain          string   `yaml:"not_contain,omitempty"`
+	base.DefaultProbe `yaml:",inline"`
+	Command           string   `yaml:"cmd"`
+	Args              []string `yaml:"args,omitempty"`
+	Env               []string `yaml:"env,omitempty"`
+	Contain           string   `yaml:"contain,omitempty"`
+	NotContain        string   `yaml:"not_contain,omitempty"`
 
 	exitCode  int `yaml:"-"`
 	outputLen int `yaml:"-"`
@@ -51,7 +51,7 @@ func (s *Shell) Config(gConf global.ProbeSettings) error {
 	kind := "shell"
 	tag := ""
 	name := s.ProbeName
-	s.DefaultOptions.Config(gConf, kind, tag, name,
+	s.DefaultProbe.Config(gConf, kind, tag, name,
 		probe.CommandLine(s.Command, s.Args), s.DoProbe)
 
 	s.metrics = newMetrics(kind, tag)

--- a/probe/shell/shell.go
+++ b/probe/shell/shell.go
@@ -82,10 +82,12 @@ func (s *Shell) DoProbe() (bool, string) {
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			s.exitCode = exitError.ExitCode()
+			message = fmt.Sprintf("Error: %v, ExitCode(%d), Output:%s",
+				err, s.exitCode, probe.CheckEmpty(string(output)))
+		} else {
+			message = fmt.Sprintf("Error: %v, ExitCode(null), Output:%s",
+				err, probe.CheckEmpty(string(output)))
 		}
-
-		message = fmt.Sprintf("Error: %v, ExitCode(%d), Output:%s",
-			err, s.exitCode, probe.CheckEmpty(string(output)))
 		log.Errorf(message)
 		status = false
 	}
@@ -96,7 +98,7 @@ func (s *Shell) DoProbe() (bool, string) {
 
 	if err := probe.CheckOutput(s.Contain, s.NotContain, string(output)); err != nil {
 		log.Errorf("[%s / %s] - %v", s.ProbeKind, s.ProbeName, err)
-		s.ProbeResult.Message = fmt.Sprintf("Error: %v", err)
+		message = fmt.Sprintf("Error: %v", err)
 		status = false
 	}
 

--- a/probe/shell/shell_test.go
+++ b/probe/shell/shell_test.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shell
+
+import (
+	"context"
+	"os/exec"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/probe/base"
+	"github.com/stretchr/testify/assert"
+)
+
+func createShell() *Shell {
+	return &Shell{
+		DefaultProbe: base.DefaultProbe{ProbeName: "dummy shell"},
+		Command:      "dummy command",
+		Args:         []string{"arg1", "arg2"},
+		Env:          []string{"env1=value1", "env2=value2"},
+		Contain:      "good",
+		NotContain:   "bad",
+	}
+}
+func TestShell(t *testing.T) {
+	s := createShell()
+	s.Config(global.ProbeSettings{})
+	assert.Equal(t, "shell", s.ProbeKind)
+
+	monkey.Patch(exec.CommandContext, func(ctx context.Context, name string, arg ...string) *exec.Cmd {
+		return &exec.Cmd{}
+	})
+	var cmd *exec.Cmd
+	monkey.PatchInstanceMethod(reflect.TypeOf(cmd), "CombinedOutput", func(_ *exec.Cmd) ([]byte, error) {
+		return []byte("good"), nil
+	})
+
+	status, message := s.DoProbe()
+	assert.True(t, status)
+	assert.Contains(t, message, "Successfully")
+
+	// contains the bad output
+	s.Contain = ""
+	s.NotContain = "bad"
+	monkey.PatchInstanceMethod(reflect.TypeOf(cmd), "CombinedOutput", func(_ *exec.Cmd) ([]byte, error) {
+		return []byte("bad"), nil
+	})
+	status, message = s.DoProbe()
+	assert.False(t, status)
+	assert.Contains(t, message, "bad")
+
+	// run command error
+	monkey.UnpatchAll()
+	//no exit code
+	status, message = s.DoProbe()
+	assert.False(t, status)
+	assert.Contains(t, message, "ExitCode(null)")
+
+	s.Command = "sh"
+	s.Args = []string{"-c", "notfound"}
+	status, message = s.DoProbe()
+	assert.False(t, status)
+	assert.NotContains(t, message, "ExitCode(null)")
+
+}

--- a/probe/ssh/ssh.go
+++ b/probe/ssh/ssh.go
@@ -140,19 +140,18 @@ func (s *Server) DoProbe() (bool, string) {
 		log.Errorf("[%s / %s] %v", s.ProbeKind, s.ProbeName, err)
 		status = false
 		message = err.Error() + " - " + output
+	} else {
+		if err := probe.CheckOutput(s.Contain, s.NotContain, string(output)); err != nil {
+			log.Errorf("[%s / %s] - %v", s.ProbeKind, s.ProbeName, err)
+			message = fmt.Sprintf("Error: %v", err)
+			status = false
+		}
 	}
 
 	log.Debugf("[%s / %s] - %s", s.ProbeKind, s.ProbeName, probe.CommandLine(s.Command, s.Args))
 	log.Debugf("[%s / %s] - %s", s.ProbeKind, s.ProbeName, probe.CheckEmpty(string(output)))
 
 	s.ExportMetrics()
-
-	if err := probe.CheckOutput(s.Contain, s.NotContain, string(output)); err != nil {
-		log.Errorf("[%s / %s] - %v", s.ProbeKind, s.ProbeName, err)
-		message = fmt.Sprintf("Error: %v", err)
-		status = false
-	}
-
 	return status, message
 }
 

--- a/probe/ssh/ssh.go
+++ b/probe/ssh/ssh.go
@@ -35,13 +35,13 @@ const Kind string = "ssh"
 
 // Server implements a config for ssh command
 type Server struct {
-	base.DefaultOptions `yaml:",inline"`
-	Endpoint            `yaml:",inline"`
-	Command             string   `yaml:"cmd"`
-	Args                []string `yaml:"args,omitempty"`
-	Env                 []string `yaml:"env,omitempty"`
-	Contain             string   `yaml:"contain,omitempty"`
-	NotContain          string   `yaml:"not_contain,omitempty"`
+	base.DefaultProbe `yaml:",inline"`
+	Endpoint          `yaml:",inline"`
+	Command           string   `yaml:"cmd"`
+	Args              []string `yaml:"args,omitempty"`
+	Env               []string `yaml:"env,omitempty"`
+	Contain           string   `yaml:"contain,omitempty"`
+	NotContain        string   `yaml:"not_contain,omitempty"`
 
 	BastionID string    `yaml:"bastion"`
 	bastion   *Endpoint `yaml:"-"`
@@ -96,7 +96,7 @@ func (s *Server) Configure(gConf global.ProbeSettings,
 	kind, tag, name, endpoint string,
 	bastionMap *BastionMapType, fn base.ProbeFuncType) error {
 
-	s.DefaultOptions.Config(gConf, kind, tag, name, endpoint, fn)
+	s.DefaultProbe.Config(gConf, kind, tag, name, endpoint, fn)
 
 	if len(s.Password) <= 0 && len(s.PrivateKey) <= 0 {
 		return fmt.Errorf("password or private key is required")

--- a/probe/ssh/ssh_test.go
+++ b/probe/ssh/ssh_test.go
@@ -53,7 +53,7 @@ func createSSHConfig() *SSH {
 		Bastion: &BastionMap,
 		Servers: []Server{
 			{
-				DefaultOptions: base.DefaultOptions{
+				DefaultProbe: base.DefaultProbe{
 					ProbeName: "Server One",
 				},
 				Endpoint: Endpoint{
@@ -71,7 +71,7 @@ func createSSHConfig() *SSH {
 				BastionID:  "aws",
 			},
 			{
-				DefaultOptions: base.DefaultOptions{
+				DefaultProbe: base.DefaultProbe{
 					ProbeName: "Server Two",
 				},
 				Endpoint: Endpoint{

--- a/probe/status.go
+++ b/probe/status.go
@@ -20,6 +20,8 @@ package probe
 import (
 	"encoding/json"
 	"strings"
+
+	"github.com/megaease/easeprobe/global"
 )
 
 // Status is the status of Probe
@@ -42,13 +44,9 @@ var (
 		StatusUnknown: "unknown",
 		StatusBad:     "bad",
 	}
-	toStatus = map[string]Status{
-		"init":    StatusInit,
-		"up":      StatusUp,
-		"down":    StatusDown,
-		"unknown": StatusUnknown,
-		"bad":     StatusBad,
-	}
+
+	toStatus = global.ReverseMap(toString)
+
 	toEmoji = map[Status]string{
 		StatusInit:    "🔎",
 		StatusUp:      "✅",

--- a/probe/tcp/tcp.go
+++ b/probe/tcp/tcp.go
@@ -28,8 +28,8 @@ import (
 
 // TCP implements a config for TCP
 type TCP struct {
-	base.DefaultOptions `yaml:",inline"`
-	Host                string `yaml:"host"`
+	base.DefaultProbe `yaml:",inline"`
+	Host              string `yaml:"host"`
 }
 
 // Config HTTP Config Object
@@ -37,7 +37,7 @@ func (t *TCP) Config(gConf global.ProbeSettings) error {
 	kind := "tcp"
 	tag := ""
 	name := t.ProbeName
-	t.DefaultOptions.Config(gConf, kind, tag, name, t.Host, t.DoProbe)
+	t.DefaultProbe.Config(gConf, kind, tag, name, t.Host, t.DoProbe)
 
 	log.Debugf("[%s] configuration: %+v, %+v", t.ProbeKind, t, t.Result())
 	return nil

--- a/probe/tcp/tcp_test.go
+++ b/probe/tcp/tcp_test.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tcp
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+	"testing"
+	"time"
+
+	"bou.ke/monkey"
+	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/probe/base"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTCP(t *testing.T) {
+	global.InitEaseProbe("easeprobe", "http://icon")
+	tcp := TCP{
+		DefaultProbe: base.DefaultProbe{ProbeName: "dummy tcp"},
+		Host:         "example.com",
+	}
+
+	tcp.Config(global.ProbeSettings{})
+	assert.Equal(t, "tcp", tcp.ProbeKind)
+
+	monkey.Patch(net.DialTimeout, func(network, address string, timeout time.Duration) (net.Conn, error) {
+		return &net.TCPConn{}, nil
+	})
+	var conn *net.TCPConn
+	monkey.PatchInstanceMethod(reflect.TypeOf(conn), "Close", func(_ *net.TCPConn) error {
+		return nil
+	})
+
+	s, m := tcp.DoProbe()
+	assert.True(t, s)
+	assert.Contains(t, m, "Successfully")
+
+	monkey.Patch(net.DialTimeout, func(network, address string, timeout time.Duration) (net.Conn, error) {
+		return nil, fmt.Errorf("tcp dial error")
+	})
+	s, m = tcp.DoProbe()
+	assert.False(t, s)
+	assert.Contains(t, m, "tcp dial error")
+}

--- a/probe/tls/tls.go
+++ b/probe/tls/tls.go
@@ -36,9 +36,9 @@ import (
 
 // TLS implements a config for TLS
 type TLS struct {
-	base.DefaultOptions `yaml:",inline"`
-	Host                string `yaml:"host"`
-	InsecureSkipVerify  bool   `yaml:"insecure_skip_verify"`
+	base.DefaultProbe  `yaml:",inline"`
+	Host               string `yaml:"host"`
+	InsecureSkipVerify bool   `yaml:"insecure_skip_verify"`
 
 	RootCAPemPath string `yaml:"root_ca_pem_path"`
 	RootCaPem     string `yaml:"root_ca_pem"`
@@ -54,7 +54,7 @@ func (t *TLS) Config(gConf global.ProbeSettings) error {
 	kind := "tls"
 	tag := ""
 	name := t.ProbeName
-	t.DefaultOptions.Config(gConf, kind, tag, name, t.Host, t.DoProbe)
+	t.DefaultProbe.Config(gConf, kind, tag, name, t.Host, t.DoProbe)
 
 	rootCaPem := []byte(t.RootCaPem)
 

--- a/report/common.go
+++ b/report/common.go
@@ -65,7 +65,6 @@ func HTMLHeader(title string) string {
 			color: #ff9;
 			text-decoration: none;
 		  }
-		  
 		  .head a:hover, .head a:active {
 			text-decoration: underline;
 		  }

--- a/report/common_test.go
+++ b/report/common_test.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package report
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDurationStr(t *testing.T) {
+	var expected, result string
+
+	expected = "0s"
+	result = DurationStr(0)
+	assert.Equal(t, expected, result)
+
+	expected = "10ns"
+	result = DurationStr(-10)
+	assert.Equal(t, expected, result)
+
+	expected = "10ms"
+	result = DurationStr(10 * 1000 * 1000)
+	assert.Equal(t, expected, result)
+
+	expected = "10s"
+	result = DurationStr(10 * 1000 * 1000 * 1000)
+	assert.Equal(t, expected, result)
+
+	expected = "10m0s"
+	result = DurationStr(10 * 60 * 1000 * 1000 * 1000)
+	assert.Equal(t, expected, result)
+
+	expected = "10h0m0s"
+	result = DurationStr(10 * 60 * 60 * 1000 * 1000 * 1000)
+	assert.Equal(t, expected, result)
+
+	expected = "10d"
+	result = DurationStr(10 * 24 * 60 * 60 * 1000 * 1000 * 1000)
+	assert.Equal(t, expected, result)
+
+	expected = "10d10h10m10s"
+	result = DurationStr(10*24*60*60*1000*1000*1000 + 10*60*60*1000*1000*1000 + 10*60*1000*1000*1000 + 10*1000*1000*1000)
+	assert.Equal(t, expected, result)
+}
+
+func TestJSONEscape(t *testing.T) {
+	var expected, result string
+
+	expected = `\"\"`
+	result = JSONEscape(`""`)
+	assert.Equal(t, expected, result)
+
+	expected = `hello`
+	result = JSONEscape(`hello`)
+	assert.Equal(t, expected, result)
+
+	expected = `hello\\nworld`
+	result = JSONEscape(`hello\nworld`)
+	assert.Equal(t, expected, result)
+}
+
+func TestAutoRefreshJS(t *testing.T) {
+	result := AutoRefreshJS("1000")
+	assert.Contains(t, result, "setInterval('autoRefresh()', 1000);")
+}
+
+func TestLogSend(t *testing.T) {
+	LogSend("client", "MYSQL Test", "mysql", "Hello World", nil)
+	LogSend("client", "MYSQL Test", "mysql", "", fmt.Errorf("error"))
+}

--- a/report/result_test.go
+++ b/report/result_test.go
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package report
+
+import (
+	"encoding/json"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/probe"
+	"github.com/stretchr/testify/assert"
+)
+
+func newDummyResult(name string) probe.Result {
+
+	var total int64 = 100
+	up := rand.Int63n(total)
+	down := rand.Int63n(total - up)
+
+	return probe.Result{
+		Name:             name,
+		Endpoint:         "http://endpoint:8080",
+		StartTime:        time.Now(),
+		StartTimestamp:   time.Now().Unix(),
+		RoundTripTime:    100 * time.Millisecond,
+		Status:           probe.StatusUp,
+		PreStatus:        probe.StatusDown,
+		Message:          "dummy message",
+		LatestDownTime:   time.Now(),
+		RecoveryDuration: 20 * time.Second,
+		Stat: probe.Stat{
+			Since: time.Now(),
+			Total: total,
+			Status: map[probe.Status]int64{
+				probe.StatusUp:      up,
+				probe.StatusDown:    down,
+				probe.StatusUnknown: total - up - down,
+			},
+			UpTime:   time.Duration(up) * time.Second,
+			DownTime: time.Duration(down) * time.Second,
+		},
+		TimeFormat: time.RFC3339,
+	}
+}
+
+func TestToText(t *testing.T) {
+	global.InitEaseProbe("EaseProbe", "http://icon/url")
+	r := newDummyResult("dummy")
+	str := ToText(r)
+	assert.NotEmpty(t, str)
+	assert.Contains(t, str, r.Title())
+	assert.Contains(t, str, r.Endpoint)
+	assert.Contains(t, str, r.StartTime.Format(r.TimeFormat))
+	assert.Contains(t, str, r.RoundTripTime.String())
+	assert.Contains(t, str, r.Status.Emoji())
+	assert.NotContains(t, str, r.PreStatus.Emoji())
+	assert.Contains(t, str, r.Message)
+	assert.Contains(t, str, r.LatestDownTime.Format(r.TimeFormat))
+	assert.Contains(t, str, global.FooterString())
+}
+
+func checkResult(t *testing.T, r probe.Result, rDTO resultDTO) {
+	assert.Equal(t, r.Title(), rDTO.Name)
+	assert.Equal(t, r.Endpoint, rDTO.Endpoint)
+	assert.Equal(t, r.StartTime.Format(r.TimeFormat), rDTO.StartTime.Format(r.TimeFormat))
+	assert.Equal(t, r.StartTimestamp, rDTO.StartTimestamp)
+	assert.Equal(t, r.RoundTripTime.Round(time.Millisecond), rDTO.RoundTripTime)
+	assert.Equal(t, r.Status, rDTO.Status)
+	assert.Equal(t, r.PreStatus, rDTO.PreStatus)
+	assert.Equal(t, r.Message, rDTO.Message)
+}
+func TestResultToJSON(t *testing.T) {
+	r := newDummyResult("dummy")
+	str := ToJSON(r)
+	var rDTO resultDTO
+	err := json.Unmarshal([]byte(str), &rDTO)
+	assert.Nil(t, err)
+	checkResult(t, r, rDTO)
+	str = ToJSONIndent(r)
+	err = json.Unmarshal([]byte(str), &rDTO)
+	assert.Nil(t, err)
+	checkResult(t, r, rDTO)
+}
+
+func TestResultToHTML(t *testing.T) {
+	global.InitEaseProbe("EaseProbe", "http://icon/url")
+	r := newDummyResult("dummy")
+	str := ToHTML(r)
+	assert.NotEmpty(t, str)
+	assert.Contains(t, str, "EaseProbe")
+	assert.Contains(t, str, r.Title())
+	assert.Contains(t, str, global.GetEaseProbe().IconURL)
+}
+
+func checkMarkdown(t *testing.T, str string, r probe.Result) {
+	assert.NotEmpty(t, str)
+	assert.Contains(t, str, "EaseProbe")
+	assert.Contains(t, str, r.Title())
+	assert.Contains(t, str, r.Status.Emoji())
+	assert.Contains(t, str, r.Message)
+	assert.Contains(t, str, r.StartTime.Format(r.TimeFormat))
+	assert.Contains(t, str, r.RoundTripTime.String())
+	assert.Contains(t, str, r.LatestDownTime.Format(r.TimeFormat))
+	assert.Contains(t, str, global.FooterString())
+}
+
+func TestResultToMarkdown(t *testing.T) {
+	global.InitEaseProbe("EaseProbe", "http://icon/url")
+	r := newDummyResult("dummy")
+	str := ToMarkdown(r)
+	checkMarkdown(t, str, r)
+
+	str = ToMarkdownSocial(r)
+	checkMarkdown(t, str, r)
+}
+
+func TestResultToSlack(t *testing.T) {
+	global.InitEaseProbe("EaseProbe", "http://icon/url")
+	r := newDummyResult("dummy")
+	str := ToSlack(r)
+	assert.NotEmpty(t, str)
+	assert.Contains(t, str, "EaseProbe")
+	assert.Contains(t, str, r.Title())
+	assert.Contains(t, str, r.Status.Emoji())
+	assert.Contains(t, str, r.Message)
+	context := SlackTimeFormation(r.StartTime, " probed at ", r.TimeFormat)
+	assert.Contains(t, str, context)
+	assert.Contains(t, str, r.RoundTripTime.String())
+	assert.Contains(t, str, global.FooterString())
+}
+
+func TestResultToLark(t *testing.T) {
+	global.InitEaseProbe("EaseProbe", "http://icon/url")
+	r := newDummyResult("dummy")
+	str := ToLark(r)
+	assert.NotEmpty(t, str)
+	assert.Contains(t, str, "EaseProbe")
+	assert.Contains(t, str, r.Title())
+	assert.Contains(t, str, r.Status.Emoji())
+	assert.Contains(t, str, r.Message)
+	assert.Contains(t, str, r.RoundTripTime.String())
+	assert.Contains(t, str, global.FooterString())
+
+	assert.Contains(t, str, "green")
+
+	r.Status = probe.StatusDown
+	str = ToLark(r)
+	assert.Contains(t, str, "red")
+
+	r.Status = probe.StatusUnknown
+	str = ToLark(r)
+	assert.Contains(t, str, "gray")
+
+	r.Status = probe.StatusInit
+	str = ToLark(r)
+	assert.Contains(t, str, "blue")
+}

--- a/report/sla_test.go
+++ b/report/sla_test.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package report
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/probe"
+	"github.com/megaease/easeprobe/probe/base"
+	"github.com/stretchr/testify/assert"
+)
+
+type ProbeFuncType func() (bool, string)
+
+type dummyProber struct {
+	base.DefaultOptions
+}
+
+func (d *dummyProber) Config(g global.ProbeSettings) error {
+	d.DefaultOptions.Config(g, d.ProbeKind, d.ProbeTag, d.ProbeName, "endpoint", d.DoProbe)
+	return nil
+}
+func (d *dummyProber) DoProbe() (bool, string) {
+	return rand.Int()%2 == 0, "hello world"
+}
+
+var probes = []probe.Prober{
+	newDummyProber("probe1"),
+	newDummyProber("probe2"),
+	newDummyProber("probe3"),
+	newDummyProber("probe4"),
+}
+
+func newDummyProber(name string) probe.Prober {
+	r := newDummyResult(name)
+	return &dummyProber{
+		DefaultOptions: base.DefaultOptions{
+			ProbeKind:   "dummy",
+			ProbeTag:    "tag",
+			ProbeName:   name,
+			ProbeResult: &r,
+		},
+	}
+}
+
+func TestSLA(t *testing.T) {
+	global.InitEaseProbe("DummyProbe", "icon")
+	for f, fn := range FormatFuncs {
+		sla := fn.StatFn(probes)
+		assert.NotEmpty(t, sla)
+		if f == SMS {
+			assert.Contains(t, sla, "Total "+fmt.Sprintf("%d", len(probes))+" Services")
+			continue
+		}
+		for _, p := range probes {
+			assert.Contains(t, sla, p.Name())
+		}
+	}
+}

--- a/report/sla_test.go
+++ b/report/sla_test.go
@@ -31,11 +31,11 @@ import (
 type ProbeFuncType func() (bool, string)
 
 type dummyProber struct {
-	base.DefaultOptions
+	base.DefaultProbe
 }
 
 func (d *dummyProber) Config(g global.ProbeSettings) error {
-	d.DefaultOptions.Config(g, d.ProbeKind, d.ProbeTag, d.ProbeName, "endpoint", d.DoProbe)
+	d.DefaultProbe.Config(g, d.ProbeKind, d.ProbeTag, d.ProbeName, "endpoint", d.DoProbe)
 	return nil
 }
 func (d *dummyProber) DoProbe() (bool, string) {
@@ -52,7 +52,7 @@ var probes = []probe.Prober{
 func newDummyProber(name string) probe.Prober {
 	r := newDummyResult(name)
 	return &dummyProber{
-		DefaultOptions: base.DefaultOptions{
+		DefaultProbe: base.DefaultProbe{
 			ProbeKind:   "dummy",
 			ProbeTag:    "tag",
 			ProbeName:   name,

--- a/report/types.go
+++ b/report/types.go
@@ -20,6 +20,7 @@ package report
 import (
 	"strings"
 
+	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe"
 )
 
@@ -40,57 +41,34 @@ const (
 	SMS
 )
 
+var fmtToStr = map[Format]string{
+	Unknown:        "unknown",
+	MarkdownSocial: "markdown-social",
+	Markdown:       "markdown",
+	HTML:           "html",
+	JSON:           "json",
+	Text:           "text",
+	Slack:          "slack",
+	Discord:        "discord",
+	Lark:           "lark",
+	SMS:            "sms",
+}
+
+var strToFmt = global.ReverseMap(fmtToStr)
+
 // String covert the Format to string
 func (f Format) String() string {
-	switch f {
-	case MarkdownSocial:
-		return "markdown-social"
-	case Markdown:
-		return "markdown"
-	case HTML:
-		return "html"
-	case JSON:
-		return "json"
-	case Slack:
-		return "slack"
-	case Discord:
-		return "discord"
-	case Lark:
-		return "lark"
-	case SMS:
-		return "sms"
-	default:
-		return "unknown"
-	}
+	return fmtToStr[f]
 }
 
 // Format covert the string to Format
 func (f *Format) Format(s string) {
-	switch strings.ToLower(s) {
-	case "markdown":
-		*f = Markdown
-	case "markdown-social":
-		*f = MarkdownSocial
-	case "html":
-		*f = HTML
-	case "json":
-		*f = JSON
-	case "slack":
-		*f = Slack
-	case "discrod":
-		*f = Discord
-	case "lark":
-		*f = Lark
-	case "sms":
-		*f = SMS
-	default:
-		*f = Unknown
-	}
+	*f = strToFmt[strings.ToLower(s)]
 }
 
 // MarshalYAML is marshal the format
-func (f *Format) MarshalYAML() ([]byte, error) {
-	return []byte(f.String()), nil
+func (f Format) MarshalYAML() (interface{}, error) {
+	return f.String(), nil
 }
 
 // UnmarshalYAML is unmarshal the format

--- a/report/types_test.go
+++ b/report/types_test.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package report
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func testFormat(t *testing.T, except Format, str string) {
+	var result Format
+	result.Format(str)
+	assert.Equal(t, except, result)
+}
+
+func TestFormat(t *testing.T) {
+	testFormat(t, MarkdownSocial, "markdown-social")
+	testFormat(t, Markdown, "markdown")
+	testFormat(t, HTML, "html")
+	testFormat(t, JSON, "json")
+	testFormat(t, Text, "text")
+	testFormat(t, Slack, "slack")
+	testFormat(t, Discord, "discord")
+	testFormat(t, Lark, "lark")
+	testFormat(t, SMS, "sms")
+	testFormat(t, Unknown, "unknown")
+}
+
+func testFormatYAML(t *testing.T, except Format, str string) {
+	var result Format
+	buf, err := yaml.Marshal(except)
+	assert.Nil(t, err)
+	assert.Equal(t, str, string(buf))
+
+	assert.Nil(t, yaml.Unmarshal(buf, &result))
+	assert.Equal(t, except, result)
+}
+
+func TestFormatYAML(t *testing.T) {
+	testFormatYAML(t, MarkdownSocial, "markdown-social\n")
+	testFormatYAML(t, Markdown, "markdown\n")
+	testFormatYAML(t, HTML, "html\n")
+	testFormatYAML(t, JSON, "json\n")
+	testFormatYAML(t, Text, "text\n")
+	testFormatYAML(t, Slack, "slack\n")
+	testFormatYAML(t, Discord, "discord\n")
+	testFormatYAML(t, Lark, "lark\n")
+	testFormatYAML(t, SMS, "sms\n")
+	testFormatYAML(t, Unknown, "unknown\n")
+}


### PR DESCRIPTION
- rename the base probe `DefaultOptions` to `DefaultProbe`
- add all of probers test case
- add the report test case
- fix some bugs.