### PR TITLE
feat: Add HTTP Probe trace time metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ EaseProbe is a simple, standalone, and lightWeight tool that can do health/statu
     - [1.3 Report](#13-report)
     - [1.4 Channel](#14-channel)
     - [1.5 Administration](#15-administration)
-    - [1.6 Prometheus Metrics](#16-prometheus-metrics)
+    - [1.6 Prometheus Metrics Exporter](#16-prometheus-metrics-exporter)
   - [2. Getting Started](#2-getting-started)
     - [2.1 Build](#21-build)
     - [2.2 Configure](#22-configure)
@@ -375,15 +375,49 @@ There are some administration configuration options:
 
   EaseProbe accepts the `HUP` signal to rotate the log.
 
-### 1.6 Prometheus Metrics
+### 1.6 Prometheus Metrics Exporter
 
-EaseProbe supports Prometheus metrics. The Prometheus endpoint is `http://localhost:8181/metrics` by default.
+EaseProbe supports Prometheus metrics exporter. The Prometheus endpoint is `http://localhost:8181/metrics` by default.
+
+Currently, All of the Probers support the following metrics:
+
+  - `total`: the total number of probes
+  - `duration`: Probe duration in milliseconds
+  - `status`: Probe status
+  - `SLA`: Probe SLA percentage
+
+And for the different Probers, the following metrics are available:
+
+- HTTP Probe
+  - `status_code`: HTTP status code
+  - `content_len`: HTTP content length
+  - `dns_duration`: DNS duration in milliseconds
+  - `connect_duration`: TCP connection duration in milliseconds
+  - `tls_duration`: TLS handshake duration in milliseconds
+  - `send_duration`: HTTP send duration in milliseconds
+  - `wait_duration`: HTTP wait duration in milliseconds
+  - `transfer_duration`: HTTP transfer duration in milliseconds
+  - `total_duration`: HTTP total duration in milliseconds
+
+- TLS Probe
+  - `earliest_cert_expiry`: last TLS chain expiry in timestamp seconds
+  - `last_chain_expiry_timestamp_seconds`: earliest TLS cert expiry in Unix time
+
+- Shell & SSH Probe
+  - `exit_code`: exit code of the command
+  - `output_len`: length of the output
+
+- Host Probe
+  - `cpu`: CPU usage in percentage
+  - `memory`: memory usage in percentage
+  - `disk`: disk usage in percentage
+
 
 The following snapshot is the Grafana panel for host CPU metrics
 
 ![](./docs/grafana.demo.png)
 
-Refer to the [Global Setting Configuration](#38-global-setting-configuration) for further details on how to configure the HTTP server.
+Refer to the [Global Setting Configuration](#39-global-setting-configuration) for further details on how to configure the HTTP server.
 
 ## 2. Getting Started
 

--- a/global/global.go
+++ b/global/global.go
@@ -37,7 +37,7 @@ const (
 	// DefaultProg is the program name
 	DefaultProg = "EaseProbe"
 	// Ver is the program version
-	Ver = "v1.6.0"
+	Ver = "v1.7.0"
 
 	//OrgProg combine organization and program
 	OrgProg = Org + " " + DefaultProg

--- a/metric/prometheus.go
+++ b/metric/prometheus.go
@@ -40,8 +40,8 @@ var (
 )
 
 var (
-	validMetric = regexp.MustCompile(`[a-zA-Z_:][a-zA-Z0-9_:]*`)
-	validLabel  = regexp.MustCompile(`[a-zA-Z_][a-zA-Z0-9_]*`)
+	validMetric = regexp.MustCompile(`^[a-zA-Z_:][a-zA-Z0-9_:]*$`)
+	validLabel  = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 )
 
 // Counter get the counter metric by key
@@ -112,13 +112,11 @@ func NewGauge(namespace, subsystem, name, metric string,
 func getAndValid(namespace, subsystem, name, metric string, labels []string) (string, error) {
 	metricName := GetName(namespace, subsystem, name, metric)
 	if ValidMetricName(metricName) == false {
-
 		return "", fmt.Errorf("Invalid metric name: %s", metricName)
 	}
 
 	for _, l := range labels {
 		if ValidLabelName(l) == false {
-
 			return "", fmt.Errorf("Invalid label name: %s", l)
 		}
 	}

--- a/probe/http/metrics.go
+++ b/probe/http/metrics.go
@@ -25,8 +25,15 @@ import (
 
 // metrics is the metrics for http probe
 type metrics struct {
-	StatusCode *prometheus.CounterVec
-	ContentLen *prometheus.GaugeVec
+	StatusCode       *prometheus.CounterVec
+	ContentLen       *prometheus.GaugeVec
+	DNSDuration      *prometheus.GaugeVec
+	ConnectDuration  *prometheus.GaugeVec
+	TLSDuration      *prometheus.GaugeVec
+	SendDuration     *prometheus.GaugeVec
+	WaitDuration     *prometheus.GaugeVec
+	TransferDuration *prometheus.GaugeVec
+	TotalDuration    *prometheus.GaugeVec
 }
 
 // newMetrics create the HTTP metrics
@@ -37,5 +44,19 @@ func newMetrics(subsystem, name string) *metrics {
 			"HTTP Status Code", []string{"name", "status"}),
 		ContentLen: metric.NewGauge(namespace, subsystem, name, "content_len",
 			"HTTP Content Length", []string{"name", "status"}),
+		DNSDuration: metric.NewGauge(namespace, subsystem, name, "dns_duration",
+			"DNS Duration", []string{"name", "status"}),
+		ConnectDuration: metric.NewGauge(namespace, subsystem, name, "connect_duration",
+			"Connect Duration", []string{"name", "status"}),
+		TLSDuration: metric.NewGauge(namespace, subsystem, name, "tls_duration",
+			"TLS Duration", []string{"name", "status"}),
+		SendDuration: metric.NewGauge(namespace, subsystem, name, "send_duration",
+			"Send Duration", []string{"name", "status"}),
+		WaitDuration: metric.NewGauge(namespace, subsystem, name, "wait_duration",
+			"Wait Duration", []string{"name", "status"}),
+		TransferDuration: metric.NewGauge(namespace, subsystem, name, "transfer_duration",
+			"Transfer Duration", []string{"name", "status"}),
+		TotalDuration: metric.NewGauge(namespace, subsystem, name, "total_duration",
+			"Total Duration", []string{"name", "status"}),
 	}
 }

--- a/probe/http/metrics.go
+++ b/probe/http/metrics.go
@@ -47,7 +47,7 @@ func newMetrics(subsystem, name string) *metrics {
 		DNSDuration: metric.NewGauge(namespace, subsystem, name, "dns_duration",
 			"DNS Duration", []string{"name", "status"}),
 		ConnectDuration: metric.NewGauge(namespace, subsystem, name, "connect_duration",
-			"Connect Duration", []string{"name", "status"}),
+			"TCP Connection Duration", []string{"name", "status"}),
 		TLSDuration: metric.NewGauge(namespace, subsystem, name, "tls_duration",
 			"TLS Duration", []string{"name", "status"}),
 		SendDuration: metric.NewGauge(namespace, subsystem, name, "send_duration",

--- a/probe/http/trace.go
+++ b/probe/http/trace.go
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package http
+
+import (
+	"crypto/tls"
+	"net/http/httptrace"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// TraceStats is the stats for a http request
+type TraceStats struct {
+	kind string
+	tag  string
+	name string
+
+	connStartAt     time.Time
+	connTook        time.Duration
+	dnsStartAt      time.Time
+	dnsTook         time.Duration
+	sendStartAt     time.Time
+	sendTook        time.Duration
+	tlsStartAt      time.Time
+	tlsTook         time.Duration
+	totalStartAt    time.Time
+	totalTook       time.Duration
+	transferStartAt time.Time
+	transferTook    time.Duration
+	waitStartAt     time.Time
+	waitTook        time.Duration
+
+	clientTrace *httptrace.ClientTrace
+}
+
+func (s *TraceStats) getConn(hostPort string) {
+	s.totalStartAt = time.Now()
+}
+
+func (s *TraceStats) dnsStart(info httptrace.DNSStartInfo) {
+	s.dnsStartAt = time.Now()
+}
+
+func (s *TraceStats) dnsDone(info httptrace.DNSDoneInfo) {
+	s.dnsTook = time.Since(s.dnsStartAt)
+	if info.Err != nil {
+		return
+	}
+	log.Debugf("[%s %s %s] - DNS resolve time %.3fms", s.kind, s.tag, s.name, toMS(s.dnsTook))
+	for _, addr := range info.Addrs {
+		log.Debugf("[%s %s %s]   %s\n", s.kind, s.tag, s.name, &addr.IP)
+	}
+}
+
+func (s *TraceStats) connectStart(network, addr string) {
+	s.connStartAt = time.Now()
+}
+
+func (s *TraceStats) connectDone(network, addr string, err error) {
+	s.connTook = time.Since(s.connStartAt)
+	if err != nil {
+		return
+	}
+	log.Debugf("[%s %s %s] - %s connection created to %s. time: %.3fms\n",
+		s.kind, s.tag, s.name, network, addr, toMS(s.connTook))
+}
+
+func (s *TraceStats) tlsStart() {
+	s.tlsStartAt = time.Now()
+}
+
+func (s *TraceStats) tlsDone(cs tls.ConnectionState, err error) {
+	s.tlsTook = time.Since(s.tlsStartAt)
+	if err != nil {
+		return
+	}
+	log.Debugf("[%s %s %s] - tls negotiated to %q, time: %.3fms",
+		s.kind, s.tag, s.name, cs.ServerName, toMS(s.tlsTook))
+}
+
+func (s TraceStats) gotConn(info httptrace.GotConnInfo) {
+	log.Debugf("[%s %s %s] - connection established. reused: %t idle: %t idle time: %dms\n",
+		s.kind, s.tag, s.name, info.Reused, info.WasIdle, info.IdleTime.Milliseconds())
+}
+
+func (s *TraceStats) wroteHeaderField(key string, value []string) {
+	s.sendStartAt = time.Now()
+}
+
+func (s *TraceStats) wroteHeaders() {
+	s.sendTook = time.Since(s.sendStartAt)
+	log.Debugf("[%s %s %s] - headers written, time: %.3fms",
+		s.kind, s.tag, s.name, toMS(s.sendTook))
+}
+
+func (s *TraceStats) wroteRequest(info httptrace.WroteRequestInfo) {
+	s.waitStartAt = time.Now()
+	if info.Err != nil {
+		return
+	}
+}
+
+func (s *TraceStats) gotFirstResponseByte() {
+	s.waitTook = time.Since(s.waitStartAt)
+	s.transferStartAt = time.Now()
+	log.Debugf("[%s %s %s] - got first response byte, time: %.3fms",
+		s.kind, s.tag, s.name, toMS(s.waitTook))
+}
+
+func (s *TraceStats) putIdleConn(err error) {
+	s.totalTook = time.Since(s.totalStartAt)
+	s.transferTook = time.Since(s.transferStartAt)
+	if err != nil {
+		return
+	}
+	log.Debugf("[%s %s %s] - put conn idle, transfer: %.3f, total: %.3fms",
+		s.kind, s.tag, s.name, toMS(s.transferTook), toMS(s.totalTook))
+}
+
+func toMS(t time.Duration) float64 {
+	return float64(t.Nanoseconds()) / 1000000.0
+}
+
+// NewTraceStats returns a new traceSTats.
+func NewTraceStats(kind, tag, name string) *TraceStats {
+	s := &TraceStats{
+		kind: kind,
+		name: name,
+		tag:  tag,
+	}
+
+	s.clientTrace = &httptrace.ClientTrace{
+		GetConn:              s.getConn,
+		DNSStart:             s.dnsStart,
+		DNSDone:              s.dnsDone,
+		ConnectStart:         s.connectStart,
+		ConnectDone:          s.connectDone,
+		TLSHandshakeStart:    s.tlsStart,
+		TLSHandshakeDone:     s.tlsDone,
+		GotConn:              s.gotConn,
+		WroteHeaderField:     s.wroteHeaderField,
+		WroteHeaders:         s.wroteHeaders,
+		WroteRequest:         s.wroteRequest,
+		GotFirstResponseByte: s.gotFirstResponseByte,
+		PutIdleConn:          s.putIdleConn,
+	}
+	return s
+}

--- a/probe/http/trace_test.go
+++ b/probe/http/trace_test.go
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package http
+
+import (
+	"crypto/tls"
+	"errors"
+	"net"
+	"net/http/httptrace"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func testTimeStart(t *testing.T, start *time.Time, fn func()) {
+	var newTime time.Time
+	assert.Equal(t, newTime, *start)
+	fn()
+	assert.Less(t, time.Since(*start), time.Minute)
+}
+
+func testTimeDone(t *testing.T, took *time.Duration, fns ...func()) {
+	assert.Equal(t, time.Duration(0), *took)
+	for _, fn := range fns {
+		fn()
+		assert.Less(t, *took, time.Minute)
+	}
+}
+
+func TestTraceStart(t *testing.T) {
+	// Create a new trace
+	s := NewTraceStats("http", "tag", "test")
+	assert.Equal(t, "http", s.kind)
+	assert.Equal(t, "test", s.name)
+	assert.Equal(t, "tag", s.tag)
+
+	testTimeStart(t, &s.totalStartAt, func() { s.getConn("8080") })
+	testTimeStart(t, &s.dnsStartAt, func() { s.dnsStart(httptrace.DNSStartInfo{}) })
+	testTimeStart(t, &s.connStartAt, func() { s.connectStart("tcp", "8080") })
+	testTimeStart(t, &s.sendStartAt, func() { s.wroteHeaderField("key", []string{"value"}) })
+	testTimeStart(t, &s.tlsStartAt, func() { s.tlsStart() })
+	testTimeStart(t, &s.transferStartAt, func() { s.gotFirstResponseByte() })
+	testTimeStart(t, &s.waitStartAt, func() { s.wroteRequest(httptrace.WroteRequestInfo{}) })
+}
+
+func TestTraceDone(t *testing.T) {
+	s := NewTraceStats("http", "tag", "test")
+
+	s.connStartAt = time.Now()
+	s.dnsStartAt = time.Now()
+	s.sendStartAt = time.Now()
+	s.tlsStartAt = time.Now()
+	s.transferStartAt = time.Now()
+	s.waitStartAt = time.Now()
+	s.totalStartAt = time.Now()
+
+	// Test DNS
+	testTimeDone(t, &s.dnsTook,
+		func() {
+			s.dnsDone(httptrace.DNSDoneInfo{
+				Addrs: []net.IPAddr{
+					{IP: net.IPv4(1, 2, 3, 4)},
+				}})
+		},
+		func() {
+			s.dnsDone(httptrace.DNSDoneInfo{Err: &net.DNSError{}})
+		},
+	)
+
+	// Test connection
+	testTimeDone(t, &s.connTook,
+		func() {
+			s.connectDone("tcp", "8080", nil)
+		},
+		func() {
+			s.connectDone("tcp", "8080", &net.OpError{})
+		},
+	)
+
+	// Test TLS
+	testTimeDone(t, &s.tlsTook,
+		func() {
+			s.tlsDone(tls.ConnectionState{}, nil)
+		},
+		func() {
+			s.tlsDone(tls.ConnectionState{}, errors.New("test error"))
+		},
+	)
+
+	// Test send
+	testTimeDone(t, &s.sendTook,
+		func() {
+			s.wroteHeaders()
+		},
+	)
+
+	// Test Wait
+	testTimeDone(t, &s.waitTook,
+		func() {
+			s.wroteRequest(httptrace.WroteRequestInfo{})
+		},
+		func() {
+			s.wroteRequest(httptrace.WroteRequestInfo{Err: errors.New("test error")})
+		},
+	)
+
+	// Test transfer
+	testTimeDone(t, &s.transferTook,
+		func() {
+			s.putIdleConn(nil)
+		},
+		func() {
+			s.putIdleConn(errors.New("test error"))
+		},
+	)
+
+	took := s.connTook
+	s.gotConn(httptrace.GotConnInfo{})
+	assert.Equal(t, took, s.connTook)
+
+}

--- a/probe/tls/metrics.go
+++ b/probe/tls/metrics.go
@@ -39,7 +39,7 @@ func newMetrics(subsystem, name string) *metrics {
 		EarliestCertExpiry: metric.NewGauge(namespace, subsystem, name, "earliest_cert_expiry",
 			"last TLS chain expiry in timestamp seconds", []string{}),
 		LastChainExpiryTimestampSeconds: metric.NewGauge(namespace, subsystem, name, "last_chain_expiry_timestamp_seconds",
-			"earliest TLS cert expiry in unixtime", []string{}),
+			"earliest TLS cert expiry in unix time", []string{}),
 	}
 }
 


### PR DESCRIPTION
the following tracing metrics have been added:
- **dns**: get the ip address, from `dnsStartAt()` to  `dnsDone()`
- **conn**: tcp connection,  from `connectStart()` to `connectDone()`
- **tls**: tls connection, from `tlsStart()` to `tlsDone()`
- **send**: send the http header, from `wroteHeaderField()` to `wroteHeaders()`
-  **wait**: send the http request, from `wroteRequest()` to `gotFirstResponseByte()`
- **transfer** : wait all of data received, from `gotFirstResponseByte()` to `putIdleConn()` 
- **total**: from the beginning to the end. `getConn()` to `putIdleConn()`

```
total >= DNS + conn + tls + send + wait +transfer 
```

it can be seen in Prometheus and Grafana, the following snapshot is an example.

<img width="233" alt="image" src="https://user-images.githubusercontent.com/1014558/176139079-35071f53-e2bc-4d47-a2b9-7db2ff081466.png">

open the debug log, you will see the following debug information

```log
DEBU[2022-06-28T20:26:33+08:00] [http TRACE MegaEase] - total - start get connection: 1656419193697500000 
DEBU[2022-06-28T20:26:33+08:00] [http TRACE MegaEase] - dns - start resolve megaease.com: 1656419193697806 
DEBU[2022-06-28T20:26:33+08:00] [http TRACE MegaEase] - dns - resolve ip [{172.67.222.231 } {104.21.46.25 } {2606:4700:3033::6815:2e19 } {2606:4700:3033::ac43:dee7 }], time 67.725ms 
DEBU[2022-06-28T20:26:33+08:00] [http TRACE MegaEase] - conn - start tcp connect to 172.67.222.231:443: 1656419193765629 
DEBU[2022-06-28T20:26:33+08:00] [http TRACE MegaEase] - conn - tcp connection created to 172.67.222.231:443. time: 85.463ms 
DEBU[2022-06-28T20:26:33+08:00] [http TRACE MegaEase] - tls - start negotiation: 1656419193851180 
DEBU[2022-06-28T20:26:33+08:00] [http TRACE MegaEase] - tls - negotiated to "megaease.com", time: 96.888ms 
DEBU[2022-06-28T20:26:33+08:00] [http TRACE MegaEase] - connection established. reused: false idle: false idle time: 0ms 
DEBU[2022-06-28T20:26:33+08:00] [http TRACE MegaEase] - send - start write header field :authority [megaease.com] : 1656419193948308 
DEBU[2022-06-28T20:26:33+08:00] [http TRACE MegaEase] - send - start write header field :method [GET] : 1656419193948308 
DEBU[2022-06-28T20:26:33+08:00] [http TRACE MegaEase] - send - start write header field :path [/] : 1656419193948308 
DEBU[2022-06-28T20:26:33+08:00] [http TRACE MegaEase] - send - start write header field :scheme [https] : 1656419193948308 
DEBU[2022-06-28T20:26:33+08:00] [http TRACE MegaEase] - send - start write header field user-agent [MegaEase EaseProbe/v1.7.0] : 1656419193948308 
DEBU[2022-06-28T20:26:33+08:00] [http TRACE MegaEase] - send - start write header field accept-encoding [gzip] : 1656419193948308 
DEBU[2022-06-28T20:26:33+08:00] [http TRACE MegaEase] - send - headers written, time: 0.089ms 
DEBU[2022-06-28T20:26:33+08:00] [http TRACE MegaEase] - wait - start write request: 1656419193948405 
DEBU[2022-06-28T20:26:34+08:00] [http TRACE MegaEase] - transfer - start transfer the response: 1656419194738504 
DEBU[2022-06-28T20:26:34+08:00] [http TRACE MegaEase] - wait - got first response byte, time: 790.082ms 
DEBU[2022-06-28T20:26:34+08:00] [http TRACE MegaEase] - transfer - done, time: 0.085ms 
DEBU[2022-06-28T20:26:34+08:00] [http TRACE MegaEase] - total - done , time: 1041.068ms 
DEBU[2022-06-28T20:26:34+08:00] [http TRACE MegaEase] ======================== Trace Stats ====================== 
DEBU[2022-06-28T20:26:34+08:00] [http TRACE MegaEase] DNS       Connect TLS     Send    Wait    Trans   Total 
DEBU[2022-06-28T20:26:34+08:00] [http TRACE MegaEase] 67.73     85.46   96.89   0.09    790.08  0.09    1041.07 
DEBU[2022-06-28T20:26:34+08:00] [http TRACE MegaEase] =========================================================== 
```