### PR TITLE
feat: support regexp output check for http/shell/ssh probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,7 @@ http:
     # Response Checking
     contain: "success" # response body must contain this string, if not the probe is considered failed.
     not_contain: "failure" # response body must NOT contain this string, if it does the probe is considered failed.
+    regex: false # if true, the contain and not_contain will be treated as regular expression. default: false
     # configuration
     timeout: 10s # default is 30 seconds
 
@@ -616,6 +617,8 @@ shell:
       - "REDISCLI_AUTH=abc123"
     # check the command output, if does not contain the PONG, mark the status down
     contain : "PONG"
+    not_contain: "failure" # response body must NOT contain this string, if it does the probe is considered failed.
+    regex: false # if true, the contain and not_contain will be treated as regular expression. default: false
 
   # Run Zookeeper command `stat` to check the zookeeper status
   - name: Zookeeper (Local)
@@ -670,6 +673,8 @@ ssh:
         - "REDISCLI_AUTH=abc123"
       # check the command output, if does not contain the PONG, mark the status down
       contain : "PONG"
+      not_contain: "failure" # response body must NOT contain this string, if it does the probe is considered failed.
+      regex: false # if true, the contain and not_contain will be treated as regular expression. default: false
 
     # Check the process status of `Kafka`
     - name:  Kafka (GCP)

--- a/probe/common_test.go
+++ b/probe/common_test.go
@@ -37,6 +37,68 @@ func TestCheckOutput(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestCheckOutputRegExp(t *testing.T) {
+	reg := `word[0-9]+`
+	err := CheckOutputRegExp(reg, "", "word word10 word")
+	assert.Nil(t, err)
+	err = CheckOutputRegExp("", reg, "word word word")
+	assert.Nil(t, err)
+
+	time := "[0-9]?[0-9]:[0-9][0-9]"
+	err = CheckOutputRegExp(time, "", "easeprobe hello world 1234")
+	assert.NotNil(t, err)
+	err = CheckOutputRegExp(time, "", "easeprobe hello world 12:34")
+	assert.Nil(t, err)
+
+	html := `<\/?[\w\s]*>|<.+[\W]>`
+	err = CheckOutputRegExp(html, "", "<p>test hello world </p>")
+	assert.Nil(t, err)
+	err = CheckOutputRegExp("hello", html, "text test hello world")
+	assert.Nil(t, err)
+
+	or := `word1|word2`
+	err = CheckOutputRegExp(or, "", "word1 easeprobe word2")
+	assert.Nil(t, err)
+	err = CheckOutputRegExp(or, "", "word2 easeprobe word1")
+	assert.Nil(t, err)
+	err = CheckOutputRegExp("", or, " easeprobe word1")
+	assert.NotNil(t, err)
+
+	unsupported := "(?=.*word1)(?=.*word2)"
+	err = CheckOutputRegExp(unsupported, "", "word1 word2")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "invalid or unsupported Perl syntax")
+	err = CheckOutputRegExp("", unsupported, "word1 word2")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "invalid or unsupported Perl syntax")
+
+}
+
+func TestTextChecker(t *testing.T) {
+	checker := TextChecker{
+		Contain:    "hello",
+		NotContain: "",
+		RegExp:     false,
+	}
+	assert.Nil(t, checker.Check("hello world"))
+	assert.Contains(t, checker.String(), "Text Mode")
+
+	checker = TextChecker{
+		Contain:    "[0-9]+$",
+		NotContain: "",
+		RegExp:     true,
+	}
+	assert.Nil(t, checker.Check("hello world 2022"))
+	assert.Contains(t, checker.String(), "RegExp Mode")
+
+	checker = TextChecker{
+		Contain:    "",
+		NotContain: `<\/?[\w\s]*>|<.+[\W]>`,
+		RegExp:     true,
+	}
+	assert.NotNil(t, checker.Check("<p>test hello world </p>"))
+}
+
 func TestCheckEmpty(t *testing.T) {
 	assert.Equal(t, "a", CheckEmpty("a"))
 	assert.Equal(t, "empty", CheckEmpty("    "))

--- a/probe/http/http.go
+++ b/probe/http/http.go
@@ -45,8 +45,9 @@ type HTTP struct {
 	Method            string            `yaml:"method,omitempty"`
 	Headers           map[string]string `yaml:"headers,omitempty"`
 	Body              string            `yaml:"body,omitempty"`
-	Contain           string            `yaml:"contain,omitempty"`
-	NotContain        string            `yaml:"not_contain,omitempty"`
+
+	// Output Text Checker
+	probe.TextChecker `yaml:",inline"`
 
 	// Option - HTTP Basic Auth Credentials
 	User string `yaml:"username,omitempty"`
@@ -197,7 +198,9 @@ func (h *HTTP) DoProbe() (bool, string) {
 	}
 
 	message := fmt.Sprintf("HTTP Status Code is %d", resp.StatusCode)
-	if err := probe.CheckOutput(h.Contain, h.NotContain, string(response)); err != nil {
+
+	log.Debugf("[%s / %s] - %s", h.ProbeKind, h.ProbeName, h.TextChecker.String())
+	if err := h.Check(string(response)); err != nil {
 		log.Errorf("[%s / %s] - %v", h.ProbeKind, h.ProbeName, err)
 		message += fmt.Sprintf(". Error: %v", err)
 		return false, message

--- a/probe/http/http_test.go
+++ b/probe/http/http_test.go
@@ -30,6 +30,7 @@ import (
 
 	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/probe"
 	"github.com/megaease/easeprobe/probe/base"
 	"github.com/stretchr/testify/assert"
 )
@@ -41,10 +42,12 @@ func createHTTP() *HTTP {
 		ContentEncoding: "text/json",
 		Headers:         map[string]string{"header1": "value1", "header2": "value2"},
 		Body:            "{ \"key1\": \"value1\", \"key2\": \"value2\" }",
-		Contain:         "good",
-		NotContain:      "bad",
-		User:            "user",
-		Pass:            "pass",
+		TextChecker: probe.TextChecker{
+			Contain:    "good",
+			NotContain: "bad",
+		},
+		User: "user",
+		Pass: "pass",
 		TLS: global.TLS{
 			CA:   "ca.crt",
 			Cert: "cert.crt",

--- a/probe/shell/shell.go
+++ b/probe/shell/shell.go
@@ -37,8 +37,9 @@ type Shell struct {
 	Args              []string `yaml:"args,omitempty"`
 	Env               []string `yaml:"env,omitempty"`
 	CleanEnv          bool     `yaml:"clean_env,omitempty"`
-	Contain           string   `yaml:"contain,omitempty"`
-	NotContain        string   `yaml:"not_contain,omitempty"`
+
+	// Output Text Checker
+	probe.TextChecker `yaml:",inline"`
 
 	exitCode  int `yaml:"-"`
 	outputLen int `yaml:"-"`
@@ -97,7 +98,8 @@ func (s *Shell) DoProbe() (bool, string) {
 
 	s.ExportMetrics()
 
-	if err := probe.CheckOutput(s.Contain, s.NotContain, string(output)); err != nil {
+	log.Debugf("[%s / %s] - %s", s.ProbeKind, s.ProbeName, s.TextChecker.String())
+	if err := s.Check(string(output)); err != nil {
 		log.Errorf("[%s / %s] - %v", s.ProbeKind, s.ProbeName, err)
 		message = fmt.Sprintf("Error: %v", err)
 		status = false

--- a/probe/shell/shell_test.go
+++ b/probe/shell/shell_test.go
@@ -26,6 +26,7 @@ import (
 
 	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/probe"
 	"github.com/megaease/easeprobe/probe/base"
 	"github.com/stretchr/testify/assert"
 )
@@ -36,8 +37,10 @@ func createShell() *Shell {
 		Command:      "dummy command",
 		Args:         []string{"arg1", "arg2"},
 		Env:          []string{"env1=value1", "env2=value2"},
-		Contain:      "good",
-		NotContain:   "bad",
+		TextChecker: probe.TextChecker{
+			Contain:    "good",
+			NotContain: "bad",
+		},
 	}
 }
 func TestShell(t *testing.T) {

--- a/probe/ssh/ssh.go
+++ b/probe/ssh/ssh.go
@@ -41,8 +41,9 @@ type Server struct {
 	Command           string   `yaml:"cmd"`
 	Args              []string `yaml:"args,omitempty"`
 	Env               []string `yaml:"env,omitempty"`
-	Contain           string   `yaml:"contain,omitempty"`
-	NotContain        string   `yaml:"not_contain,omitempty"`
+
+	// Output Text Checker
+	probe.TextChecker `yaml:",inline"`
 
 	BastionID string    `yaml:"bastion"`
 	bastion   *Endpoint `yaml:"-"`
@@ -142,7 +143,8 @@ func (s *Server) DoProbe() (bool, string) {
 		status = false
 		message = err.Error() + " - " + output
 	} else {
-		if err := probe.CheckOutput(s.Contain, s.NotContain, string(output)); err != nil {
+		log.Debugf("[%s / %s] - %s", s.ProbeKind, s.ProbeName, s.TextChecker.String())
+		if err := s.Check(string(output)); err != nil {
 			log.Errorf("[%s / %s] - %v", s.ProbeKind, s.ProbeName, err)
 			message = fmt.Sprintf("Error: %v", err)
 			status = false

--- a/probe/ssh/ssh_test.go
+++ b/probe/ssh/ssh_test.go
@@ -27,6 +27,7 @@ import (
 
 	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/probe"
 	"github.com/megaease/easeprobe/probe/base"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/crypto/ssh"
@@ -65,12 +66,14 @@ func createSSHConfig() *SSH {
 					Password:   "",
 					client:     &ssh.Client{},
 				},
-				Command:    "test",
-				Args:       []string{},
-				Env:        []string{},
-				Contain:    "good",
-				NotContain: "bad",
-				BastionID:  "aws",
+				Command: "test",
+				Args:    []string{},
+				Env:     []string{},
+				TextChecker: probe.TextChecker{
+					Contain:    "good",
+					NotContain: "bad",
+				},
+				BastionID: "aws",
 			},
 			{
 				DefaultProbe: base.DefaultProbe{


### PR DESCRIPTION
- add an options `regex:true|false` to indicate the `contain` and `not_contain` is regexp or not.
- create a `TextChecker` object to dedicate the checker configuration and logic
- embed the `TextChecker` into HTTP/Shell/SSH probe