### PR TITLE
[minor] Copy paste typo

### DIFF
--- a/probe/client/kafka/kafka.go
+++ b/probe/client/kafka/kafka.go
@@ -37,7 +37,7 @@ type Kafka struct {
 	Context      context.Context `yaml:"-"`
 }
 
-// New create a Redis client
+// New create a Kafka client
 func New(opt conf.Options) Kafka {
 	tls, err := opt.TLS.Config()
 	if err != nil {

--- a/probe/client/mongo/mongo.go
+++ b/probe/client/mongo/mongo.go
@@ -39,7 +39,7 @@ type Mongo struct {
 	Context      context.Context        `yaml:"-"`
 }
 
-// New create a Redis client
+// New create a Mongo client
 func New(opt conf.Options) Mongo {
 	var conn string
 	if len(opt.Password) > 0 {

--- a/probe/client/mysql/mysql.go
+++ b/probe/client/mysql/mysql.go
@@ -39,7 +39,7 @@ type MySQL struct {
 	ConnStr      string      `yaml:"conn_str"`
 }
 
-// New create a Redis client
+// New create a Mysql client
 func New(opt conf.Options) MySQL {
 
 	var conn string

--- a/probe/client/zookeeper/zookeeper.go
+++ b/probe/client/zookeeper/zookeeper.go
@@ -20,11 +20,12 @@ package zookeeper
 import (
 	"context"
 	"crypto/tls"
+	"net"
+	"time"
+
 	"github.com/go-zookeeper/zk"
 	"github.com/megaease/easeprobe/probe/client/conf"
 	log "github.com/sirupsen/logrus"
-	"net"
-	"time"
 )
 
 // Kind is the type of driver
@@ -37,7 +38,7 @@ type Zookeeper struct {
 	Context      context.Context `yaml:"conn_str"`
 }
 
-// New create a Redis client
+// New create a Zookeeper client
 func New(opt conf.Options) Zookeeper {
 	tls, err := opt.TLS.Config()
 	if err != nil {

--- a/probe/client/zookeeper/zookeeper_test.go
+++ b/probe/client/zookeeper/zookeeper_test.go
@@ -36,7 +36,7 @@ import (
 func TestZooKeeper(t *testing.T) {
 	conf := conf.Options{
 		Host:       "127.0.0.0:2181",
-		DriverType: conf.Redis,
+		DriverType: conf.Zookeeper,
 		Username:   "username",
 		Password:   "password",
 		TLS: global.TLS{


### PR DESCRIPTION
This PR changes the comment for our various clients from Redis to their appropriate names. It also fixes a bug in a test case where we tested with the Redis driver on the Zookeeper test case.