### PR TITLE
feat: support the syslog notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Ease Probe supports the following notifications:
 > **Note**:
 >
 > The notification is **Edge-Triggered Mode**, only notified while the status is changed.
+> The Windows platform doesn't support syslog
 
 ```YAML
 # Notification Configuration
@@ -165,7 +166,7 @@ notify:
   log:
     - name: log file # local log file
       file: /var/log/easeprobe.log
-    - name: Remote syslog # syslog
+    - name: Remote syslog # syslog (!!! Not For Windows !!!)
       file: syslog # <-- must be "syslog" keyword
       host: 127.0.0.1:514 # remote syslog server - optional
       network: udp #remote syslog network [tcp, udp] - optional
@@ -764,7 +765,7 @@ notify:
     - name: "Local Log"
       file: "/tmp/easeprobe.log"
       dry: true
-    - name: Remote syslog # syslog
+    - name: Remote syslog # syslog (!!! Not For Windows !!!)
       file: syslog # <-- must be "syslog" keyword
       host: 127.0.0.1:514 # remote syslog server - optional
       network: udp #remote syslog network [tcp, udp] - optional

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Ease Probe supports the following notifications:
 - **WeChat Work**. Support Enterprise WeChat Work notification.
 - **DingTalk**. Support the DingTalk notification.
 - **Lark**. Support the Lark(Feishu) notification.
-- **Log File**. Write the notification into a log file
+- **Log**. Write the notification into a log file or syslog.
 - **SMS**. Support SMS notification with multiple SMS service providers - [Twilio](https://www.twilio.com/sms), [Vonage(Nexmo)](https://developer.vonage.com/messaging/sms/overview), [YunPain](https://www.yunpian.com/doc/en/domestic/list.html)
 - **Teams**. Support the [Microsoft Teams](https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using?tabs=cURL#setting-up-a-custom-incoming-webhook) notification.
 
@@ -162,6 +162,13 @@ Ease Probe supports the following notifications:
 ```YAML
 # Notification Configuration
 notify:
+  log:
+    - name: log file # local log file
+      file: /var/log/easeprobe.log
+    - name: Remote syslog # syslog
+      file: syslog # <-- must be "syslog" keyword
+      host: 127.0.0.1:514 # remote syslog server - optional
+      network: udp #remote syslog network [tcp, udp] - optional
   slack:
     - name: "MegaEase#Alert"
       webhook: "https://hooks.slack.com/services/........../....../....../"
@@ -757,6 +764,10 @@ notify:
     - name: "Local Log"
       file: "/tmp/easeprobe.log"
       dry: true
+    - name: Remote syslog # syslog
+      file: syslog # <-- must be "syslog" keyword
+      host: 127.0.0.1:514 # remote syslog server - optional
+      network: udp #remote syslog network [tcp, udp] - optional
   # Notify by sms using yunpian  https://www.yunpian.com/official/document/sms/zh_cn/domestic_single_send
   sms:
     - name: "sms alert service - yunpian"

--- a/notify/log/format.go
+++ b/notify/log/format.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package log
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/megaease/easeprobe/global"
+	log "github.com/sirupsen/logrus"
+)
+
+//SysLogFormatter is log custom format
+type SysLogFormatter struct {
+	Type Type `yaml:"-"`
+}
+
+//Format details
+func (s *SysLogFormatter) Format(entry *log.Entry) ([]byte, error) {
+	timestamp := time.Now().Local().Format(time.RFC3339)
+	host := global.GetEaseProbe().Host
+	app := global.GetEaseProbe().Name
+
+	var msg string
+	if s.Type == SysLog {
+		msg = fmt.Sprintf("%s\n", entry.Message)
+	} else {
+		msg = fmt.Sprintf("%s %s %s %s %s\n", timestamp, host, app, entry.Level.String(), entry.Message)
+
+	}
+	return []byte(msg), nil
+}

--- a/notify/log/format.go
+++ b/notify/log/format.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/megaease/easeprobe/global"
+
 	log "github.com/sirupsen/logrus"
 )
 

--- a/notify/log/format.go
+++ b/notify/log/format.go
@@ -33,16 +33,14 @@ type SysLogFormatter struct {
 
 //Format details
 func (s *SysLogFormatter) Format(entry *log.Entry) ([]byte, error) {
+	if s.Type == SysLog {
+		return []byte(fmt.Sprintf("%s\n", entry.Message)), nil
+	}
+
 	timestamp := time.Now().Local().Format(time.RFC3339)
 	host := global.GetEaseProbe().Host
 	app := global.GetEaseProbe().Name
 
-	var msg string
-	if s.Type == SysLog {
-		msg = fmt.Sprintf("%s\n", entry.Message)
-	} else {
-		msg = fmt.Sprintf("%s %s %s %s %s\n", timestamp, host, app, entry.Level.String(), entry.Message)
-
-	}
+	msg := fmt.Sprintf("%s %s %s %s %s\n", timestamp, host, app, entry.Level.String(), entry.Message)
 	return []byte(msg), nil
 }

--- a/notify/log/log.go
+++ b/notify/log/log.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/notify/base"
+
 	log "github.com/sirupsen/logrus"
 )
 

--- a/notify/log/log.go
+++ b/notify/log/log.go
@@ -84,5 +84,5 @@ func (c *NotifyConfig) Log(title, msg string) error {
 		c.logger.Info(line)
 	}
 
-	return nil
+	return scanner.Err()
 }

--- a/notify/log/log.go
+++ b/notify/log/log.go
@@ -124,7 +124,7 @@ func (c *NotifyConfig) Config(gConf global.NotifySettings) error {
 			return err
 		}
 		c.logger.SetOutput(writer)
-		log.Info("[%s] %s - local syslog configured", c.NotifyKind, c.NotifyName)
+		log.Infof("[%s] %s - local syslog configured!", c.NotifyKind, c.NotifyName)
 	} else { // just log file
 		c.NotifyKind = "log"
 		c.Type = FileLog

--- a/notify/log/log.go
+++ b/notify/log/log.go
@@ -18,62 +18,139 @@
 package log
 
 import (
-	"log"
+	"bufio"
+	"fmt"
+	"log/syslog"
+	"net"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/notify/base"
-	"github.com/megaease/easeprobe/probe"
 	"github.com/megaease/easeprobe/report"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
+)
+
+// Network protocols
+const (
+	TCP = "tcp"
+	UDP = "udp"
+)
+
+// Type is the log type
+type Type int
+
+// Log Type
+const (
+	FileLog = iota
+	SysLog
 )
 
 // NotifyConfig is the configuration of the Notify
 type NotifyConfig struct {
 	base.DefaultNotify `yaml:",inline"`
-	File               string `yaml:"file"`
+
+	File    string `yaml:"file"`
+	Host    string `yaml:"host"`
+	Network string `yaml:"network"`
+	Type    Type   `yaml:"-"`
+	logger  *log.Logger
 }
 
-// Config configures the log files
-func (c *NotifyConfig) Config(global global.NotifySettings) error {
-	c.NotifyKind = "log"
-	c.NotifyFormat = report.Text
-	if c.Dry {
-		logrus.Infof("Notification [%s] - [%s] is running on Dry mode!", c.NotifyKind, c.NotifyName)
-		log.SetOutput(os.Stdout)
-		return nil
+func (c *NotifyConfig) checkNetworkProtocol() error {
+	if len(c.Network) == 0 {
+		return fmt.Errorf("protocol is required")
 	}
-	file, err := os.OpenFile(c.File, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	if len(c.Host) == 0 {
+		return fmt.Errorf("host is required")
+	}
+	if c.Network != TCP && c.Network != UDP {
+		return fmt.Errorf("[%s] invalid protocol: %s", c.NotifyKind, c.Network)
+	}
+	_, port, err := net.SplitHostPort(c.Host)
 	if err != nil {
-		logrus.Errorf("error: %s", err)
-		return err
+		return fmt.Errorf("[%s] invalid host: %s", c.NotifyKind, c.Host)
 	}
-	log.SetOutput(file)
-
-	logrus.Infof("Notification [%s] - [%s] is configured!", c.Kind(), c.NotifyName)
-	logrus.Debugf("Notification [%s] - [%s] configuration: %+v", c.Kind(), c.NotifyName, c)
+	_, err = strconv.Atoi(port)
+	if err != nil {
+		return fmt.Errorf("[%s] invalid port: %s", c.NotifyKind, port)
+	}
 	return nil
 }
 
-// Notify write the message into the file
-func (c *NotifyConfig) Notify(result probe.Result) {
-	if c.Dry {
-		c.DryNotify(result)
-		return
+// Config configures the log files
+func (c *NotifyConfig) Config(gConf global.NotifySettings) error {
+	c.NotifyKind = "log"
+	c.NotifyFormat = report.Log
+	c.NotifySendFunc = c.Log
+
+	c.logger = log.New()
+
+	isSyslog := (strings.TrimSpace(c.File) == "syslog")
+	hasNetwork := false
+	if isSyslog == true {
+		if len(c.Network) == 0 || len(c.Host) == 0 {
+			hasNetwork = false
+		} else {
+			err := c.checkNetworkProtocol()
+			if err != nil {
+				return err
+			}
+			hasNetwork = true
+		}
 	}
-	log.Println(result.DebugJSON())
-	logrus.Infof("Logged the notification for %s (%s)!", result.Name, result.Endpoint)
+
+	// sysylog && network configuration error
+	if isSyslog && hasNetwork == true { // remote syslog
+		c.NotifyKind = "syslog"
+		c.Type = SysLog
+		if err := c.checkNetworkProtocol(); err != nil {
+			return err
+		}
+		writer, err := syslog.Dial(c.Network, c.Host, syslog.LOG_NOTICE, global.GetEaseProbe().Name)
+		if err != nil {
+			log.Errorf("[%s] cannot dial syslog network: %s", c.NotifyKind, err)
+			return err
+		}
+		c.logger.SetOutput(writer)
+		log.Infof("[%s] %s - remote syslog (%s:%s) configured", c.NotifyKind, c.NotifyName, c.Network, c.Host)
+	} else if isSyslog { // only for local syslog
+		c.NotifyKind = "syslog"
+		c.Type = SysLog
+		writer, err := syslog.New(syslog.LOG_NOTICE, global.GetEaseProbe().Name)
+		if err != nil {
+			log.Errorf("[%s] cannot open syslog: %s", c.NotifyKind, err)
+			return err
+		}
+		c.logger.SetOutput(writer)
+		log.Info("[%s] %s - local syslog configured", c.NotifyKind, c.NotifyName)
+	} else { // just log file
+		c.NotifyKind = "log"
+		c.Type = FileLog
+		file, err := os.OpenFile(c.File, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+		if err != nil {
+			log.Errorf("[%s] cannot open file: %s", c.NotifyKind, err)
+			return err
+		}
+		c.logger.SetOutput(file)
+		log.Infof("[%s] %s - local log file(%s) configured", c.NotifyKind, c.NotifyName, c.File)
+	}
+	c.logger.SetFormatter(&SysLogFormatter{
+		Type: c.Type,
+	})
+	c.DefaultNotify.Config(gConf)
+	return nil
 }
 
-// NotifyStat write the stat message into the file
-func (c *NotifyConfig) NotifyStat(probers []probe.Prober) {
-	if c.Dry {
-		c.DryNotifyStat(probers)
-		return
+// Log logs the message
+func (c *NotifyConfig) Log(title, msg string) error {
+	scanner := bufio.NewScanner(strings.NewReader(msg))
+	for scanner.Scan() {
+		line := scanner.Text()
+		log.Debugf("[%s] %s", c.NotifyKind, line)
+		c.logger.Info(line)
 	}
-	logrus.Infoln("LogFile Sending the Statstics...")
-	for _, p := range probers {
-		log.Println(p.Result())
-	}
-	logrus.Infof("Logged the Statstics into %s!", c.File)
+
+	return nil
 }

--- a/notify/log/log.go
+++ b/notify/log/log.go
@@ -19,16 +19,11 @@ package log
 
 import (
 	"bufio"
-	"fmt"
-	"log/syslog"
-	"net"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/notify/base"
-	"github.com/megaease/easeprobe/report"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -58,89 +53,25 @@ type NotifyConfig struct {
 	logger  *log.Logger
 }
 
-func (c *NotifyConfig) checkNetworkProtocol() error {
-	if len(c.Network) == 0 {
-		return fmt.Errorf("protocol is required")
-	}
-	if len(c.Host) == 0 {
-		return fmt.Errorf("host is required")
-	}
-	if c.Network != TCP && c.Network != UDP {
-		return fmt.Errorf("[%s] invalid protocol: %s", c.NotifyKind, c.Network)
-	}
-	_, port, err := net.SplitHostPort(c.Host)
+func (c *NotifyConfig) configLogFile() error {
+	c.NotifyKind = "log"
+	c.Type = FileLog
+	file, err := os.OpenFile(c.File, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
 	if err != nil {
-		return fmt.Errorf("[%s] invalid host: %s", c.NotifyKind, c.Host)
+		log.Errorf("[%s] cannot open file: %s", c.NotifyKind, err)
+		return err
 	}
-	_, err = strconv.Atoi(port)
-	if err != nil {
-		return fmt.Errorf("[%s] invalid port: %s", c.NotifyKind, port)
-	}
+	c.logger.SetOutput(file)
+	log.Infof("[%s] %s - local log file(%s) configured", c.NotifyKind, c.NotifyName, c.File)
 	return nil
 }
 
-// Config configures the log files
+// Config configures the log notification
 func (c *NotifyConfig) Config(gConf global.NotifySettings) error {
-	c.NotifyKind = "log"
-	c.NotifyFormat = report.Log
-	c.NotifySendFunc = c.Log
-
-	c.logger = log.New()
-
-	isSyslog := (strings.TrimSpace(c.File) == "syslog")
-	hasNetwork := false
-	if isSyslog == true {
-		if len(c.Network) == 0 || len(c.Host) == 0 {
-			hasNetwork = false
-		} else {
-			err := c.checkNetworkProtocol()
-			if err != nil {
-				return err
-			}
-			hasNetwork = true
-		}
+	if err := c.ConfigLog(); err != nil {
+		return err
 	}
-
-	// sysylog && network configuration error
-	if isSyslog && hasNetwork == true { // remote syslog
-		c.NotifyKind = "syslog"
-		c.Type = SysLog
-		if err := c.checkNetworkProtocol(); err != nil {
-			return err
-		}
-		writer, err := syslog.Dial(c.Network, c.Host, syslog.LOG_NOTICE, global.GetEaseProbe().Name)
-		if err != nil {
-			log.Errorf("[%s] cannot dial syslog network: %s", c.NotifyKind, err)
-			return err
-		}
-		c.logger.SetOutput(writer)
-		log.Infof("[%s] %s - remote syslog (%s:%s) configured", c.NotifyKind, c.NotifyName, c.Network, c.Host)
-	} else if isSyslog { // only for local syslog
-		c.NotifyKind = "syslog"
-		c.Type = SysLog
-		writer, err := syslog.New(syslog.LOG_NOTICE, global.GetEaseProbe().Name)
-		if err != nil {
-			log.Errorf("[%s] cannot open syslog: %s", c.NotifyKind, err)
-			return err
-		}
-		c.logger.SetOutput(writer)
-		log.Infof("[%s] %s - local syslog configured!", c.NotifyKind, c.NotifyName)
-	} else { // just log file
-		c.NotifyKind = "log"
-		c.Type = FileLog
-		file, err := os.OpenFile(c.File, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
-		if err != nil {
-			log.Errorf("[%s] cannot open file: %s", c.NotifyKind, err)
-			return err
-		}
-		c.logger.SetOutput(file)
-		log.Infof("[%s] %s - local log file(%s) configured", c.NotifyKind, c.NotifyName, c.File)
-	}
-	c.logger.SetFormatter(&SysLogFormatter{
-		Type: c.Type,
-	})
-	c.DefaultNotify.Config(gConf)
-	return nil
+	return c.DefaultNotify.Config(gConf)
 }
 
 // Log logs the message

--- a/notify/log/log_unix.go
+++ b/notify/log/log_unix.go
@@ -1,0 +1,112 @@
+//go:build !windows
+
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package log
+
+import (
+	"fmt"
+	"log/syslog"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/report"
+	log "github.com/sirupsen/logrus"
+)
+
+func (c *NotifyConfig) checkNetworkProtocol() error {
+	if len(c.Network) == 0 {
+		return fmt.Errorf("protocol is required")
+	}
+	if len(c.Host) == 0 {
+		return fmt.Errorf("host is required")
+	}
+	if c.Network != TCP && c.Network != UDP {
+		return fmt.Errorf("[%s] invalid protocol: %s", c.NotifyKind, c.Network)
+	}
+	_, port, err := net.SplitHostPort(c.Host)
+	if err != nil {
+		return fmt.Errorf("[%s] invalid host: %s", c.NotifyKind, c.Host)
+	}
+	_, err = strconv.Atoi(port)
+	if err != nil {
+		return fmt.Errorf("[%s] invalid port: %s", c.NotifyKind, port)
+	}
+	return nil
+}
+
+// ConfigLog configures the log
+// Unix platform support syslog and log file notification
+func (c *NotifyConfig) ConfigLog() error {
+	c.NotifyKind = "log"
+	c.NotifyFormat = report.Log
+	c.NotifySendFunc = c.Log
+
+	c.logger = log.New()
+
+	isSyslog := (strings.TrimSpace(c.File) == "syslog")
+	hasNetwork := false
+	if isSyslog == true {
+		if len(c.Network) == 0 || len(c.Host) == 0 {
+			hasNetwork = false
+		} else {
+			err := c.checkNetworkProtocol()
+			if err != nil {
+				return err
+			}
+			hasNetwork = true
+		}
+	}
+
+	// syslog && network configuration error
+	if isSyslog && hasNetwork == true { // remote syslog
+		c.NotifyKind = "syslog"
+		c.Type = SysLog
+		if err := c.checkNetworkProtocol(); err != nil {
+			return err
+		}
+		writer, err := syslog.Dial(c.Network, c.Host, syslog.LOG_NOTICE, global.GetEaseProbe().Name)
+		if err != nil {
+			log.Errorf("[%s] cannot dial syslog network: %s", c.NotifyKind, err)
+			return err
+		}
+		c.logger.SetOutput(writer)
+		log.Infof("[%s] %s - remote syslog (%s:%s) configured", c.NotifyKind, c.NotifyName, c.Network, c.Host)
+	} else if isSyslog { // only for local syslog
+		c.NotifyKind = "syslog"
+		c.Type = SysLog
+		writer, err := syslog.New(syslog.LOG_NOTICE, global.GetEaseProbe().Name)
+		if err != nil {
+			log.Errorf("[%s] cannot open syslog: %s", c.NotifyKind, err)
+			return err
+		}
+		c.logger.SetOutput(writer)
+		log.Infof("[%s] %s - local syslog configured!", c.NotifyKind, c.NotifyName)
+	} else { // just log file
+		if err := c.configLogFile(); err != nil {
+			return err
+		}
+	}
+	c.logger.SetFormatter(&SysLogFormatter{
+		Type: c.Type,
+	})
+
+	return nil
+}

--- a/notify/log/log_windows.go
+++ b/notify/log/log_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+// +build windows
+
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package log
+
+// ConfigLog is the config for log
+// Windows platform only support log file notification
+func (c *NotifyConfig) ConfigLog() error {
+	return c.configLogFile()
+}

--- a/report/result.go
+++ b/report/result.go
@@ -29,10 +29,10 @@ import (
 
 // ToLog convert the result object to Log format
 func ToLog(r probe.Result) string {
-	tpl := `title="%s"; status="%s"; endpoint="%s"; rtt="%s"; time="%s"; message="%s"`
+	tpl := `title="%s"; name="%s"; status="%s"; endpoint="%s"; rtt="%s"; time="%s"; message="%s"`
 	rtt := r.RoundTripTime.Round(time.Millisecond)
 	return fmt.Sprintf(tpl,
-		r.Title(), r.Status.String(), r.Endpoint, rtt, r.StartTime.Format(r.TimeFormat), r.Message)
+		r.Title(), r.Name, r.Status.String(), r.Endpoint, rtt, r.StartTime.Format(r.TimeFormat), r.Message)
 }
 
 // ToText convert the result object to ToText

--- a/report/result.go
+++ b/report/result.go
@@ -27,6 +27,14 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// ToLog convert the result object to Log format
+func ToLog(r probe.Result) string {
+	tpl := `title="%s"; status="%s"; endpoint="%s"; rtt="%s"; time="%s"; message="%s"`
+	rtt := r.RoundTripTime.Round(time.Millisecond)
+	return fmt.Sprintf(tpl,
+		r.Title(), r.Status.String(), r.Endpoint, rtt, r.StartTime.Format(r.TimeFormat), r.Message)
+}
+
 // ToText convert the result object to ToText
 func ToText(r probe.Result) string {
 	tpl := "[%s] %s\n%s - ⏱ %s\n%s\n%s"
@@ -219,7 +227,7 @@ func ToLark(r probe.Result) string {
 					"elements": [
 						{
 							"tag": "plain_text",
-							"content": %s 
+							"content": %s
 						}
 					]
 				}

--- a/report/sla.go
+++ b/report/sla.go
@@ -126,6 +126,26 @@ func SLAText(probers []probe.Prober) string {
 	return text
 }
 
+// SLALogSection return the Log format string to stat
+func SLALogSection(r *probe.Result) string {
+	text := `name="%s"; endpoint="%s"; up="%s"; down="%s"; sla="%.2f%%"; total="%d(%s)"; latest_time="%s"; latest_status="%s"; message="%s"`
+	return fmt.Sprintf(text, r.Name, r.Endpoint,
+		DurationStr(r.Stat.UpTime), DurationStr(r.Stat.DownTime), r.SLAPercent(),
+		r.Stat.Total, SLAStatusText(r.Stat, Log),
+		time.Now().UTC().Format(r.TimeFormat),
+		r.Status.String(), r.Message)
+}
+
+// SLALog return a full stat report with Log format
+func SLALog(probers []probe.Prober) string {
+	var text string
+	n := len(probers)
+	for i, p := range probers {
+		text += fmt.Sprintf("SLA-Report-%d-%d %s\n", i+1, n, SLALogSection(p.Result()))
+	}
+	return text
+}
+
 // SLAMarkdownSection return the Markdown format string to stat
 func SLAMarkdownSection(r *probe.Result, f Format) string {
 
@@ -323,6 +343,8 @@ func SLAStatusText(s probe.Stat, t Format) string {
 		format = "**%s** : `%d` \t"
 	case HTML:
 		format = "<b>%s</b> : %d \t"
+	case Log:
+		format = "%s:%d "
 	}
 	for k, v := range s.Status {
 		status += fmt.Sprintf(format, k.String(), v)

--- a/report/types.go
+++ b/report/types.go
@@ -35,6 +35,7 @@ const (
 	HTML
 	JSON
 	Text
+	Log
 	Slack
 	Discord
 	Lark
@@ -48,6 +49,7 @@ var fmtToStr = map[Format]string{
 	HTML:           "html",
 	JSON:           "json",
 	Text:           "text",
+	Log:            "log",
 	Slack:          "slack",
 	Discord:        "discord",
 	Lark:           "lark",
@@ -97,6 +99,7 @@ type FormatFuncStruct struct {
 var FormatFuncs = map[Format]FormatFuncStruct{
 	Unknown:        {ToText, SLAText},
 	Text:           {ToText, SLAText},
+	Log:            {ToLog, SLALog},
 	JSON:           {ToJSON, SLAJSON},
 	Markdown:       {ToMarkdown, SLAMarkdown},
 	MarkdownSocial: {ToMarkdownSocial, SLAMarkdownSocial},


### PR DESCRIPTION
## Configuration

Support the local file log and syslog . 

**Note**: syslog doesn't support the Windows platform.

```yaml
notify:
  log:
    - name: log file # local log file
      file: /var/log/easeprobe.log

    - name: Remote syslog # syslog ((!!! Not For Windows !!!))
      file: syslog # <-- must be "syslog" keyword
      host: 127.0.0.1:514 # remote syslog server - optional
      network: udp #remote syslog network [tcp, udp] - optional
```

## Output Examples

### syslog

#### Status

```log
2022-06-07T12:15:50+08:00 MacBookPro EaseProbeBot[17652]: title="TLS Test Failure"; status="down"; name="TLS Test"; endpoint="https://localhost:8443/hello"; rtt="2ms"; time="2022-06-07 04:15:50 UTC"; message="Error (http): Error: Get "https://localhost:8443/hello": dial tcp [::1]:8443: connect: connection refused"
```

#### SLA Report

```syslog
2022-06-07T12:14:35+08:00 MacBookPro EaseProbeBot[17652]: SLA-Report-1-4 name="dummy"; endpoint="http://localhost:12345/dummay"; up="0s"; down="6m15s"; sla="0.00%"; total="25(down:25)"; latest_time="2022-06-07 04:14:35 UTC"; latest_status="down"; message="Error (http): Error: Get "http://localhost:12345/dummay": dial tcp [::1]:12345: connect: connection refused"
2022-06-07T12:14:35+08:00 MacBookPro EaseProbeBot[17652]: SLA-Report-2-4 name="Example"; endpoint="https://example.com/"; up="6m0s"; down="0s"; sla="100.00%"; total="12(up:12)"; latest_time="2022-06-07 04:14:35 UTC"; latest_status="up"; message="Success (http): HTTP Status Code is 200"
2022-06-07T12:14:35+08:00 MacBookPro EaseProbeBot[17652]: SLA-Report-3-4 name="MegaEase Website (China)"; endpoint="https://megaease.cn"; up="4m15s"; down="0s"; sla="100.00%"; total="17(up:17)"; latest_time="2022-06-07 04:14:35 UTC"; latest_status="up"; message="Success (http): HTTP Status Code is 200"
2022-06-07T12:14:35+08:00 MacBookPro EaseProbeBot[17652]: SLA-Report-4-4 name="TLS Test"; endpoint="https://localhost:8443/hello"; up="45s"; down="5m0s"; sla="13.04%"; total="23(down:20 up:3)"; latest_time="2022-06-07 04:14:35 UTC"; latest_status="down"; message="Error (http): Error: Get "https://localhost:8443/hello": dial tcp [::1]:8443: connect: connection refused"
```

### local file

#### Status 
```
2022-06-07T12:12:45+08:00 MacBookPro EaseProbeBot info title="TLS Test Recovery - ( 37m14s Downtime )"; name="TLS Test"; status="up"; endpoint="https://localhost:8443/hello"; rtt="43ms"; time="2022-06-07 04:12:45 UTC"; message="Success (http): HTTP Status Code is 200"
```

#### SLA report
```
2022-06-07T12:00:41+08:00 MacBookPro EaseProbeBot info SLA-Report-1-4 name="dummy"; endpoint="http://localhost:12345/dummay"; up="0s"; down="5m30s"; sla="0.00%"; total="22(down:22)"; latest_time="2022-06-07 04:00:41 UTC"; latest_status="down"; message="Error (http): Error: Get "http://localhost:12345/dummay": dial tcp [::1]:12345: connect: connection refused"
2022-06-07T12:00:41+08:00 MacBookPro EaseProbeBot info SLA-Report-2-4 name="Example"; endpoint="https://example.com/"; up="5m30s"; down="0s"; sla="100.00%"; total="11(up:11)"; latest_time="2022-06-07 04:00:41 UTC"; latest_status="up"; message="Success (http): HTTP Status Code is 200"
2022-06-07T12:00:41+08:00 MacBookPro EaseProbeBot info SLA-Report-3-4 name="MegaEase Website (China)"; endpoint="https://megaease.cn"; up="4m0s"; down="0s"; sla="100.00%"; total="16(up:16)"; latest_time="2022-06-07 04:00:41 UTC"; latest_status="up"; message="Success (http): HTTP Status Code is 200"
2022-06-07T12:00:41+08:00 MacBookPro EaseProbeBot info SLA-Report-4-4 name="TLS Test"; endpoint="https://localhost:8443/hello"; up="45s"; down="4m30s"; sla="14.29%"; total="21(down:18 up:3)"; latest_time="2022-06-07 04:00:41 UTC"; latest_status="down"; message="Error (http): Error: Get "https://localhost:8443/hello": dial tcp [::1]:8443: connect: connection refused"

```