### PR TITLE
Remove probes with fail config

### DIFF
--- a/cmd/easeprobe/main.go
+++ b/cmd/easeprobe/main.go
@@ -103,9 +103,8 @@ func main() {
 	probers := c.AllProbers()
 	// Notification
 	notifies := c.AllNotifiers()
-
 	// Configure the Probes
-	configProbers(probers)
+	probers = configProbers(probers)
 	// Configure the Notifiers
 	configNotifiers(notifies)
 	// configure channels

--- a/cmd/easeprobe/main.go
+++ b/cmd/easeprobe/main.go
@@ -105,6 +105,10 @@ func main() {
 	notifies := c.AllNotifiers()
 	// Configure the Probes
 	probers = configProbers(probers)
+	if len(probers) == 0 {
+		fmt.Errorf("No probes configured, exiting...")
+		os.Exit(-1)
+	}
 	// Configure the Notifiers
 	configNotifiers(notifies)
 	// configure channels

--- a/cmd/easeprobe/main.go
+++ b/cmd/easeprobe/main.go
@@ -109,7 +109,11 @@ func main() {
 		log.Fatal("No probes configured, exiting...")
 	}
 	// Configure the Notifiers
-	configNotifiers(notifies)
+	notifies = configNotifiers(notifies)
+	if len(notifies) == 0 {
+		log.Fatal("No notifies configured, exiting...")
+	}
+
 	// configure channels
 	configChannels(probers, notifies)
 

--- a/cmd/easeprobe/main.go
+++ b/cmd/easeprobe/main.go
@@ -106,8 +106,7 @@ func main() {
 	// Configure the Probes
 	probers = configProbers(probers)
 	if len(probers) == 0 {
-		fmt.Errorf("No probes configured, exiting...")
-		os.Exit(-1)
+		log.Fatal("No probes configured, exiting...")
 	}
 	// Configure the Notifiers
 	configNotifiers(notifies)

--- a/cmd/easeprobe/notify.go
+++ b/cmd/easeprobe/notify.go
@@ -24,16 +24,21 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func configNotifiers(notifies []notify.Notify) {
+func configNotifiers(notifies []notify.Notify) []notify.Notify {
 	gNotifyConf := global.NotifySettings{
 		TimeFormat: conf.Get().Settings.TimeFormat,
 		Retry:      conf.Get().Settings.Notify.Retry,
 	}
+
+	validNotifies := []notify.Notify{}
 	for _, n := range notifies {
 		if err := n.Config(gNotifyConf); err != nil {
 			log.Errorf("error: %v", err)
 			continue
 		}
+		validNotifies = append(validNotifies, n)
 		log.Infof("Successfully setup the notify channel: %s", n.Kind())
 	}
+
+	return validNotifies
 }

--- a/cmd/easeprobe/probe.go
+++ b/cmd/easeprobe/probe.go
@@ -28,13 +28,15 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func configProbers(probers []probe.Prober) {
+func configProbers(probers []probe.Prober) []probe.Prober {
 	gProbeConf := global.ProbeSettings{
 		TimeFormat: conf.Get().Settings.TimeFormat,
 		Interval:   conf.Get().Settings.Probe.Interval,
 		Timeout:    conf.Get().Settings.Probe.Timeout,
 	}
 	log.Debugf("Global Probe Configuration: %+v", gProbeConf)
+
+	validProbers := []probe.Prober{}
 	for i := 0; i < len(probers); i++ {
 		p := probers[i]
 		if err := p.Config(gProbeConf); err != nil {
@@ -47,7 +49,10 @@ func configProbers(probers []probe.Prober) {
 		if len(p.Result().Message) <= 0 {
 			p.Result().Message = "Good Configuration!"
 		}
+		validProbers = append(validProbers, p)
 	}
+
+	return validProbers
 }
 
 func runProbers(probers []probe.Prober, wg *sync.WaitGroup, done chan bool) {

--- a/probe/client/client.go
+++ b/probe/client/client.go
@@ -18,6 +18,8 @@
 package client
 
 import (
+	"fmt"
+
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe"
 	"github.com/megaease/easeprobe/probe/client/conf"
@@ -45,6 +47,10 @@ func (c *Client) Config(gConf global.ProbeSettings) error {
 	name := c.ProbeName
 	c.DefaultProbe.Config(gConf, kind, tag, name, c.Host, c.DoProbe)
 	c.configClientDriver()
+
+	if c.DriverType == conf.Unknown {
+		return fmt.Errorf("[%s / %s ] unknown driver type", kind, name)
+	}
 
 	log.Debugf("[%s] configuration: %+v, %+v", c.ProbeKind, c, c.Result())
 	return nil


### PR DESCRIPTION
This PR introduces the following changes
* [x] Display a clear error message when an unknown client driver is used
* [x] Remove probers that are not configured properly, from `probers[]`
* [x] Remove notifies that are not configured properly, from `notifies[]`
* [x] Error out and (exit?) when there are no probers or notifies configured
* [x] Update test cases to test for empty probers and notifies
* [x] Update test case for config to use port `65535` instead of the more common `8080` to avoid conflicts with local development environments