### PR TITLE
set the `SO_LINGER=0` to tcp, http, tls, ssh probe

### DIFF
--- a/probe/ssh/ssh.go
+++ b/probe/ssh/ssh.go
@@ -20,6 +20,7 @@ package ssh
 import (
 	"bytes"
 	"fmt"
+	"net"
 
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe"
@@ -203,6 +204,10 @@ func (s *Server) GetSSHClientFromBastion() error {
 	conn, err := bClient.Dial("tcp", s.Host)
 	if err != nil {
 		return fmt.Errorf("Server: %s", err)
+	}
+
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		tcpConn.SetLinger(0)
 	}
 
 	ncc, chans, reqs, err := ssh.NewClientConn(conn, s.Host, config)

--- a/probe/tcp/tcp.go
+++ b/probe/tcp/tcp.go
@@ -54,7 +54,10 @@ func (t *TCP) DoProbe() (bool, string) {
 		status = false
 	} else {
 		message = "TCP Connection Established Successfully!"
-		conn.Close()
+		if tcpCon, ok := conn.(*net.TCPConn); ok {
+			tcpCon.SetLinger(0)
+		}
+		defer conn.Close()
 	}
 	return status, message
 }

--- a/probe/tls/tls.go
+++ b/probe/tls/tls.go
@@ -88,6 +88,9 @@ func (t *TLS) DoProbe() (bool, string) {
 		log.Errorf("tcp dial error: %v", err)
 		return false, fmt.Sprintf("tcp dial error: %v", err)
 	}
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		tcpConn.SetLinger(0)
+	}
 	defer conn.Close()
 
 	colonPos := strings.LastIndex(addr, ":")


### PR DESCRIPTION
EaseProbe would create and close a new TCP connection every time, this would cause many TIME_WAIT connections 

To solve this, we can set `SO_LINGER=0`, so the closed TCP connect won't have TIME_WAIT status.

Reference: https://stackoverflow.com/questions/3757289/when-is-tcp-option-so-linger-0-required