### PR TITLE
Fix the concurrent map access crashing problem

### DIFF
--- a/cmd/easeprobe/main.go
+++ b/cmd/easeprobe/main.go
@@ -153,13 +153,15 @@ func main() {
 	doneProbe := make(chan bool, len(probers))
 	// the exit channel for saving the data
 	doneSave := make(chan bool)
+	// the channel for saving the probe result data
+	saveChannel := make(chan probe.Result, len(probers))
 
 	// 1) SLA Data Save process
-	probe.CleanData(probers) // remove the data not in probers
-	go saveData(doneSave)    // save the data to file
+	probe.CleanData(probers)           // remove the data not in probers
+	go saveData(doneSave, saveChannel) // save the data to file
 
 	// 2) Start the Probers
-	runProbers(probers, &wg, doneProbe)
+	runProbers(probers, &wg, doneProbe, saveChannel)
 	// 3) Start the Event Watching
 	channel.WatchForAllEvents()
 

--- a/cmd/easeprobe/report.go
+++ b/cmd/easeprobe/report.go
@@ -27,7 +27,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func saveData(doneSave chan bool) {
+func saveData(doneSave chan bool, saveChannel chan probe.Result) {
 	c := conf.Get()
 	file := c.Settings.SLAReport.DataFile
 	save := func() {
@@ -50,6 +50,8 @@ func saveData(doneSave chan bool) {
 	defer interval.Stop()
 	for {
 		select {
+		case res := <-saveChannel:
+			probe.SetResultData(res.Name, &res)
 		case <-doneSave:
 			save()
 			log.Info("Received the exit signal, Saving data process is exiting...")

--- a/probe/base/base.go
+++ b/probe/base/base.go
@@ -149,7 +149,9 @@ func (d *DefaultProbe) Probe() probe.Result {
 	d.DownTimeCalculation(status)
 
 	d.ProbeResult.DoStat(d.Interval())
-	return *d.ProbeResult
+
+	result := d.ProbeResult.Clone()
+	return result
 }
 
 // ExportMetrics export the metrics

--- a/probe/data.go
+++ b/probe/data.go
@@ -85,7 +85,6 @@ func GetResultData(name string) *Result {
 
 // CleanData removes the items in resultData not in []Prober
 func CleanData(p []Prober) {
-	mutex.Lock()
 	var data = map[string]*Result{}
 	for i := 0; i < len(p); i++ {
 		r := p[i].Result()
@@ -96,6 +95,7 @@ func CleanData(p []Prober) {
 			data[r.Name] = r
 		}
 	}
+	mutex.Lock()
 	resultData = data
 	mutex.Unlock()
 }
@@ -162,8 +162,6 @@ func LoadDataFromFile(filename string) error {
 					log.Debugf("Load meta data: name[%s], version[%s]", metaData.Name, metaData.Ver)
 				}
 			} else {
-				mutex.Lock()
-				defer mutex.Unlock()
 				if err := yaml.Unmarshal(valueBytes, &resultData); err != nil {
 					return err
 				}

--- a/probe/data.go
+++ b/probe/data.go
@@ -85,6 +85,7 @@ func GetResultData(name string) *Result {
 
 // CleanData removes the items in resultData not in []Prober
 func CleanData(p []Prober) {
+	mutex.Lock()
 	var data = map[string]*Result{}
 	for i := 0; i < len(p); i++ {
 		r := p[i].Result()
@@ -95,7 +96,6 @@ func CleanData(p []Prober) {
 			data[r.Name] = r
 		}
 	}
-	mutex.Lock()
 	resultData = data
 	mutex.Unlock()
 }

--- a/probe/data.go
+++ b/probe/data.go
@@ -49,7 +49,7 @@ var (
 		Ver:  global.Ver,
 	}
 	metaBuf []byte
-	mutex = &sync.RWMutex{}
+	mutex   = &sync.RWMutex{}
 )
 
 const split = "---\n"

--- a/probe/data.go
+++ b/probe/data.go
@@ -236,6 +236,7 @@ func SetMetaData(name string, ver string) {
 	// reconstructure the meta buf
 	genMetaBuf()
 }
+
 // Note: we no need lock for this function, because this is only called by one go routine.
 func genMetaBuf() {
 	// if the meta data is not exist in current data file, using the default.

--- a/probe/data.go
+++ b/probe/data.go
@@ -100,7 +100,6 @@ func CleanData(p []Prober) {
 }
 
 // SaveDataToFile save the results to file
-// Note: we no need lock for this function, because this is only called once during the startup
 func SaveDataToFile(filename string) error {
 	metaData.file = filename
 	if strings.TrimSpace(filename) == "-" {

--- a/probe/data.go
+++ b/probe/data.go
@@ -84,6 +84,7 @@ func GetResultData(name string) *Result {
 }
 
 // CleanData removes the items in resultData not in []Prober
+// Note: we no need lock for this function, because this is only called once during the startup
 func CleanData(p []Prober) {
 	var data = map[string]*Result{}
 	for i := 0; i < len(p); i++ {
@@ -95,12 +96,11 @@ func CleanData(p []Prober) {
 			data[r.Name] = r
 		}
 	}
-	mutex.Lock()
 	resultData = data
-	mutex.Unlock()
 }
 
 // SaveDataToFile save the results to file
+// Note: we no need lock for this function, because this is only called once during the startup
 func SaveDataToFile(filename string) error {
 	metaData.file = filename
 	if strings.TrimSpace(filename) == "-" {
@@ -124,6 +124,7 @@ func SaveDataToFile(filename string) error {
 }
 
 // LoadDataFromFile load the results from file
+// Note: we no need lock for this function, because this is only called once during the startup
 func LoadDataFromFile(filename string) error {
 
 	// if the data file is disabled, return
@@ -188,6 +189,7 @@ func LoadDataFromFile(filename string) error {
 }
 
 // CleanDataFile keeps the max backup of data file
+// Note: we no need lock for this function, because this is only called once during the startup
 func CleanDataFile(filename string, backups int) {
 	if strings.TrimSpace(filename) == "-" {
 		return
@@ -225,6 +227,7 @@ func CleanDataFile(filename string, backups int) {
 }
 
 // SetMetaData set the meta data
+// Note: we no need lock for this function, because this is only called once during the startup
 func SetMetaData(name string, ver string) {
 
 	metaData.Name = name
@@ -233,7 +236,7 @@ func SetMetaData(name string, ver string) {
 	// reconstructure the meta buf
 	genMetaBuf()
 }
-
+// Note: we no need lock for this function, because this is only called by one go routine.
 func genMetaBuf() {
 	// if the meta data is not exist in current data file, using the default.
 	if metaData.Name == "" {

--- a/probe/result.go
+++ b/probe/result.go
@@ -118,7 +118,7 @@ func (s *Stat) Clone() Stat {
 	return dst
 }
 
-// DoStat is the function do the statstics
+// DoStat is the function do the statistics
 func (r *Result) DoStat(d time.Duration) {
 	r.Stat.Total++
 	r.Stat.Status[r.Status]++

--- a/report/filter.go
+++ b/report/filter.go
@@ -134,6 +134,8 @@ func (f *SLAFilter) Filter(probers []probe.Prober) []probe.Prober {
 	f.cnt = 0
 	result := make([]probe.Prober, 0)
 	for _, p := range probers {
+		// get the Probe Result data from the Data Manager
+		r := probe.GetResultData(p.Name())
 		// if the name is not empty then filter by name
 		if f.Name != "" && !strings.Contains(p.Name(), f.Name) {
 			continue
@@ -143,19 +145,19 @@ func (f *SLAFilter) Filter(probers []probe.Prober) []probe.Prober {
 			continue
 		}
 		// if the endpoint is not empty then filter by endpoint
-		if f.Endpoint != "" && !strings.Contains(p.Result().Endpoint, f.Endpoint) {
+		if f.Endpoint != "" && !strings.Contains(r.Endpoint, f.Endpoint) {
 			continue
 		}
 		// if the status is not right then ignore it
-		if f.Status != nil && p.Result().Status != *f.Status {
+		if f.Status != nil && r.Status != *f.Status {
 			continue
 		}
 		// if the message is not empty then filter by message
-		if f.Message != "" && !strings.Contains(p.Result().Message, f.Message) {
+		if f.Message != "" && !strings.Contains(r.Message, f.Message) {
 			continue
 		}
 		//if the SLA is not right then ignore it
-		percent := p.Result().SLAPercent()
+		percent := r.SLAPercent()
 		if percent < f.SLAGreater || percent > f.SLALess {
 			continue
 		}

--- a/report/filter_test.go
+++ b/report/filter_test.go
@@ -90,6 +90,10 @@ func initData() []probe.Prober {
 	probes[3].Result().Stat.UpTime = 20
 	probes[3].Result().Stat.DownTime = 80
 
+	for _, p := range probes {
+		probe.SetResultData(p.Name(), p.Result())
+	}
+
 	return probes
 }
 func TestFilter(t *testing.T) {

--- a/report/result_test.go
+++ b/report/result_test.go
@@ -37,7 +37,7 @@ func newDummyResult(name string) probe.Result {
 	up := rand.Int63n(total)
 	down := rand.Int63n(total - up)
 
-	return probe.Result{
+	r := probe.Result{
 		Name:             name,
 		Endpoint:         "http://endpoint:8080",
 		StartTime:        time.Now(),
@@ -61,6 +61,8 @@ func newDummyResult(name string) probe.Result {
 		},
 		TimeFormat: time.RFC3339,
 	}
+	probe.SetResultData(name, &r)
+	return r
 }
 
 func TestToLog(t *testing.T) {

--- a/report/sla.go
+++ b/report/sla.go
@@ -99,7 +99,8 @@ func SLAJSONSection(r *probe.Result) string {
 func SLAJSON(probers []probe.Prober) string {
 	var sla []SLA
 	for _, p := range probers {
-		sla = append(sla, SLAObject(p.Result()))
+		r := probe.GetResultData(p.Name())
+		sla = append(sla, SLAObject(r))
 	}
 	j, err := json.Marshal(&sla)
 	if err != nil {
@@ -123,7 +124,8 @@ func SLATextSection(r *probe.Result) string {
 func SLAText(probers []probe.Prober) string {
 	text := "[Overall SLA Report]\n\n"
 	for _, p := range probers {
-		text += SLATextSection(p.Result()) + "\n"
+		r := probe.GetResultData(p.Name())
+		text += SLATextSection(r) + "\n"
 	}
 	return text
 }
@@ -143,7 +145,8 @@ func SLALog(probers []probe.Prober) string {
 	var text string
 	n := len(probers)
 	for i, p := range probers {
-		text += fmt.Sprintf("SLA-Report-%d-%d %s\n", i+1, n, SLALogSection(p.Result()))
+		r := probe.GetResultData(p.Name())
+		text += fmt.Sprintf("SLA-Report-%d-%d %s\n", i+1, n, SLALogSection(r))
 	}
 	return text
 }
@@ -184,7 +187,8 @@ func slaMarkdown(probers []probe.Prober, f Format) string {
 		md = "*Overall SLA Report*\n"
 	}
 	for _, p := range probers {
-		md += SLAMarkdownSection(p.Result(), f)
+		r := probe.GetResultData(p.Name())
+		md += SLAMarkdownSection(r, f)
 	}
 	timeFmt := "2006-01-02 15:04:05"
 	if len(probers) > 0 {
@@ -234,7 +238,8 @@ func SLAHTMLFilter(probers []probe.Prober, filter *SLAFilter) string {
 	probers = filter.Filter(probers)
 	table := `<table style="font-size: 16px; line-height: 20px;">`
 	for _, p := range probers {
-		table += SLAHTMLSection(p.Result())
+		r := probe.GetResultData(p.Name())
+		table += SLAHTMLSection(r)
 	}
 	table += `</table>`
 
@@ -312,9 +317,11 @@ func SLASlack(probers []probe.Prober) string {
 		}
 		json += "," + sectionHead
 		for i := start; i < end-1; i++ {
-			json += SLASlackSection(probers[i].Result()) + ","
+			r := probe.GetResultData(probers[i].Name())
+			json += SLASlackSection(r) + ","
 		}
-		json += SLASlackSection(probers[end-1].Result())
+		r := probe.GetResultData(probers[end-1].Name())
+		json += SLASlackSection(r)
 		json += sectionFoot
 	}
 
@@ -420,7 +427,8 @@ func SLALark(probers []probe.Prober) string {
 	title := "Overall SLA Report"
 	sections := []string{}
 	for _, p := range probers {
-		sections = append(sections, SLALarkSection(p.Result()))
+		r := probe.GetResultData(p.Name())
+		sections = append(sections, SLALarkSection(r))
 	}
 
 	elements := strings.Join(sections, "")
@@ -433,7 +441,8 @@ func SLALark(probers []probe.Prober) string {
 func SLASummary(probers []probe.Prober) string {
 	sla := 0.0
 	for _, p := range probers {
-		sla += p.Result().SLAPercent()
+		r := probe.GetResultData(p.Name())
+		sla += r.SLAPercent()
 	}
 	sla /= float64(len(probers))
 	summary := fmt.Sprintf("Total %d Services, Average %.2f%% SLA", len(probers), sla)
@@ -464,7 +473,8 @@ func SLACSV(probers []probe.Prober) string {
 	}
 
 	for _, p := range probers {
-		data = append(data, SLACSVSection(p.Result()))
+		r := probe.GetResultData(p.Name())
+		data = append(data, SLACSVSection(r))
 	}
 
 	buf := new(bytes.Buffer)

--- a/report/sla_test.go
+++ b/report/sla_test.go
@@ -42,12 +42,14 @@ func (d *dummyProber) DoProbe() (bool, string) {
 	return rand.Int()%2 == 0, "hello world"
 }
 func getProbers() []probe.Prober {
-	return []probe.Prober{
+	ps := []probe.Prober{
 		newDummyProber("probe1"),
 		newDummyProber("probe2"),
 		newDummyProber("probe3"),
 		newDummyProber("probe4"),
 	}
+	setResultData(ps)
+	return ps
 }
 func newDummyProber(name string) probe.Prober {
 	r := newDummyResult(name)
@@ -58,6 +60,12 @@ func newDummyProber(name string) probe.Prober {
 			ProbeName:   name,
 			ProbeResult: &r,
 		},
+	}
+}
+
+func setResultData(probes []probe.Prober) {
+	for _, p := range probes {
+		probe.SetResultData(p.Name(), p.Result())
 	}
 }
 
@@ -91,6 +99,7 @@ func TestSLAFilter(t *testing.T) {
 	probes[1].Result().Status = probe.StatusDown
 	probes[2].Result().Status = probe.StatusUp
 	probes[3].Result().Status = probe.StatusDown
+	setResultData(probes)
 
 	html := SLAHTMLFilter(probes, nil)
 	for _, p := range probes {
@@ -126,6 +135,8 @@ func TestSLAFilter(t *testing.T) {
 	// 20% SLA
 	probes[3].Result().Stat.UpTime = 20
 	probes[3].Result().Stat.DownTime = 80
+
+	setResultData(probes)
 
 	// sla between 50 - 90, status is up
 	filter.SLAGreater = 50


### PR DESCRIPTION
# Background 

We have a map to collect all of the probers' probe results, all of the probers would set its result into this map concurrently in a different key(this is not a problem), however, we have another go routine that persistent this map periodically, this causes the "**concurrent map iteration and map write**" problem and it makes EaseProbe crash.

the stake trace of the crash as below:

```st
fatal error: concurrent map iteration and map write

goroutine 50 [running]:
runtime.throw({0xfd17f1?, 0x0?})
        /usr/local/go/src/runtime/panic.go:992 +0x71 fp=0xc0172745f0 sp=0xc0172745c0 pc=0x438b31
runtime.mapiternext(0x0?)
        /usr/local/go/src/runtime/map.go:871 +0x4eb fp=0xc017274660 sp=0xc0172745f0 pc=0x41058b
runtime.mapiterinit(0xc0172747e8?, 0xc0265008d0?, 0xc017274710?)
        /usr/local/go/src/runtime/map.go:861 +0x228 fp=0xc017274680 sp=0xc017274660 pc=0x410048
reflect.mapiterinit(0xc0172746c8?, 0x8c24b3?, 0xc000303400?)
....
....
....
....
gopkg.in/yaml%2ev3.(*encoder).marshalDoc(0xc000303400, {0x0, 0x0}, {0xe7b4e0?, 0xc02a155740?, 0x0?})
        /home/ubuntu/go/pkg/mod/gopkg.in/yaml.v3@v3.0.0-20210107192922-496545a6307b/encode.go:105 +0x185 fp=0xc017275ab8 sp=0xc017275838 pc=0x8c2765
gopkg.in/yaml%2ev3.Marshal({0xe7b4e0?, 0xc02a155740})
        /home/ubuntu/go/pkg/mod/gopkg.in/yaml.v3@v3.0.0-20210107192922-496545a6307b/yaml.go:222 +0x370 fp=0xc017275de8 sp=0xc017275ab8 pc=0x8e2e70
gopkg.in/yaml%2ev3.Marshal({0xe7b4e0?, 0xc02a155740})
        /home/ubuntu/go/pkg/mod/gopkg.in/yaml.v3@v3.0.0-20210107192922-496545a6307b/yaml.go:222 +0x370 fp=0xc017275de8 sp=0xc017275ab8 pc=0x8e2e70
github.com/megaease/easeprobe/probe.SaveDataToFile({0xc0015858c0, 0x18})
        /home/ubuntu/hchen/easeprobe/probe/data.go:102 +0x85 fp=0xc017275e50 sp=0xc017275de8 pc=0x8e6ba5
main.saveData.func1()
        /home/ubuntu/hchen/easeprobe/cmd/easeprobe/report.go:34 +0x3d fp=0xc017275ee8 sp=0xc017275e50 pc=0xda975d
main.saveData(0xc000090780)
        /home/ubuntu/hchen/easeprobe/cmd/easeprobe/report.go:59 +0x16f fp=0xc017275fc8 sp=0xc017275ee8 pc=0xda958f
main.main.func3()
        /home/ubuntu/hchen/easeprobe/cmd/easeprobe/main.go:159 +0x26 fp=0xc017275fe0 sp=0xc017275fc8 pc=0xda7f66
runtime.goexit()
        /usr/local/go/src/runtime/asm_amd64.s:1571 +0x1 fp=0xc017275fe8 sp=0xc017275fe0 pc=0x46b6a1
created by main.main
        /home/ubuntu/hchen/easeprobe/cmd/easeprobe/main.go:159 +0x5fd

goroutine 1 [chan receive, 328 minutes]:
main.main()
        /home/ubuntu/hchen/easeprobe/cmd/easeprobe/main.go:205 +0x82b
```

the crash code line as blow:

```go
// SaveDataToFile save the results to file
func SaveDataToFile(filename string) error {
        metaData.file = filename
        if strings.TrimSpace(filename) == "-" {
                return nil
        }

        dataBuf, err := yaml.Marshal(resultData)   //<========= Panic at this line
        if err != nil {
                return err
        }

        genMetaBuf()
        buf := append(metaBuf, dataBuf...)

        if err := ioutil.WriteFile(filename, []byte(buf), 0644); err != nil {
                return err
        }
        return nil
}
````

# Investigation

The problem here is the prober's result (statistics data) would be consumed by the following modules:

- Data Saving
- SLA Report
- Web Server

All of the above modules only read the statistics data, the probers would update the statistics data.

So, this is the read-write concurrent problem. 

# Solution

We transfer all of the probers statistics data into the Save Manager (via a channel), and all of the consumers(Saving, SLA Report, Web Server) retrieve the statistics data from Save Manager instead of the probers directly.

1. Each Prober retrieves the persistent data from Save Manager by a clone object.
2. Each Prober clones & reports its Result to Save Manager via a go channel.
3. Web Server and SLA Report would query the result data from Save Manager.
4.  A Read-Write Lock added in Save Manager's Get/Set method.

```
                                                              ┌────────────┐
                                                   Query      │            │
  Result┌────────┐ retrieve                 ┌────────────────►│ Web Server │
┌───────┤ Prober │◄────────┐                │                 │            │
│       └────────┘         │                │                 └────────────┘
│                          │ Result. ┌──────┴──────┐
│ Result┌────────┐ retrieve│ Clone() │             │          ┌────────────┐
├───────┤ Prober │◄────────┼─────────┤ Save Manager│  Query   │            │
│       └────────┘         │         │   data.go   ├─────────►│ SLA Report │
│                          │    ┌────►             │          │            │
│ Result┌────────┐ retrieve│    │    └─────▲─┬─────┘          └────────────┘
├───────┤ Prober │◄────────┘    │          │ │
│       └────────┘              │          │ │  map[name]*Result
│                               │          │ │
│                               │     Load │ │ Save
│    Result.                    │      ┌───┴─▼────┐
│    Clone()  ┌──────────────┐  │      │          │
└────────────►│    Channel   ├──┘      │   File   │
              └──────────────┘         │          │
                                       └──────────┘
```