### PR TITLE
Change the start up delay if we have less than 60 probers

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ EaseProbe supports the following probing methods: **HTTP**, **TCP**, **Shell Com
 
 Each probe is identified by the method it supports (eg `http`), a unique name (across all probes in the configuration file) and the method specific parameters.
 
+On application startup, the configured probes are scheduled for their initial fire up based on the following criteria:
+* Less than or equal to 60 total probers exist: the delay between initial prober fire-up is `1 second`
+* More than 60 total probers exist: the startup is scheduled based on the following equation `timeGap = DefaultProbeInterval / numProbes`
+
 > **Note**:
 >
 > **If multiple probes using the same name then this could lead to corruption of the metrics data and/or the behavior of the application in non-deterministic way.**

--- a/cmd/easeprobe/probe.go
+++ b/cmd/easeprobe/probe.go
@@ -58,6 +58,9 @@ func configProbers(probers []probe.Prober) []probe.Prober {
 func runProbers(probers []probe.Prober, wg *sync.WaitGroup, done chan bool) {
 	// we need to run all probers in equally distributed time, not at the same time.
 	timeGap := global.DefaultProbeInterval / time.Duration(len(probers))
+	if len(probers) <= 60 {
+		timeGap = 1000000000
+	}
 	log.Debugf("Start Time Gap: %v = %v / %d", timeGap, global.DefaultProbeInterval, len(probers))
 
 	probeFn := func(p probe.Prober, index int) {

--- a/cmd/easeprobe/probe.go
+++ b/cmd/easeprobe/probe.go
@@ -59,7 +59,7 @@ func runProbers(probers []probe.Prober, wg *sync.WaitGroup, done chan bool) {
 	// we need to run all probers in equally distributed time, not at the same time.
 	timeGap := global.DefaultProbeInterval / time.Duration(len(probers))
 	// if less than or equal to 60 probers, use 1 second instead
-	if time.Duration(len(probers)) <= time.Minute {
+	if time.Duration(len(probers))*time.Second <= time.Minute {
 		timeGap = time.Second
 	}
 	log.Debugf("Start Time Gap: %v = %v / %d", timeGap, global.DefaultProbeInterval, len(probers))

--- a/cmd/easeprobe/probe.go
+++ b/cmd/easeprobe/probe.go
@@ -58,8 +58,9 @@ func configProbers(probers []probe.Prober) []probe.Prober {
 func runProbers(probers []probe.Prober, wg *sync.WaitGroup, done chan bool) {
 	// we need to run all probers in equally distributed time, not at the same time.
 	timeGap := global.DefaultProbeInterval / time.Duration(len(probers))
-	if len(probers) <= 60 {
-		timeGap = 1000000000
+	// if less than or equal to 60 probers, use 1 second instead
+	if time.Duration(len(probers)) <= time.Minute {
+		timeGap = time.Second
 	}
 	log.Debugf("Start Time Gap: %v = %v / %d", timeGap, global.DefaultProbeInterval, len(probers))
 


### PR DESCRIPTION
This PR changes the start up delay of the probers.

if probers are less than 60 then just use 1 second delay instead