### PR TITLE
Using DurationStr() format Discord Uptime and DownTime

### DIFF
--- a/notify/discord/discord.go
+++ b/notify/discord/discord.go
@@ -215,7 +215,7 @@ func (c *NotifyConfig) NewField(result probe.Result, inline bool) Fields {
 		"\n>\t`%s ` \n\n"
 
 	desc := fmt.Sprintf(message, result.Endpoint,
-		result.Stat.UpTime.Round(time.Second), result.Stat.DownTime.Round(time.Second), result.SLAPercent(),
+		report.DurationStr(result.Stat.UpTime), report.DurationStr(result.Stat.DownTime), result.SLAPercent(),
 		result.Stat.Total, report.SLAStatusText(result.Stat, report.Markdown),
 		result.StartTime.UTC().Format(result.TimeFormat), result.Status.Emoji()+" "+result.Status.String(),
 		result.Message)


### PR DESCRIPTION
Currently, the SLA report in Discord reports the Uptime and Downtime in the following format:

Up: `785h39m0s`   <- 785 hours is too large

It should be: 

Up:  `32d17h39m0s`  <- 32 days and 17 hours would be better.

The second format is used by all notifications.  

