### PR TITLE
Memcache client

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Each probe is identified by the method it supports (eg `http`), a unique name (a
 - **Client**. Currently, support the following native client. Support the mTLS. ( refer to: [Native Client Probe Configuration](#37-native-client-probe-configuration) )
   - **MySQL**. Connect to the MySQL server and run the `SHOW STATUS` SQL.
   - **Redis**. Connect to the Redis server and run the `PING` command.
+  - **Memcache**. Connect to a Memcache server and run the `version` command or check based on key/value checks.
   - **MongoDB**. Connect to MongoDB server and just ping server.
   - **Kafka**. Connect to Kafka server and list all topics.
   - **PostgreSQL**. Connect to PostgreSQL server and run `SELECT 1` SQL.
@@ -689,6 +690,14 @@ client:
     username: "admin"
     password: "abc123"
     timeout: 5s
+
+  - name: Memcache Native Client (local)
+    driver: "memcache"
+    host: "localhost:11211"
+    timeout: 5s
+    data:         # Optional
+      key: val    # Check that key exists and its value is val
+      "namespace:key": val # Namespaced keys enclosed in "
 
   - name: Kafka Native Client (local)
     driver: "kafka"

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	bou.ke/monkey v1.0.2
 	github.com/aws/aws-sdk-go v1.44.26
+	github.com/bradfitz/gomemcache v0.0.0-20220106215444-fb4bf637b56d
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/go-co-op/gocron v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bradfitz/gomemcache v0.0.0-20220106215444-fb4bf637b56d h1:pVrfxiGfwelyab6n21ZBkbkmbevaf+WvMIiR7sr97hw=
+github.com/bradfitz/gomemcache v0.0.0-20220106215444-fb4bf637b56d/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=

--- a/probe/client/client.go
+++ b/probe/client/client.go
@@ -24,6 +24,7 @@ import (
 	"github.com/megaease/easeprobe/probe"
 	"github.com/megaease/easeprobe/probe/client/conf"
 	"github.com/megaease/easeprobe/probe/client/kafka"
+	"github.com/megaease/easeprobe/probe/client/memcache"
 	"github.com/megaease/easeprobe/probe/client/mongo"
 	"github.com/megaease/easeprobe/probe/client/mysql"
 	"github.com/megaease/easeprobe/probe/client/postgres"
@@ -62,6 +63,8 @@ func (c *Client) configClientDriver() {
 		c.client = mysql.New(c.Options)
 	case conf.Redis:
 		c.client = redis.New(c.Options)
+	case conf.Memcache:
+		c.client = memcache.New(c.Options)
 	case conf.Mongo:
 		c.client = mongo.New(c.Options)
 	case conf.Kafka:

--- a/probe/client/conf/conf.go
+++ b/probe/client/conf/conf.go
@@ -63,10 +63,11 @@ var DriverMap = map[DriverType]string{
 type Options struct {
 	base.DefaultProbe `yaml:",inline"`
 
-	Host       string     `yaml:"host"`
-	DriverType DriverType `yaml:"driver"`
-	Username   string     `yaml:"username"`
-	Password   string     `yaml:"password"`
+	Host       string            `yaml:"host"`
+	DriverType DriverType        `yaml:"driver"`
+	Username   string            `yaml:"username"`
+	Password   string            `yaml:"password"`
+	Data       map[string]string `yaml:"data"`
 
 	//TLS
 	global.TLS `yaml:",inline"`

--- a/probe/client/conf/conf.go
+++ b/probe/client/conf/conf.go
@@ -40,6 +40,7 @@ const (
 	Unknown DriverType = iota
 	MySQL
 	Redis
+	Memcache
 	Kafka
 	Mongo
 	PostgreSQL
@@ -50,6 +51,7 @@ const (
 var DriverMap = map[DriverType]string{
 	MySQL:      "mysql",
 	Redis:      "redis",
+	Memcache:   "memcache",
 	Kafka:      "kafka",
 	Mongo:      "mongo",
 	PostgreSQL: "postgres",

--- a/probe/client/conf/conf_test.go
+++ b/probe/client/conf/conf_test.go
@@ -28,11 +28,13 @@ import (
 func TestDirverType(t *testing.T) {
 	assert.Equal(t, "mysql", MySQL.String())
 	assert.Equal(t, "redis", Redis.String())
+	assert.Equal(t, "memcache", Memcache.String())
 	assert.Equal(t, "mongo", Mongo.String())
 
 	d := Unknown
 	assert.Equal(t, MySQL, d.DriverType("mysql"))
 	assert.Equal(t, Redis, d.DriverType("redis"))
+	assert.Equal(t, Memcache, d.DriverType("memcache"))
 
 	d = d.DriverType("postgres")
 	buf, err := yaml.Marshal(d)
@@ -55,6 +57,11 @@ func TestDirverType(t *testing.T) {
 	err = json.Unmarshal([]byte("\"mongo\""), &d)
 	assert.Nil(t, err)
 	assert.Equal(t, Mongo, d)
+
+	d = Memcache
+	buf, err = json.Marshal(d)
+	assert.Nil(t, err)
+	assert.Equal(t, "\"memcache\"", string(buf))
 
 	d = 10
 	assert.Equal(t, "unknown", d.String())

--- a/probe/client/memcache/memcache.go
+++ b/probe/client/memcache/memcache.go
@@ -97,12 +97,12 @@ func (m *Memcache) validateKeyValues(items map[string]*MemcacheClient.Item) (boo
 	// iterate the keys and confirm their values match
 	for _, item := range items {
 		log.Debugf("Got key: %s with value: %s", item.Key, string(item.Value))
-		if string(m.Data[item.Key]) != "" {
-			if string(item.Value) != m.Data[item.Key] {
-				return false, fmt.Sprintf("Memcache value for key %s returned %s, expected %s", item.Key, string(item.Value), string(m.Data[item.Key]))
-			}
-		} else {
+		if strings.TrimSpace(m.Data[item.Key]) == "" {
 			log.Debugf("Skipping value check for item %s", item.Key)
+			continue
+		}
+		if string(item.Value) != m.Data[item.Key] {
+			return false, fmt.Sprintf("Memcache value for key %s returned %s, expected %s", item.Key, string(item.Value), string(m.Data[item.Key]))
 		}
 	}
 	return true, "Memcache key values match"

--- a/probe/client/memcache/memcache.go
+++ b/probe/client/memcache/memcache.go
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memcache
+
+import (
+	"context"
+
+	MemcacheClient "github.com/bradfitz/gomemcache/memcache"
+	"github.com/megaease/easeprobe/probe/client/conf"
+)
+
+// Kind is the type of driver
+const Kind string = "Memcache"
+
+// Memcache is the Memcache client
+type Memcache struct {
+	conf.Options `yaml:",inline"`
+	Key          string          `yaml:",inline`
+	Value        string          `yaml:",inline`
+	Context      context.Context `yaml:"-"`
+}
+
+// New create a Memcache client
+func New(opt conf.Options) Memcache {
+
+	return Memcache{
+		Options: opt,
+		Context: context.Background(),
+	}
+}
+
+// Kind return the name of client
+func (r Memcache) Kind() string {
+	return Kind
+}
+
+// Probe do the health check
+func (r Memcache) Probe() (bool, string) {
+
+	mc := MemcacheClient.New(r.Host)
+	//	ctx, cancel := context.WithTimeout(r.Context, r.Timeout())
+	//	defer cancel()
+
+	it, err := mc.Get("sysconfig:event_active")
+	if err != nil {
+		return false, err.Error()
+	}
+
+	if string(it.Value) != "1" {
+		return false, "Memcache value returned do not much"
+	}
+
+	return true, "Memcache key fetched Successfully!"
+
+}

--- a/probe/client/memcache/memcache.go
+++ b/probe/client/memcache/memcache.go
@@ -20,6 +20,7 @@ package memcache
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	MemcacheClient "github.com/bradfitz/gomemcache/memcache"
 	"github.com/megaease/easeprobe/probe/client/conf"

--- a/probe/client/memcache/memcache.go
+++ b/probe/client/memcache/memcache.go
@@ -30,8 +30,8 @@ const Kind string = "Memcache"
 // Memcache is the Memcache client
 type Memcache struct {
 	conf.Options `yaml:",inline"`
-	Key          string          `yaml:",inline`
-	Value        string          `yaml:",inline`
+	Key          string          `yaml:"key"`
+	Value        string          `yaml:"value"`
 	Context      context.Context `yaml:"-"`
 }
 
@@ -50,18 +50,17 @@ func (r Memcache) Kind() string {
 }
 
 // Probe do the health check
-func (r Memcache) Probe() (bool, string) {
+func (m Memcache) Probe() (bool, string) {
 
-	mc := MemcacheClient.New(r.Host)
+	mc := MemcacheClient.New(m.Host)
 	//	ctx, cancel := context.WithTimeout(r.Context, r.Timeout())
 	//	defer cancel()
 
-	it, err := mc.Get("sysconfig:event_active")
+	it, err := mc.Get(m.Key)
 	if err != nil {
 		return false, err.Error()
 	}
-
-	if string(it.Value) != "1" {
+	if string(it.Value) != m.Value {
 		return false, "Memcache value returned do not much"
 	}
 

--- a/probe/client/memcache/memcache.go
+++ b/probe/client/memcache/memcache.go
@@ -37,7 +37,6 @@ type Memcache struct {
 
 // New create a Memcache client
 func New(opt conf.Options) Memcache {
-
 	return Memcache{
 		Options: opt,
 		Context: context.Background(),
@@ -70,12 +69,12 @@ func (m Memcache) Probe() (bool, string) {
 		}
 
 		return m.validateKeyValues(items)
-	} else {
-		log.Debugf("Data empty, Pinging")
-		err := mc.Ping()
-		if err != nil {
-			return false, err.Error()
-		}
+	}
+
+	log.Debugf("Data empty, Pinging")
+	err := mc.Ping()
+	if err != nil {
+		return false, err.Error()
 	}
 
 	return true, "Memcache key fetched Successfully!"
@@ -85,7 +84,7 @@ func (m Memcache) Probe() (bool, string) {
 func (m *Memcache) getDataKeys() []string {
 	keys := make([]string, len(m.Data))
 	i := 0
-	for k, _ := range m.Data {
+	for k := range m.Data {
 		keys[i] = k
 		i++
 	}

--- a/probe/client/memcache/memcache_test.go
+++ b/probe/client/memcache/memcache_test.go
@@ -18,6 +18,7 @@
 package memcache
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/megaease/easeprobe/probe/client/conf"
@@ -38,7 +39,11 @@ func TestMemcache(t *testing.T) {
 	// confirm that we get error
 	s, errmsg := m.Probe()
 	assert.False(t, s)
-	assert.Contains(t, errmsg, "connection refused")
+	if runtime.GOOS == "windows" {
+		assert.Contains(t, errmsg, "connect timeout")
+	} else {
+		assert.Contains(t, errmsg, "connection refused")
+	}
 
 	conf.Data = map[string]string{"sysconfig:event_active": "1"}
 	assert.Equal(t, len(m.getDataKeys()), len(conf.Data))

--- a/probe/client/memcache/memcache_test.go
+++ b/probe/client/memcache/memcache_test.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package memcache
+
+import (
+	"testing"
+
+	"github.com/megaease/easeprobe/probe/client/conf"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMemcache(t *testing.T) {
+	conf := conf.Options{
+		Host:       "localhost:11211",
+		DriverType: conf.Memcache,
+		Data:       map[string]string{"sysconfig:event_active": "1"},
+	}
+
+	m := New(conf)
+	assert.Equal(t, "Memcache", m.Kind())
+
+	s, _ := m.Probe()
+	assert.True(t, s)
+
+	conf.Data = map[string]string{"sysconfig:event_active": "1"}
+	assert.Equal(t, len(m.getDataKeys()), len(conf.Data))
+	assert.True(t, len(m.getDataKeys()) > 0)
+
+}

--- a/probe/client/memcache/memcache_test.go
+++ b/probe/client/memcache/memcache_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestMemcache(t *testing.T) {
 	conf := conf.Options{
-		Host:       "localhost:11211",
+		Host:       "localhost:12345",
 		DriverType: conf.Memcache,
 		Data:       map[string]string{"sysconfig:event_active": "1"},
 	}
@@ -34,8 +34,11 @@ func TestMemcache(t *testing.T) {
 	m := New(conf)
 	assert.Equal(t, "Memcache", m.Kind())
 
-	s, _ := m.Probe()
-	assert.True(t, s)
+	// since memcached is not running
+	// confirm that we get error
+	s, errmsg := m.Probe()
+	assert.False(t, s)
+	assert.Contains(t, errmsg, "connection refused")
 
 	conf.Data = map[string]string{"sysconfig:event_active": "1"}
 	assert.Equal(t, len(m.getDataKeys()), len(conf.Data))


### PR DESCRIPTION
This PR adds support for Memcache client probe
* [x] Add support for `data:` on all client configs
* [x] Check for key(s) when conf `data:` option exists
* [x] Check for value (optional) when conf option exists eg `key: val`
* [x] If no key exists issue a ping command instead

```yaml
client:
  - name: Memcache
    driver: "memcache"
    host: "localhost:11211" # host to query
    data:
      "sysconfig:event_active": "1" # Check the namespaced key `sysconfig:event_active` has value `1` and fail if not
      mykey: "value" # Check the key `mykey` has value `value` and fail if not
      mykeywithnovalcheck:  # Just check the existence of key
```

@haoel i am currently stuck with this. I will need help with the following
1. I cant figure out how to make it populate the Key/Value pairs from the config my m.Key and m.Value are always nil
2. I cant figure out how to utilize ctx with the Memcache Get() and New()