### PR TITLE
feat: support shell notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Ease Probe supports the following notifications:
 - **DingTalk**. Support the DingTalk notification.
 - **Lark**. Support the Lark(Feishu) notification.
 - **Log File**. Write the notification into a log file
+- **Shell**. Run a shell command to notify the result.
 - **SMS**. Support SMS notification with multiple SMS service providers - [Twilio](https://www.twilio.com/sms), [Vonage(Nexmo)](https://developer.vonage.com/messaging/sms/overview), [YunPain](https://www.yunpian.com/doc/en/domestic/list.html)
 - **Teams**. Support the [Microsoft Teams](https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using?tabs=cURL#setting-up-a-custom-incoming-webhook) notification.
 
@@ -204,6 +205,13 @@ notify:
   teams:
       - name: "teams alert service"
         webhook: "https://outlook.office365.com/webhook/a1269812-6d10-44b1-abc5-b84f93580ba0@9e7b80c7-d1eb-4b52-8582-76f921e416d9/IncomingWebhook/3fdd6767bae44ac58e5995547d66a4e4/f332c8d9-3397-4ac5-957b-b8e3fc465a8c" # see https://docs.microsoft.com/en-us/outlook/actionable-messages/send-via-connectors
+  shell: # EaseProbe set the environment variables -
+         # (see the example: resources/scripts/notify/notify.sh)
+    - name: "shell alert service"
+      command: "/bin/bash"
+      args:
+        - "-c"
+        - "/path/to/script.sh"
 ```
 
 Check the  [Notification Configuration](#38-notification-configuration) to see how to configure it.
@@ -765,6 +773,23 @@ notify:
       mobile: 123456789,987654321 # mobile phone number, multi phone number joint by `,`
       sign: "xxxxx" # get this from yunpian
 
+  # EaseProbe set the following environment variables
+  #  - TYPE: "Status" or "SLA"
+  #  - NAME: probe name
+  #  - STATUS: "up" or "down"
+  #  - RTT: round trip time in milliseconds
+  #  - TIMESTAMP: timestamp of probe time
+  #  - MESSAGE: probe message
+  # and offer two formats of string
+  #  - JSON: the JSON format
+  #  - CSV: the CSV format
+  # (see the example: resources/scripts/notify/notify.sh)
+  shell:
+    - name: "shell alert service"
+      command: "/bin/bash"
+      args:
+        - "-c"
+        - "/path/to/script.sh"
 ```
 
 **Note**: All of the notifications can have the following optional configuration.

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Ease Probe supports the following notifications:
 - **DingTalk**. Support the DingTalk notification.
 - **Lark**. Support the Lark(Feishu) notification.
 - **Log File**. Write the notification into a log file
-- **Shell**. Run a shell command to notify the result.
+- **Shell**. Run a shell command to notify the result. (see [example](resources/scripts/notify/notify.sh))
 - **SMS**. Support SMS notification with multiple SMS service providers - [Twilio](https://www.twilio.com/sms), [Vonage(Nexmo)](https://developer.vonage.com/messaging/sms/overview), [YunPain](https://www.yunpian.com/doc/en/domestic/list.html)
 - **Teams**. Support the [Microsoft Teams](https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-using?tabs=cURL#setting-up-a-custom-incoming-webhook) notification.
 
@@ -783,6 +783,7 @@ notify:
   # and offer two formats of string
   #  - JSON: the JSON format
   #  - CSV: the CSV format
+  # The CVS format would be set for STDIN for the shell command.
   # (see the example: resources/scripts/notify/notify.sh)
   shell:
     - name: "shell alert service"
@@ -810,7 +811,7 @@ notify:
 settings:
 
   # The customized name and icon
-  name: "Easeprobe" # the name of the probe: default: "EaseProbe"
+  name: "EaseProbe" # the name of the probe: default: "EaseProbe"
   icon: "https://path/to/icon.png" # the icon of the probe. default: "https://megaease.com/favicon.png"
   # Daemon settings
 

--- a/global/global.go
+++ b/global/global.go
@@ -214,3 +214,12 @@ func MakeDirectory(filename string) string {
 
 	return filepath.Join(dir, file)
 }
+
+// CommandLine will return the whole command line which includes command and all arguments
+func CommandLine(cmd string, args []string) string {
+	result := cmd
+	for _, arg := range args {
+		result += " " + arg
+	}
+	return result
+}

--- a/global/global_test.go
+++ b/global/global_test.go
@@ -317,3 +317,11 @@ func TestMakeDirectoryFail(t *testing.T) {
 	monkey.Unpatch(os.MkdirAll)
 
 }
+
+func TestCommandLine(t *testing.T) {
+	s := CommandLine("echo", []string{"hello", "world"})
+	assert.Equal(t, "echo hello world", s)
+
+	s = CommandLine("kubectl", []string{"get", "pod", "--all-namespaces", "-o", "json"})
+	assert.Equal(t, "kubectl get pod --all-namespaces -o json", s)
+}

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -25,6 +25,7 @@ import (
 	"github.com/megaease/easeprobe/notify/email"
 	"github.com/megaease/easeprobe/notify/lark"
 	"github.com/megaease/easeprobe/notify/log"
+	"github.com/megaease/easeprobe/notify/shell"
 	"github.com/megaease/easeprobe/notify/slack"
 	"github.com/megaease/easeprobe/notify/sms"
 	"github.com/megaease/easeprobe/notify/teams"
@@ -46,6 +47,7 @@ type Config struct {
 	Lark     []lark.NotifyConfig     `yaml:"lark"`
 	Sms      []sms.NotifyConfig      `yaml:"sms"`
 	Teams    []teams.NotifyConfig    `yaml:"teams"`
+	Shell    []shell.NotifyConfig    `yaml:"shell"`
 }
 
 // Notify is the configuration of the Notify

--- a/notify/shell/shell.go
+++ b/notify/shell/shell.go
@@ -66,7 +66,7 @@ func (c *NotifyConfig) RunShell(title, msg string) error {
 	for k, v := range envMap {
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}
-	cmd.Stdin = strings.NewReader(envMap["EASEPROBE_CSV"] + "\n")
+	cmd.Stdin = strings.NewReader(envMap["EASEPROBE_CSV"])
 	cmd.Env = append(os.Environ(), env...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/notify/shell/shell.go
+++ b/notify/shell/shell.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package shell
+
+import (
+	"context"
+	"os/exec"
+
+	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/notify/base"
+	"github.com/megaease/easeprobe/report"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// NotifyConfig is the config for shell notify
+type NotifyConfig struct {
+	base.DefaultNotify `yaml:",inline"`
+
+	Cmd  string   `yaml:"cmd"`
+	Args []string `yaml:"args"`
+}
+
+// Config is the config for shell probe
+func (c *NotifyConfig) Config(gConf global.NotifySettings) error {
+	c.NotifyKind = "shell"
+	c.NotifyFormat = report.Shell
+	c.NotifySendFunc = c.RunShell
+	c.DefaultNotify.Config(gConf)
+
+	return nil
+}
+
+// RunShell is the shell for shell notify
+func (c *NotifyConfig) RunShell(title, msg string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), c.Timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, c.Cmd, c.Args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return err
+	}
+	log.Debugf("[%s / %s] - %s", c.NotifyKind, c.NotifyName, global.CommandLine(c.Cmd, c.Args))
+	log.Debugf("input: \n%s", msg)
+	log.Debugf("output:\n%s", string(output))
+	return nil
+}

--- a/notify/shell/shell.go
+++ b/notify/shell/shell.go
@@ -66,7 +66,7 @@ func (c *NotifyConfig) RunShell(title, msg string) error {
 	for k, v := range envMap {
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}
-	cmd.Stdin = strings.NewReader(envMap["EASEPROBE_CSV"]+"\n")
+	cmd.Stdin = strings.NewReader(envMap["EASEPROBE_CSV"] + "\n")
 	cmd.Env = append(os.Environ(), env...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/probe/common.go
+++ b/probe/common.go
@@ -22,15 +22,6 @@ import (
 	"strings"
 )
 
-// CommandLine will return the whole command line which includes command and all arguments
-func CommandLine(cmd string, args []string) string {
-	result := cmd
-	for _, arg := range args {
-		result += " " + arg
-	}
-	return result
-}
-
 // CheckOutput checks the output text,
 // - if it contains a configured string then return nil
 // - if it does not contain a configured string then return nil

--- a/probe/common_test.go
+++ b/probe/common_test.go
@@ -23,14 +23,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCommandLine(t *testing.T) {
-	s := CommandLine("echo", []string{"hello", "world"})
-	assert.Equal(t, "echo hello world", s)
-
-	s = CommandLine("kubectl", []string{"get", "pod", "--all-namespaces", "-o", "json"})
-	assert.Equal(t, "kubectl get pod --all-namespaces -o json", s)
-}
-
 func TestCheckOutput(t *testing.T) {
 	err := CheckOutput("hello", "good", "easeprobe hello world")
 	assert.Nil(t, err)

--- a/probe/host/host.go
+++ b/probe/host/host.go
@@ -113,7 +113,7 @@ func (s *Server) DoProbe() (bool, string) {
 		return false, err.Error() + " - " + output
 	}
 
-	log.Debugf("[%s / %s] - %s", s.ProbeKind, s.ProbeName, probe.CommandLine(s.Command, s.Args))
+	log.Debugf("[%s / %s] - %s", s.ProbeKind, s.ProbeName, global.CommandLine(s.Command, s.Args))
 	log.Debugf("[%s / %s] - %s", s.ProbeKind, s.ProbeName, probe.CheckEmpty(string(output)))
 
 	info, err := s.ParseHostInfo(string(output))

--- a/probe/shell/shell.go
+++ b/probe/shell/shell.go
@@ -52,7 +52,7 @@ func (s *Shell) Config(gConf global.ProbeSettings) error {
 	tag := ""
 	name := s.ProbeName
 	s.DefaultProbe.Config(gConf, kind, tag, name,
-		probe.CommandLine(s.Command, s.Args), s.DoProbe)
+		global.CommandLine(s.Command, s.Args), s.DoProbe)
 
 	s.metrics = newMetrics(kind, tag)
 
@@ -91,7 +91,7 @@ func (s *Shell) DoProbe() (bool, string) {
 		log.Errorf(message)
 		status = false
 	}
-	log.Debugf("[%s / %s] - %s", s.ProbeKind, s.ProbeName, probe.CommandLine(s.Command, s.Args))
+	log.Debugf("[%s / %s] - %s", s.ProbeKind, s.ProbeName, global.CommandLine(s.Command, s.Args))
 	log.Debugf("[%s / %s] - %s", s.ProbeKind, s.ProbeName, probe.CheckEmpty(string(output)))
 
 	s.ExportMetrics()

--- a/probe/shell/shell.go
+++ b/probe/shell/shell.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe"
@@ -66,12 +65,8 @@ func (s *Shell) DoProbe() (bool, string) {
 	ctx, cancel := context.WithTimeout(context.Background(), s.ProbeTimeout)
 	defer cancel()
 
-	for _, e := range s.Env {
-		v := strings.Split(e, "=")
-		os.Setenv(v[0], v[1])
-	}
-
 	cmd := exec.CommandContext(ctx, s.Command, s.Args...)
+	cmd.Env = append(os.Environ(), s.Env...)
 	output, err := cmd.CombinedOutput()
 
 	status := true

--- a/probe/ssh/ssh.go
+++ b/probe/ssh/ssh.go
@@ -83,7 +83,7 @@ func (s *Server) Config(gConf global.ProbeSettings) error {
 	kind := "ssh"
 	tag := ""
 	name := s.ProbeName
-	endpoint := probe.CommandLine(s.Command, s.Args)
+	endpoint := global.CommandLine(s.Command, s.Args)
 
 	s.metrics = newMetrics(kind, tag)
 
@@ -148,7 +148,7 @@ func (s *Server) DoProbe() (bool, string) {
 		}
 	}
 
-	log.Debugf("[%s / %s] - %s", s.ProbeKind, s.ProbeName, probe.CommandLine(s.Command, s.Args))
+	log.Debugf("[%s / %s] - %s", s.ProbeKind, s.ProbeName, global.CommandLine(s.Command, s.Args))
 	log.Debugf("[%s / %s] - %s", s.ProbeKind, s.ProbeName, probe.CheckEmpty(string(output)))
 
 	s.ExportMetrics()
@@ -246,7 +246,7 @@ func (s *Server) RunSSHCmd() (string, error) {
 	var stdoutBuf, stderrBuf bytes.Buffer
 	session.Stdout = &stdoutBuf
 	session.Stderr = &stderrBuf
-	if err := session.Run(env + probe.CommandLine(s.Command, s.Args)); err != nil {
+	if err := session.Run(env + global.CommandLine(s.Command, s.Args)); err != nil {
 		return stderrBuf.String(), err
 	}
 

--- a/report/result.go
+++ b/report/result.go
@@ -258,20 +258,20 @@ func ToCSV(r probe.Result) string {
 // ToShell convert the result object to shell variables
 func ToShell(r probe.Result) string {
 	// set the notify type variable
-	os.Setenv("TYPE", "Status")
+	os.Setenv("EASEPROBE_TYPE", "Status")
 
 	// set individual variables
-	os.Setenv("TITLE", r.Title())
-	os.Setenv("NAME", r.Name)
-	os.Setenv("ENDPOINT", r.Endpoint)
-	os.Setenv("STATUS", r.Status.String())
-	os.Setenv("TIMESTAMP", fmt.Sprintf("%d", r.StartTimestamp))
-	os.Setenv("RTT", fmt.Sprintf("%d", r.RoundTripTime.Round(time.Millisecond)))
-	os.Setenv("MESSAGE", r.Message)
+	os.Setenv("EASEPROBE_TITLE", r.Title())
+	os.Setenv("EASEPROBE_NAME", r.Name)
+	os.Setenv("EASEPROBE_ENDPOINT", r.Endpoint)
+	os.Setenv("EASEPROBE_STATUS", r.Status.String())
+	os.Setenv("EASEPROBE_TIMESTAMP", fmt.Sprintf("%d", r.StartTimestamp))
+	os.Setenv("EASEPROBE_RTT", fmt.Sprintf("%d", r.RoundTripTime.Round(time.Millisecond)))
+	os.Setenv("EASEPROBE_MESSAGE", r.Message)
 
 	// set JSON and CVS format
-	os.Setenv("JSON", ToJSON(r))
+	os.Setenv("EASEPROBE_JSON", ToJSON(r))
 	csv := ToCSV(r)
-	os.Setenv("CSV", csv)
+	os.Setenv("EASEPROBE_CSV", csv)
 	return csv
 }

--- a/report/result.go
+++ b/report/result.go
@@ -20,7 +20,6 @@ package report
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/megaease/easeprobe/global"
@@ -257,21 +256,28 @@ func ToCSV(r probe.Result) string {
 
 // ToShell convert the result object to shell variables
 func ToShell(r probe.Result) string {
+	env := make(map[string]string)
+
 	// set the notify type variable
-	os.Setenv("EASEPROBE_TYPE", "Status")
+	env["EASEPROBE_TYPE"] = "Status"
 
 	// set individual variables
-	os.Setenv("EASEPROBE_TITLE", r.Title())
-	os.Setenv("EASEPROBE_NAME", r.Name)
-	os.Setenv("EASEPROBE_ENDPOINT", r.Endpoint)
-	os.Setenv("EASEPROBE_STATUS", r.Status.String())
-	os.Setenv("EASEPROBE_TIMESTAMP", fmt.Sprintf("%d", r.StartTimestamp))
-	os.Setenv("EASEPROBE_RTT", fmt.Sprintf("%d", r.RoundTripTime.Round(time.Millisecond)))
-	os.Setenv("EASEPROBE_MESSAGE", r.Message)
+	env["EASEPROBE_TITLE"] = r.Title()
+	env["EASEPROBE_NAME"] = r.Name
+	env["EASEPROBE_ENDPOINT"] = r.Endpoint
+	env["EASEPROBE_STATUS"] = r.Status.String()
+	env["EASEPROBE_TIMESTAMP"] = fmt.Sprintf("%d", r.StartTimestamp)
+	env["EASEPROBE_RTT"] = fmt.Sprintf("%d", r.RoundTripTime.Round(time.Millisecond))
+	env["EASEPROBE_MESSAGE"] = r.Message
 
 	// set JSON and CVS format
-	os.Setenv("EASEPROBE_JSON", ToJSON(r))
-	csv := ToCSV(r)
-	os.Setenv("EASEPROBE_CSV", csv)
-	return csv
+	env["EASEPROBE_JSON"] = ToJSON(r)
+	env["EASEPROBE_CSV"] = ToCSV(r)
+
+	buf, err := json.Marshal(env)
+	if err != nil {
+		log.Errorf("ToShell(): Failed to marshal env to json: %s", err)
+		return ""
+	}
+	return string(buf)
 }

--- a/report/result.go
+++ b/report/result.go
@@ -249,7 +249,7 @@ func ToLark(r probe.Result) string {
 // ToCSV convert the object to CSV
 func ToCSV(r probe.Result) string {
 	head := "Title, Name, Endpoint, Status, PreStatus, RoundTripTime, Time, Timestamp, Message\n"
-	tpl := "%s, %s, %s, %s, %s, %d, %s"
+	tpl := "%s, %s, %s, %s, %s, %d, %s, %d, %s"
 	rtt := r.RoundTripTime.Round(time.Millisecond)
 	return fmt.Sprintf(head+tpl,
 		r.Title(), r.Name, r.Endpoint, r.Status.String(), r.PreStatus.String(), rtt,

--- a/report/result.go
+++ b/report/result.go
@@ -248,10 +248,12 @@ func ToLark(r probe.Result) string {
 
 // ToCSV convert the object to CSV
 func ToCSV(r probe.Result) string {
+	head := "Title, Name, Endpoint, Status, PreStatus, RoundTripTime, Time, Timestamp, Message\n"
 	tpl := "%s, %s, %s, %s, %s, %d, %s"
 	rtt := r.RoundTripTime.Round(time.Millisecond)
-	return fmt.Sprintf(tpl,
-		r.Title(), r.Name, r.Status.String(), r.Endpoint, rtt, r.StartTimestamp, r.Message)
+	return fmt.Sprintf(head + tpl,
+		r.Title(), r.Name,  r.Endpoint, r.Status.String(), r.PreStatus.String(), rtt,
+		r.StartTime.UTC().Format(r.TimeFormat), r.StartTimestamp, r.Message)
 }
 
 // ToShell convert the result object to shell variables

--- a/report/result.go
+++ b/report/result.go
@@ -251,8 +251,8 @@ func ToCSV(r probe.Result) string {
 	head := "Title, Name, Endpoint, Status, PreStatus, RoundTripTime, Time, Timestamp, Message\n"
 	tpl := "%s, %s, %s, %s, %s, %d, %s"
 	rtt := r.RoundTripTime.Round(time.Millisecond)
-	return fmt.Sprintf(head + tpl,
-		r.Title(), r.Name,  r.Endpoint, r.Status.String(), r.PreStatus.String(), rtt,
+	return fmt.Sprintf(head+tpl,
+		r.Title(), r.Name, r.Endpoint, r.Status.String(), r.PreStatus.String(), rtt,
 		r.StartTime.UTC().Format(r.TimeFormat), r.StartTimestamp, r.Message)
 }
 

--- a/report/result_test.go
+++ b/report/result_test.go
@@ -183,13 +183,14 @@ func TestResultToShell(t *testing.T) {
 	assert.Contains(t, str, r.Status.String())
 	assert.Contains(t, str, r.Message)
 
-	assert.Equal(t, "Status", os.Getenv("TYPE"))
-	assert.Equal(t, "dummy", os.Getenv("NAME"))
-	assert.Equal(t, r.Status.String(), os.Getenv("STATUS"))
-	assert.Equal(t, fmt.Sprintf("%d", r.StartTimestamp), os.Getenv("TIMESTAMP"))
-	assert.Equal(t, fmt.Sprintf("%d", r.RoundTripTime.Round(time.Millisecond)), os.Getenv("RTT"))
-	assert.Equal(t, r.Message, os.Getenv("MESSAGE"))
+	assert.Equal(t, "Status", os.Getenv("EASEPROBE_TYPE"))
+	assert.Equal(t, "dummy", os.Getenv("EASEPROBE_NAME"))
+	assert.Equal(t, r.Status.String(), os.Getenv("EASEPROBE_STATUS"))
+	assert.Equal(t, fmt.Sprintf("%d", r.StartTimestamp), os.Getenv("EASEPROBE_TIMESTAMP"))
+	assert.Equal(t, fmt.Sprintf("%d", r.RoundTripTime.Round(time.Millisecond)), os.Getenv("EASEPROBE_RTT"))
+	assert.Equal(t, r.Message, os.Getenv("EASEPROBE_MESSAGE"))
 
-	assert.Equal(t, ToCSV(r), os.Getenv("CSV"))
+	assert.Equal(t, ToCSV(r), os.Getenv("EASEPROBE_CSV"))
+	assert.Equal(t, ToJSON(r), os.Getenv("EASEPROBE_JSON"))
 
 }

--- a/report/result_test.go
+++ b/report/result_test.go
@@ -19,7 +19,9 @@ package report
 
 import (
 	"encoding/json"
+	"fmt"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
@@ -171,4 +173,23 @@ func TestResultToLark(t *testing.T) {
 	r.Status = probe.StatusInit
 	str = ToLark(r)
 	assert.Contains(t, str, "blue")
+}
+
+func TestResultToShell(t *testing.T) {
+	r := newDummyResult("dummy")
+	str := ToShell(r)
+	assert.NotEmpty(t, str)
+	assert.Contains(t, str, r.Title())
+	assert.Contains(t, str, r.Status.String())
+	assert.Contains(t, str, r.Message)
+
+	assert.Equal(t, "Status", os.Getenv("TYPE"))
+	assert.Equal(t, "dummy", os.Getenv("NAME"))
+	assert.Equal(t, r.Status.String(), os.Getenv("STATUS"))
+	assert.Equal(t, fmt.Sprintf("%d", r.StartTimestamp), os.Getenv("TIMESTAMP"))
+	assert.Equal(t, fmt.Sprintf("%d", r.RoundTripTime.Round(time.Millisecond)), os.Getenv("RTT"))
+	assert.Equal(t, r.Message, os.Getenv("MESSAGE"))
+
+	assert.Equal(t, ToCSV(r), os.Getenv("CSV"))
+
 }

--- a/report/result_test.go
+++ b/report/result_test.go
@@ -18,9 +18,11 @@
 package report
 
 import (
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"strings"
 	"testing"
 	"time"
 
@@ -196,4 +198,17 @@ func TestResultToShell(t *testing.T) {
 	assert.Equal(t, ToCSV(r), envMap["EASEPROBE_CSV"])
 	assert.Equal(t, ToJSON(r), envMap["EASEPROBE_JSON"])
 
+	csvReader := csv.NewReader(strings.NewReader(ToCSV(r)))
+	data, err := csvReader.ReadAll()
+	assert.Nil(t, err)
+	assert.Equal(t, len(data), 2)
+	assert.Equal(t, data[1][0], r.Title())
+	assert.Equal(t, data[1][1], r.Name)
+	assert.Equal(t, data[1][2], r.Endpoint)
+	assert.Equal(t, data[1][3], r.Status.String())
+	assert.Equal(t, data[1][4], r.PreStatus.String())
+	assert.Equal(t, data[1][5], fmt.Sprintf("%d", r.RoundTripTime.Round(time.Millisecond)))
+	assert.Equal(t, data[1][6], r.StartTime.UTC().Format(r.TimeFormat))
+	assert.Equal(t, data[1][7], fmt.Sprintf("%d", r.StartTimestamp))
+	assert.Equal(t, data[1][8], r.Message)
 }

--- a/report/result_test.go
+++ b/report/result_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -183,14 +182,18 @@ func TestResultToShell(t *testing.T) {
 	assert.Contains(t, str, r.Status.String())
 	assert.Contains(t, str, r.Message)
 
-	assert.Equal(t, "Status", os.Getenv("EASEPROBE_TYPE"))
-	assert.Equal(t, "dummy", os.Getenv("EASEPROBE_NAME"))
-	assert.Equal(t, r.Status.String(), os.Getenv("EASEPROBE_STATUS"))
-	assert.Equal(t, fmt.Sprintf("%d", r.StartTimestamp), os.Getenv("EASEPROBE_TIMESTAMP"))
-	assert.Equal(t, fmt.Sprintf("%d", r.RoundTripTime.Round(time.Millisecond)), os.Getenv("EASEPROBE_RTT"))
-	assert.Equal(t, r.Message, os.Getenv("EASEPROBE_MESSAGE"))
+	var envMap map[string]string
+	err := json.Unmarshal([]byte(str), &envMap)
+	assert.Nil(t, err)
 
-	assert.Equal(t, ToCSV(r), os.Getenv("EASEPROBE_CSV"))
-	assert.Equal(t, ToJSON(r), os.Getenv("EASEPROBE_JSON"))
+	assert.Equal(t, "Status", envMap["EASEPROBE_TYPE"])
+	assert.Equal(t, "dummy", envMap["EASEPROBE_NAME"])
+	assert.Equal(t, r.Status.String(), envMap["EASEPROBE_STATUS"])
+	assert.Equal(t, fmt.Sprintf("%d", r.StartTimestamp), envMap["EASEPROBE_TIMESTAMP"])
+	assert.Equal(t, fmt.Sprintf("%d", r.RoundTripTime.Round(time.Millisecond)), envMap["EASEPROBE_RTT"])
+	assert.Equal(t, r.Message, envMap["EASEPROBE_MESSAGE"])
+
+	assert.Equal(t, ToCSV(r), envMap["EASEPROBE_CSV"])
+	assert.Equal(t, ToJSON(r), envMap["EASEPROBE_JSON"])
 
 }

--- a/report/sla.go
+++ b/report/sla.go
@@ -407,9 +407,8 @@ func SLASummary(probers []probe.Prober) string {
 
 // SLACSVSection set the CSV format for SLA
 func SLACSVSection(r *probe.Result) string {
-	head := "Name, Endpoint, UpTime, DownTime, SLA, ProbeSummary, LatestProbe, LatestStatus, Message\n"
 	text := "%s, %s, up(%s), down(%s), %.2f%%, %d(%s), %s, %s, %s"
-	return fmt.Sprintf(head+text, r.Name, r.Endpoint,
+	return fmt.Sprintf(text, r.Name, r.Endpoint,
 		DurationStr(r.Stat.UpTime), DurationStr(r.Stat.DownTime), r.SLAPercent(),
 		r.Stat.Total, SLAStatusText(r.Stat, Text),
 		r.StartTime.UTC().Format(r.TimeFormat),
@@ -418,7 +417,7 @@ func SLACSVSection(r *probe.Result) string {
 
 // SLACSV return a full stat report with CSV format
 func SLACSV(probers []probe.Prober) string {
-	csv := ""
+	csv := "Name, Endpoint, UpTime, DownTime, SLA, ProbeSummary, LatestProbe, LatestStatus, Message\n"
 	for _, p := range probers {
 		csv += SLACSVSection(p.Result()) + "\n"
 	}

--- a/report/sla.go
+++ b/report/sla.go
@@ -407,11 +407,12 @@ func SLASummary(probers []probe.Prober) string {
 
 // SLACSVSection set the CSV format for SLA
 func SLACSVSection(r *probe.Result) string {
+	head := "Name, Endpoint, UpTime, DownTime, SLA, ProbeStatistic, LatestProbe, LatestStatus, Message\n"
 	text := "%s, %s, up(%s), down(%s), %.2f%%, %d(%s), %s, %s, %s"
-	return fmt.Sprintf(text, r.Name, r.Endpoint,
+	return fmt.Sprintf(head+text, r.Name, r.Endpoint,
 		DurationStr(r.Stat.UpTime), DurationStr(r.Stat.DownTime), r.SLAPercent(),
 		r.Stat.Total, SLAStatusText(r.Stat, Text),
-		time.Now().UTC().Format(r.TimeFormat),
+		r.StartTime.UTC().Format(r.TimeFormat),
 		r.Status.String(), r.Message)
 }
 

--- a/report/sla.go
+++ b/report/sla.go
@@ -407,7 +407,7 @@ func SLASummary(probers []probe.Prober) string {
 
 // SLACSVSection set the CSV format for SLA
 func SLACSVSection(r *probe.Result) string {
-	head := "Name, Endpoint, UpTime, DownTime, SLA, ProbeStatistic, LatestProbe, LatestStatus, Message\n"
+	head := "Name, Endpoint, UpTime, DownTime, SLA, ProbeSummary, LatestProbe, LatestStatus, Message\n"
 	text := "%s, %s, up(%s), down(%s), %.2f%%, %d(%s), %s, %s, %s"
 	return fmt.Sprintf(head+text, r.Name, r.Endpoint,
 		DurationStr(r.Stat.UpTime), DurationStr(r.Stat.DownTime), r.SLAPercent(),

--- a/report/sla.go
+++ b/report/sla.go
@@ -20,7 +20,6 @@ package report
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -427,9 +426,16 @@ func SLACSV(probers []probe.Prober) string {
 
 // SLAShell set the environment for SLA
 func SLAShell(probers []probe.Prober) string {
-	os.Setenv("EASEPROBE_TYPE", "SLA")
-	os.Setenv("EASEPROBE_JSON", SLAJSON(probers))
-	csv := SLACSV(probers)
-	os.Setenv("EASEPROBE_CSV", csv)
-	return csv
+	env := make(map[string]string)
+
+	env["EASEPROBE_TYPE"] = "SLA"
+	env["EASEPROBE_JSON"] = SLAJSON(probers)
+	env["EASEPROBE_CSV"] = SLACSV(probers)
+
+	buf, err := json.Marshal(env)
+	if err != nil {
+		log.Errorf("SLAShell(): Failed to marshal env to json: %s", err)
+		return ""
+	}
+	return string(buf)
 }

--- a/report/sla.go
+++ b/report/sla.go
@@ -427,9 +427,9 @@ func SLACSV(probers []probe.Prober) string {
 
 // SLAShell set the environment for SLA
 func SLAShell(probers []probe.Prober) string {
-	os.Setenv("TYPE", "SLA")
-	os.Setenv("JSON", SLAJSON(probers))
+	os.Setenv("EASEPROBE_TYPE", "SLA")
+	os.Setenv("EASEPROBE_JSON", SLAJSON(probers))
 	csv := SLACSV(probers)
-	os.Setenv("CSV", csv)
+	os.Setenv("EASEPROBE_CSV", csv)
 	return csv
 }

--- a/report/types.go
+++ b/report/types.go
@@ -39,6 +39,7 @@ const (
 	Discord
 	Lark
 	SMS
+	Shell
 )
 
 var fmtToStr = map[Format]string{
@@ -52,6 +53,7 @@ var fmtToStr = map[Format]string{
 	Discord:        "discord",
 	Lark:           "lark",
 	SMS:            "sms",
+	Shell:          "shell",
 }
 
 var strToFmt = global.ReverseMap(fmtToStr)
@@ -104,4 +106,5 @@ var FormatFuncs = map[Format]FormatFuncStruct{
 	Slack:          {ToSlack, SLASlack},
 	Lark:           {ToLark, SLALark},
 	SMS:            {ToText, SLASummary},
+	Shell:          {ToShell, SLAShell},
 }

--- a/resources/scripts/notify/notify.sh
+++ b/resources/scripts/notify/notify.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+echo "Type: ${TYPE}"
+echo "----------------------------------------------------"
+
+if [[ ${TYPE} == "Status" ]]; then
+    echo "Title: ${TITLE}"
+    echo "Name: ${NAME}"
+    echo "Status: ${STATUS}"
+    echo "RTT: ${RTT}"
+    echo "TIMESTAMP: ${TIMESTAMP}"
+    echo "Message: - ${MESSAGE}"
+    echo "----------------------------------------------------"
+fi
+
+echo "${JSON}"
+echo "----------------------------------------------------"
+echo "${CSV}"
+echo "----------------------------------------------------"

--- a/resources/scripts/notify/notify.sh
+++ b/resources/scripts/notify/notify.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+# This is the example script for the shell notification script.
+# it shows how to retrive the data in environment variables and the StdIn
 echo "----------------------------------------------------"
 echo "<-------- STDIN Begin ------->"
 while read -r line

--- a/resources/scripts/notify/notify.sh
+++ b/resources/scripts/notify/notify.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+echo "----------------------------------------------------"
+echo "<-------- STDIN Begin ------->"
+while read -r line
+do
+  echo "$line"
+done < "${1:-/dev/stdin}"
+echo "<--------- STDIN End -------->"
 
 echo "Type: ${EASEPROBE_TYPE}"
 echo "----------------------------------------------------"

--- a/resources/scripts/notify/notify.sh
+++ b/resources/scripts/notify/notify.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 
-echo "Type: ${TYPE}"
+echo "Type: ${EASEPROBE_TYPE}"
 echo "----------------------------------------------------"
 
-if [[ ${TYPE} == "Status" ]]; then
-    echo "Title: ${TITLE}"
-    echo "Name: ${NAME}"
-    echo "Status: ${STATUS}"
-    echo "RTT: ${RTT}"
-    echo "TIMESTAMP: ${TIMESTAMP}"
-    echo "Message: - ${MESSAGE}"
+if [[ ${EASEPROBE_TYPE} == "Status" ]]; then
+    echo "Title: ${EASEPROBE_TITLE}"
+    echo "Name: ${EASEPROBE_NAME}"
+    echo "Status: ${EASEPROBE_STATUS}"
+    echo "RTT: ${EASEPROBE_RTT}"
+    echo "TIMESTAMP: ${EASEPROBE_TIMESTAMP}"
+    echo "Message: - ${EASEPROBE_MESSAGE}"
     echo "----------------------------------------------------"
 fi
 
-echo "${JSON}"
+echo "${EASEPROBE_JSON}"
 echo "----------------------------------------------------"
-echo "${CSV}"
+echo "${EASEPROBE_CSV}"
 echo "----------------------------------------------------"


### PR DESCRIPTION
EaseProbe set the following environment variables
    - `$EASEPROBE_TYPE`:  two types of message:`Status` or `SLA`

If the TYPE is Status, the following environment variables would be set
    - `$EASEPROBE_NAME`: probe name
    - `$EASEPROBE_STATUS`: "up" or "down"
    - `$EASEPROBE_RTT`: round trip time in milliseconds
    - `$EASEPROBE_TIMESTAMP`: timestamp of probe time
    - `$EASEPROBE_MESSAGE`: probe the message

And EaseProbe offers two formats for both probe status and SLA report
    - `$EASEPROBE_JSON`: the JSON format
    - `$EASEPROBE_CSV`: the CSV format

The CVS format would be set to STDIN for the shell command. 

## Examples

### Probe Status

```
Type: Status
----------------------------------------------------
Title: TLS Test Recovery - ( 19m24s Downtime )
Name: TLS Test
Status: up
RTT: 42000000
TIMESTAMP: 1654588743532
Message: - Success (http): HTTP Status Code is 200
----------------------------------------------------
{"name":"TLS Test Recovery - ( 19m24s Downtime )","endpoint":"https://localhost:8443/hello","time":"2022-06-07T07:59:03.532214Z","timestamp":1654588743532,"rtt":42418000,"status":"up","prestatus":"down","message":"Success (http): HTTP Status Code is 200"}
----------------------------------------------------
Title, Name, Endpoint, Status, PreStatus, RoundTripTime, Time, Timestamp, Message
TLS Test Recovery - ( 1m48s Downtime ), TLS Test, https://localhost:8443/hello, up, down, 43000000, 2022-06-08 05:26:16 UTC, 1654665976106, Success (http): HTTP Status Code is 200
---------------------------------------------------- 
```

### SLA Report
the output of `resources/scripts/notify/notify.sh`

```
Type: SLA
----------------------------------------------------
[{"name":"dummy","endpoint":"http://localhost:12345/dummay","sla":{"up":0,"down":615000000000,"sla":0},"probe_summary":{"total":41,"up":0,"down":41},"latest_probe":{"time":"2022-06-07T07:58:48.530724Z","status":"down","message":"Error (http): Error: Get \"http://localhost:12345/dummay\": dial tcp [::1]:12345: connect: connection refused"}},{"name":"MegaCloud","endpoint":"https://example.com/","sla":{"up":600000000000,"down":0,"sla":100},"probe_summary":{"total":20,"up":20,"down":0},"latest_probe":{"time":"2022-06-07T07:58:48.530868Z","status":"up","message":"Success (http): HTTP Status Code is 200"}},{"name":"MegaEase Website (China)","endpoint":"https://megaease.cn","sla":{"up":450000000000,"down":0,"sla":100},"probe_summary":{"total":30,"up":30,"down":0},"latest_probe":{"time":"2022-06-07T07:58:48.530705Z","status":"up","message":"Success (http): HTTP Status Code is 200"}},{"name":"TLS Test","endpoint":"https://localhost:8443/hello","sla":{"up":135000000000,"down":435000000000,"sla":23.684210526315788},"probe_summary":{"total":38,"up":9,"down":29},"latest_probe":{"time":"2022-06-07T07:58:48.530763Z","status":"down","message":"Error (http): Error: Get \"https://localhost:8443/hello\": dial tcp [::1]:8443: connect: connection refused"}}]
----------------------------------------------------
Name, Endpoint, UpTime, DownTime, SLA, ProbeSummary, LatestProbe, LatestStatus, Message
dummy, http://localhost:12345/dummay, up(0s), down(10m15s), 0.00%, 41(down : 41), 2022-06-07 07:58:48 UTC, down, Error (http): Error: Get "http://localhost:12345/dummay": dial tcp [::1]:12345: connect: connection refused
MegaCloud, https://example.com/, up(10m0s), down(0s), 100.00%, 20(up : 20), 2022-06-07 07:58:48 UTC, up, Success (http): HTTP Status Code is 200
MegaEase Website (China), https://megaease.cn, up(7m30s), down(0s), 100.00%, 30(up : 30), 2022-06-07 07:58:48 UTC, up, Success (http): HTTP Status Code is 200
TLS Test, https://localhost:8443/hello, up(2m15s), down(7m15s), 23.68%, 38(down : 29    up : 9), 2022-06-07 07:58:48 UTC, down, Error (http): Error: Get "https://localhost:8443/hello": dial tcp [::1]:8443: connect: connection refused
---------------------------------------------------- 
```