### PR TITLE
feat: support multiple disks usage check for host probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,9 @@ host:
       bastion: aws #  <-- bastion server id ------─┘
       host: ubuntu@172.20.2.202:22
       key: /path/to/server.pem
+      disks: # [optional] Check multiple disks. if not present, only check `/` by default
+        - /
+        - /data
       threshold:
         cpu: 0.80  # cpu usage  80%
         mem: 0.70  # memory usage 70%

--- a/probe/host/host.go
+++ b/probe/host/host.go
@@ -51,6 +51,7 @@ func (t *Threshold) String() string {
 type Server struct {
 	ssh.Server `yaml:",inline"`
 	Threshold  Threshold `yaml:"threshold"`
+	Disks      []string  `yaml:"disks"`
 	metrics    *metrics  `yaml:"-"`
 }
 
@@ -84,8 +85,14 @@ func (s *Server) Config(gConf global.ProbeSettings) error {
 	awk -F= '/^NAME/{print $2}' /etc/os-release | tr -d '\"';
 	free -m | awk 'NR==2{printf "%s %s %.2f\n", $3,$2,$3*100/$2 }';
 	grep -c ^processor /proc/cpuinfo;
-	top -b -n 1 | grep Cpu | awk -F ":" '{print $2}';
-	df -h / 2>/dev/null | awk '$NF=="/"{printf "%d %d %s\n", $3,$2,$5}'`
+	top -b -n 1 | grep Cpu | awk -F ":" '{print $2}';` + "\n"
+
+	if len(s.Disks) == 0 {
+		s.Disks = []string{"/"}
+	}
+	for _, disk := range s.Disks {
+		s.Command += "\t" + `df -h ` + disk + ` 2>/dev/null | awk '$NF=="` + disk + `"{printf "%d %d %s %s\n", $3,$2,$5,$6}';` + "\n"
+	}
 
 	if s.Threshold.CPU == 0 {
 		s.Threshold.CPU = DefaultCPUThreshold
@@ -132,7 +139,11 @@ func (s *Server) CheckThreshold(info Info) (bool, string) {
 	message := ""
 	usage := fmt.Sprintf(" ( CPU: %.2f%% - ", (100 - info.CPU.Idle))
 	usage += fmt.Sprintf("Memory: %.2f%% - ", info.Memory.Usage)
-	usage += fmt.Sprintf("Disk: %.2f%% )", info.Disk.Usage)
+	usage += "Disk: "
+	for _, disk := range info.Disks {
+		usage += fmt.Sprintf(" [%s]: %.2f%% ", disk.Tag, disk.Usage)
+	}
+	usage += ")"
 
 	if s.Threshold.CPU > 0 && s.Threshold.CPU <= (100-info.CPU.Idle)/100 {
 		status = false
@@ -145,12 +156,14 @@ func (s *Server) CheckThreshold(info Info) (bool, string) {
 		}
 		message += "Memory Shortage!"
 	}
-	if s.Threshold.Disk > 0 && s.Threshold.Disk <= info.Disk.Usage/100 {
-		status = false
-		if message != "" {
-			message += " | "
+	for _, disk := range info.Disks {
+		if s.Threshold.Disk > 0 && s.Threshold.Disk <= disk.Usage/100 {
+			status = false
+			if message != "" {
+				message += " | "
+			}
+			message += fmt.Sprintf("Disk Full! - [%s]", disk.Tag)
 		}
-		message += "Disk Full!"
 	}
 
 	if message == "" {
@@ -165,6 +178,7 @@ type Usage struct {
 	Used  int     `yaml:"used"`
 	Total int     `yaml:"total"`
 	Usage float64 `yaml:"usage"`
+	Tag   string  `yaml:"tag"`
 }
 
 // CPU is the cpu usage
@@ -203,12 +217,12 @@ func first(str string) string {
 
 // Info is the host probe information
 type Info struct {
-	HostName string `yaml:"hostname"`
-	OS       string `yaml:"os"`
-	Core     int64  `yaml:"core"`
-	CPU      CPU    `yaml:"cpu"`
-	Memory   Usage  `yaml:"memory"`
-	Disk     Usage  `yaml:"disk"`
+	HostName string  `yaml:"hostname"`
+	OS       string  `yaml:"os"`
+	Core     int64   `yaml:"core"`
+	CPU      CPU     `yaml:"cpu"`
+	Memory   Usage   `yaml:"memory"`
+	Disks    []Usage `yaml:"disks"`
 }
 
 // ParseHostInfo parse the host info
@@ -235,13 +249,21 @@ func (s *Server) ParseHostInfo(str string) (Info, error) {
 		return info, err
 	}
 
-	disk := strings.Split(line[5], " ")
-	if len(disk) < 3 {
-		return info, fmt.Errorf("invalid disk output")
+	for i := 5; i < len(line); i++ {
+		if strings.TrimSpace(line[i]) == "" {
+			break
+		}
+		disk := strings.Split(line[i], " ")
+		if len(disk) < 4 {
+			return info, fmt.Errorf("invalid disk output")
+		}
+		info.Disks = append(info.Disks, Usage{
+			Used:  int(strInt(disk[0])),
+			Total: int(strInt(disk[1])),
+			Usage: strFloat(disk[2][:len(disk[2])-1]),
+			Tag:   disk[3],
+		})
 	}
-	info.Disk.Used = int(strInt(disk[0]))
-	info.Disk.Total = int(strInt(disk[1]))
-	info.Disk.Usage = strFloat(disk[2][:len(disk[2])-1])
 
 	return info, nil
 }
@@ -337,23 +359,30 @@ func (s *Server) ExportMemoryMetrics(info *Info) {
 
 // ExportDiskMetrics export the disk metrics
 func (s *Server) ExportDiskMetrics(info *Info) {
-	s.metrics.Disk.With(prometheus.Labels{
-		"host":  s.Name(),
-		"state": "used",
-	}).Set(float64(info.Disk.Used))
+	for _, disk := range info.Disks {
 
-	s.metrics.Disk.With(prometheus.Labels{
-		"host":  s.Name(),
-		"state": "available",
-	}).Set(float64(info.Disk.Total - info.Disk.Used))
+		s.metrics.Disk.With(prometheus.Labels{
+			"host":  s.Name(),
+			"disk":  disk.Tag,
+			"state": "used",
+		}).Set(float64(disk.Used))
 
-	s.metrics.Disk.With(prometheus.Labels{
-		"host":  s.Name(),
-		"state": "total",
-	}).Set(float64(info.Disk.Total))
+		s.metrics.Disk.With(prometheus.Labels{
+			"host":  s.Name(),
+			"disk":  disk.Tag,
+			"state": "available",
+		}).Set(float64(disk.Total - disk.Used))
 
-	s.metrics.Disk.With(prometheus.Labels{
-		"host":  s.Name(),
-		"state": "usage",
-	}).Set(info.Disk.Usage)
+		s.metrics.Disk.With(prometheus.Labels{
+			"host":  s.Name(),
+			"disk":  disk.Tag,
+			"state": "total",
+		}).Set(float64(disk.Total))
+
+		s.metrics.Disk.With(prometheus.Labels{
+			"host":  s.Name(),
+			"disk":  disk.Tag,
+			"state": "usage",
+		}).Set(disk.Usage)
+	}
 }

--- a/probe/host/host.go
+++ b/probe/host/host.go
@@ -78,8 +78,8 @@ func (s *Server) Config(gConf global.ProbeSettings) error {
 	// 4. retrieve the cpu core:		`grep -c ^processor /proc/cpuinfo;`
 	// 5. retrieve the cpu usage:	`top -b -n 1 | grep Cpu | awk -F ":" '{print $2}'`
 	//    output example: 1.6 us,  0.0 sy,  0.0 ni, 98.4 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st
-	// 6. retrieve the disk usage	`df -h / 2>/dev/null | awk '$NF=="/"{printf "%d %d %s\n", $3,$2,$5}'`
-	//    output: used(GB) total(GB) usage(%), example: 40 970 5%
+	// 6. retrieve the disk usage	`df -h / 2>/dev/null | awk '$NF=="/"{printf "%d %d %s\n", $3,$2,$5,$6}'`
+	//    output: used(GB) total(GB) usage(%) disk, example: 40 970 5% /
 
 	s.Command = `hostname;
 	awk -F= '/^NAME/{print $2}' /etc/os-release | tr -d '\"';
@@ -360,7 +360,6 @@ func (s *Server) ExportMemoryMetrics(info *Info) {
 // ExportDiskMetrics export the disk metrics
 func (s *Server) ExportDiskMetrics(info *Info) {
 	for _, disk := range info.Disks {
-
 		s.metrics.Disk.With(prometheus.Labels{
 			"host":  s.Name(),
 			"disk":  disk.Tag,

--- a/probe/host/host_test.go
+++ b/probe/host/host_test.go
@@ -49,7 +49,8 @@ Ubuntu
 4
   71.6 us,  1.7 sy,  0.2 ni, 26.8 id,  0.3 wa,  0.4 hi,  0.5 si,  0.6 st
 58 97 60% /
-20 80 20% /data`
+20 80 20% /data
+`
 
 func TestHostInfo(t *testing.T) {
 	host := newHost(t)
@@ -111,7 +112,7 @@ func TestHost(t *testing.T) {
 	server.Threshold.Disk = 0.2
 	status, message = server.DoProbe()
 	assert.False(t, status)
-	assert.Contains(t, message, "Disk Full!")
+	assert.Contains(t, message, "Disk Space Low!")
 
 	// invalid disk format
 	hostInfo = `t01

--- a/probe/host/host_test.go
+++ b/probe/host/host_test.go
@@ -48,7 +48,8 @@ Ubuntu
 4407 15718 28.04
 4
   71.6 us,  1.7 sy,  0.2 ni, 26.8 id,  0.3 wa,  0.4 hi,  0.5 si,  0.6 st
-58 97 60%`
+58 97 60% /
+20 80 20% /data`
 
 func TestHostInfo(t *testing.T) {
 	host := newHost(t)
@@ -68,9 +69,14 @@ func TestHostInfo(t *testing.T) {
 	assert.Equal(t, "0.40", fmt.Sprintf("%.2f", info.CPU.Hard))
 	assert.Equal(t, "0.50", fmt.Sprintf("%.2f", info.CPU.Soft))
 	assert.Equal(t, "0.60", fmt.Sprintf("%.2f", info.CPU.Steal))
-	assert.Equal(t, 58, info.Disk.Used)
-	assert.Equal(t, 97, info.Disk.Total)
-	assert.Equal(t, "60.00", fmt.Sprintf("%.2f", info.Disk.Usage))
+	assert.Equal(t, 58, info.Disks[0].Used)
+	assert.Equal(t, 97, info.Disks[0].Total)
+	assert.Equal(t, "60.00", fmt.Sprintf("%.2f", info.Disks[0].Usage))
+	assert.Equal(t, "/", info.Disks[0].Tag)
+	assert.Equal(t, 20, info.Disks[1].Used)
+	assert.Equal(t, 80, info.Disks[1].Total)
+	assert.Equal(t, "20.00", fmt.Sprintf("%.2f", info.Disks[1].Usage))
+	assert.Equal(t, "/data", info.Disks[1].Tag)
 }
 
 func TestHost(t *testing.T) {

--- a/probe/host/metrics.go
+++ b/probe/host/metrics.go
@@ -39,6 +39,6 @@ func newMetrics(subsystem, name string) *metrics {
 		Memory: metric.NewGauge(namespace, subsystem, name, "memory",
 			"Memory Usage", []string{"host", "state"}),
 		Disk: metric.NewGauge(namespace, subsystem, name, "disk",
-			"Disk Usage", []string{"host", "state"}),
+			"Disk Usage", []string{"host", "disk", "state"}),
 	}
 }


### PR DESCRIPTION
the original host probe only supports root disk usage check.

the PR allows user to configure multiple disks. if not configure the "disks", the default behavior just check the root fs.

```yaml
host:
  servers:
    - name: server
      host: user@1.1.1.1
      ....
      disks:
        - /
        - /data
 ```