### PR TITLE
Add some filter options for SLA HTML Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,8 +252,15 @@ Check the  [Notification Configuration](#38-notification-configuration) to see h
 
   The EaseProbe would listen on the `0.0.0.0:8181` port by default. And you can access the Live SLA report by the following URL:
 
-  - HTML: `http://localhost:8181/` or `http://localhost:8181/?refresh=30s`
+  - HTML: `http://localhost:8181/`
   - JSON: `http://localhost:8181/api/v1/sla`
+
+For the HTML report, you can use the following options:
+
+  - `refresh=30s`: refresh the report every `refresh` seconds.
+  - `status=up`: only shows the probers which status is `up`. the value can be `up` or `down`.
+  - `gt=50`: only shows the probers the SLA is greater than `50%`.
+  - `lt=90`: only shows the probers the SLA is less than `90%`.
 
   Refer to the [Global Setting Configuration](#39-global-setting-configuration) to see how to configure the access log.
 

--- a/README.md
+++ b/README.md
@@ -257,10 +257,10 @@ Check the  [Notification Configuration](#38-notification-configuration) to see h
 
 For the HTML report, you can use the following URL query options:
 
-  - `refresh`: report refresh rate (ex. `?refresh=30s` refreshes the page every 30 second)
-  - `status`: only show the probers with specific status, accepted values `up` or `down` (ex. `?status=up` list only probers with status `up`).
-  - `gt`: only shows the probers with SLA greater than given percentage (ex. `?gt=50` filter only hosts with SLA percentage greater than 50%)
-  - `lt`: only shows the probers with SLA less than the given percentage (ex. `?lt=90` filter only hosts with SLA percentage less than 90%)
+  - `refresh`: report refresh rate (ex. `?refresh=30s` refreshes the page every 30 seconds)
+  - `status`: only shows the probers with specific status, accepted values `up` or `down` (ex. `?status=up` list only probers with status `up`).
+  - `gte`: only shows the probers with SLA greater than given percentage (ex. `?gte=50` filter only hosts with SLA percentage `>= 50%`)
+  - `lt`: only shows the probers with SLA less than the given percentage (ex. `?lte=90` filter only hosts with SLA percentage `<= 90%` )
 
   Refer to the [Global Setting Configuration](#39-global-setting-configuration) to see how to configure the access log.
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Check the  [Notification Configuration](#38-notification-configuration) to see h
   - HTML: `http://localhost:8181/`
   - JSON: `http://localhost:8181/api/v1/sla`
 
-For the HTML report, you can use the following options:
+For the HTML report, you can use the following URL query options:
 
   - `refresh=30s`: refresh the report every `refresh` seconds.
   - `status=up`: only shows the probers which status is `up`. the value can be `up` or `down`.

--- a/README.md
+++ b/README.md
@@ -257,10 +257,10 @@ Check the  [Notification Configuration](#38-notification-configuration) to see h
 
 For the HTML report, you can use the following URL query options:
 
-  - `refresh=30s`: refresh the report every `refresh` seconds.
-  - `status=up`: only shows the probers which status is `up`. the value can be `up` or `down`.
-  - `gt=50`: only shows the probers the SLA is greater than `50%`.
-  - `lt=90`: only shows the probers the SLA is less than `90%`.
+  - `refresh`: report refresh rate (ex. `?refresh=30s` refreshes the page every 30 second)
+  - `status`: only show the probers with specific status, accepted values `up` or `down` (ex. `?status=up` list only probers with status `up`).
+  - `gt`: only shows the probers with SLA greater than given percentage (ex. `?gt=50` filter only hosts with SLA percentage greater than 50%)
+  - `lt`: only shows the probers with SLA less than the given percentage (ex. `?lt=90` filter only hosts with SLA percentage less than 90%)
 
   Refer to the [Global Setting Configuration](#39-global-setting-configuration) to see how to configure the access log.
 

--- a/README.md
+++ b/README.md
@@ -259,8 +259,8 @@ For the HTML report, you can use the following URL query options:
 
   - `refresh`: report refresh rate (ex. `?refresh=30s` refreshes the page every 30 seconds)
   - `status`: only shows the probers with specific status, accepted values `up` or `down` (ex. `?status=up` list only probers with status `up`).
-  - `gte`: only shows the probers with SLA greater than given percentage (ex. `?gte=50` filter only hosts with SLA percentage `>= 50%`)
-  - `lt`: only shows the probers with SLA less than the given percentage (ex. `?lte=90` filter only hosts with SLA percentage `<= 90%` )
+  - `gte`: only shows the probers with SLA greater than or equal to the given percentage (ex. `?gte=50` filter only hosts with SLA percentage `>= 50%`)
+  - `lte`: only shows the probers with SLA less than or equal to the given percentage (ex. `?lte=90` filter only hosts with SLA percentage `<= 90%` )
 
   Refer to the [Global Setting Configuration](#39-global-setting-configuration) to see how to configure the access log.
 

--- a/report/result_test.go
+++ b/report/result_test.go
@@ -63,6 +63,20 @@ func newDummyResult(name string) probe.Result {
 	}
 }
 
+func TestToLog(t *testing.T) {
+	global.InitEaseProbe("EaseProbe", "http://icon/url")
+	r := newDummyResult("dummy")
+	str := ToLog(r)
+	assert.NotEmpty(t, str)
+	assert.Contains(t, str, r.Title())
+	assert.Contains(t, str, r.Endpoint)
+	assert.Contains(t, str, r.StartTime.Format(r.TimeFormat))
+	assert.Contains(t, str, r.RoundTripTime.String())
+	assert.NotContains(t, str, r.PreStatus.Emoji())
+	assert.Contains(t, str, r.Message)
+	assert.Contains(t, str, r.LatestDownTime.Format(r.TimeFormat))
+}
+
 func TestToText(t *testing.T) {
 	global.InitEaseProbe("EaseProbe", "http://icon/url")
 	r := newDummyResult("dummy")

--- a/report/sla.go
+++ b/report/sla.go
@@ -224,6 +224,7 @@ type SLAFilter struct {
 	SLAGreater float64
 	SLALess    float64
 }
+
 // HTML return the HTML format string
 func (f *SLAFilter) HTML() string {
 	result := fmt.Sprintf("<b>SLA</b>: %.2f%% - %.2f%% ", f.SLAGreater, f.SLALess)

--- a/report/sla.go
+++ b/report/sla.go
@@ -218,13 +218,31 @@ func SLAHTMLSection(r *probe.Result) string {
 		r.Status.Emoji()+" "+r.Status.String(), JSONEscape(r.Message))
 }
 
+// SLAFilter filter the probers
+type SLAFilter struct {
+	Status     *probe.Status
+	SLAGreater float64
+	SLALess    float64
+}
+
 // SLAHTML return a full stat report
 func SLAHTML(probers []probe.Prober) string {
+	return SLAHTMLFilter(probers, nil)
+}
+
+// SLAHTMLFilter return a stat report with filter
+func SLAHTMLFilter(probers []probe.Prober, filter *SLAFilter) string {
 	html := HTMLHeader("Overall SLA Report")
 
 	html += `<table style="font-size: 16px; line-height: 20px;">`
 	for _, p := range probers {
-		html += SLAHTMLSection(p.Result())
+		if filter == nil {
+			html += SLAHTMLSection(p.Result())
+		} else if p.Result().SLAPercent() >= filter.SLAGreater && p.Result().SLAPercent() <= filter.SLALess {
+			if filter.Status == nil || p.Result().Status == *filter.Status {
+				html += SLAHTMLSection(p.Result())
+			}
+		}
 	}
 	html += `</table>`
 

--- a/report/sla.go
+++ b/report/sla.go
@@ -224,6 +224,15 @@ type SLAFilter struct {
 	SLAGreater float64
 	SLALess    float64
 }
+// HTML return the HTML format string
+func (f *SLAFilter) HTML() string {
+	result := fmt.Sprintf("<b>SLA</b>: %.2f%% - %.2f%% ", f.SLAGreater, f.SLALess)
+	if f.Status != nil {
+		result += fmt.Sprintf("  <b>Status</b>: %s", f.Status.String())
+	}
+
+	return result
+}
 
 // SLAHTML return a full stat report
 func SLAHTML(probers []probe.Prober) string {
@@ -234,17 +243,27 @@ func SLAHTML(probers []probe.Prober) string {
 func SLAHTMLFilter(probers []probe.Prober, filter *SLAFilter) string {
 	html := HTMLHeader("Overall SLA Report")
 
-	html += `<table style="font-size: 16px; line-height: 20px;">`
+	cnt := 0
+	table := `<table style="font-size: 16px; line-height: 20px;">`
 	for _, p := range probers {
 		if filter == nil {
-			html += SLAHTMLSection(p.Result())
+			table += SLAHTMLSection(p.Result())
+			cnt++
 		} else if p.Result().SLAPercent() >= filter.SLAGreater && p.Result().SLAPercent() <= filter.SLALess {
 			if filter.Status == nil || p.Result().Status == *filter.Status {
-				html += SLAHTMLSection(p.Result())
+				table += SLAHTMLSection(p.Result())
+				cnt++
 			}
 		}
 	}
-	html += `</table>`
+	table += `</table>`
+
+	summary := ""
+	if filter != nil {
+		summary += filter.HTML() + " :  "
+	}
+	summary += fmt.Sprintf(`( <b>%d</b> Probers found! )`, cnt)
+	html = html + summary + table
 
 	timeFmt := "2006-01-02 15:04:05"
 	if len(probers) > 0 {

--- a/report/sla_test.go
+++ b/report/sla_test.go
@@ -76,6 +76,14 @@ func TestSLA(t *testing.T) {
 	}
 }
 
+func TestSLAJSONSection(t *testing.T) {
+	p := newDummyProber("probe1")
+	sla := SLAJSONSection(p.Result())
+	assert.NotEmpty(t, sla)
+	assert.Contains(t, sla, "\"name\":\"probe1\"")
+	assert.Contains(t, sla, "\"status\":\"up\"")
+}
+
 func TestSLAFilter(t *testing.T) {
 	probes[0].Result().Status = probe.StatusUp
 	probes[1].Result().Status = probe.StatusDown

--- a/report/sla_test.go
+++ b/report/sla_test.go
@@ -75,3 +75,59 @@ func TestSLA(t *testing.T) {
 		}
 	}
 }
+
+func TestSLAFilter(t *testing.T) {
+	probes[0].Result().Status = probe.StatusUp
+	probes[1].Result().Status = probe.StatusDown
+	probes[2].Result().Status = probe.StatusUp
+	probes[3].Result().Status = probe.StatusDown
+
+	html := SLAHTMLFilter(probes, nil)
+	for _, p := range probes {
+		assert.Contains(t, html, p.Name())
+	}
+
+	filter := SLAFilter{
+		Status:     nil,
+		SLAGreater: 0,
+		SLALess:    100,
+	}
+	html = SLAHTMLFilter(probes, &filter)
+	for _, p := range probes {
+		assert.Contains(t, html, p.Name())
+	}
+
+	status := probe.StatusUp
+	filter.Status = &status
+	html = SLAHTMLFilter(probes, &filter)
+	assert.Contains(t, html, probes[0].Name())
+	assert.NotContains(t, html, probes[1].Name())
+	assert.Contains(t, html, probes[2].Name())
+	assert.NotContains(t, html, probes[3].Name())
+
+	// 80% SLA
+	probes[0].Result().Stat.UpTime = 80
+	probes[0].Result().Stat.DownTime = 20
+
+	// 60% SLA
+	probes[1].Result().Stat.UpTime = 60
+	probes[1].Result().Stat.DownTime = 40
+
+	// 40% SLA
+	probes[2].Result().Stat.UpTime = 40
+	probes[2].Result().Stat.DownTime = 60
+
+	// 20% SLA
+	probes[3].Result().Stat.UpTime = 20
+	probes[3].Result().Stat.DownTime = 80
+
+	// sla between 50 - 90, status is up
+	filter.SLAGreater = 50
+	filter.SLALess = 90
+	html = SLAHTMLFilter(probes, &filter)
+	assert.Contains(t, html, probes[0].Name())
+	assert.NotContains(t, html, probes[1].Name())
+	assert.NotContains(t, html, probes[2].Name())
+	assert.NotContains(t, html, probes[3].Name())
+
+}

--- a/web/server.go
+++ b/web/server.go
@@ -91,8 +91,8 @@ func slaHTML(w http.ResponseWriter, req *http.Request) {
 	if req.URL.Query().Get("status") != "" {
 		filter.Status = getStatus(req.URL.Query().Get("status"))
 	}
-	filter.SLAGreater = getFloat(req.URL.Query().Get("gt"), 0)
-	filter.SLALess = getFloat(req.URL.Query().Get("lt"), 100)
+	filter.SLAGreater = getFloat(req.URL.Query().Get("gte"), 0)
+	filter.SLALess = getFloat(req.URL.Query().Get("lte"), 100)
 
 	if err := checkFilter(filter); err != nil {
 		log.Errorf(err.Error())

--- a/web/server.go
+++ b/web/server.go
@@ -72,13 +72,13 @@ func getFloat(f string, _default float64) float64 {
 func checkFilter(filter report.SLAFilter) error {
 	log.Debugf("[Web] Check filter: %+v", filter)
 	if filter.SLAGreater > filter.SLALess {
-		return fmt.Errorf("Error: Invalid SLA filter: gt(%0.2f) > (%0.2f)", filter.SLAGreater, filter.SLALess)
+		return fmt.Errorf("Error: Invalid SLA filter: gte(%0.2f) > (%0.2f)", filter.SLAGreater, filter.SLALess)
 	}
 	if filter.SLAGreater > 100 || filter.SLALess < 0 {
-		return fmt.Errorf("Error: Invalid SLA filter: gt(%0.2f), it must be between 0 - 100", filter.SLAGreater)
+		return fmt.Errorf("Error: Invalid SLA filter: gte(%0.2f), it must be between 0 - 100", filter.SLAGreater)
 	}
 	if filter.SLALess > 100 || filter.SLALess < 0 {
-		return fmt.Errorf("Error: Invalid SLA filter: lt(%0.2f), it must be between 0 - 100", filter.SLALess)
+		return fmt.Errorf("Error: Invalid SLA filter: lte(%0.2f), it must be between 0 - 100", filter.SLALess)
 	}
 	return nil
 }

--- a/web/server.go
+++ b/web/server.go
@@ -74,7 +74,7 @@ func checkFilter(filter report.SLAFilter) error {
 	if filter.SLAGreater > filter.SLALess {
 		return fmt.Errorf("Error: Invalid SLA filter: gte(%0.2f) > (%0.2f)", filter.SLAGreater, filter.SLALess)
 	}
-	if filter.SLAGreater > 100 || filter.SLALess < 0 {
+	if filter.SLAGreater > 100 || filter.SLAGreater < 0 {
 		return fmt.Errorf("Error: Invalid SLA filter: gte(%0.2f), it must be between 0 - 100", filter.SLAGreater)
 	}
 	if filter.SLALess > 100 || filter.SLALess < 0 {


### PR DESCRIPTION
For the HTML report, add the following options:

  - `status=up`: only shows the probers which status is `up`. the value can be `up` or `down`.
  - `gte=50`: only shows the probers the SLA percentage is >= `50%`.
  - `lte=90`: only shows the probers the SLA percentage s  <= `90%`.