### PR TITLE
bug-fix: Lark(Feishu) notifications don't work

### DIFF
--- a/notify/lark/lark.go
+++ b/notify/lark/lark.go
@@ -82,7 +82,7 @@ func (c *NotifyConfig) SendLarkNotification(msg string) error {
 	}
 	// Server returns {"Extra":null,"StatusCode":0,"StatusMessage":"success"} on success
 	// otherwise it returns {"code":9499,"msg":"Bad Request","data":{}}
-	if ret["StatusCode"] != "0" {
+	if statusCode, ok := ret["StatusCode"].(float64); !ok || statusCode != 0 {
 		return fmt.Errorf("Error response from Lark [%d] - [%s]", int(ret["code"].(float64)), ret["msg"])
 	}
 	return nil

--- a/report/result.go
+++ b/report/result.go
@@ -230,7 +230,7 @@ func ToLark(r probe.Result) string {
 					"elements": [
 						{
 							"tag": "plain_text",
-							"content": %s
+							"content": "%s"
 						}
 					]
 				}

--- a/report/sla.go
+++ b/report/sla.go
@@ -405,7 +405,7 @@ func SLALark(probers []probe.Prober) string {
 					"elements": [
 						{
 							"tag": "plain_text",
-							"content": global.Prog
+							"content": "` + global.FooterString() + `"
 						}
 					]
 				}


### PR DESCRIPTION
This PR fix fails to send a notification to Lark(Feishu): `code: 9499, msg: bad request`.
This error is found in the Feishu document: https://open.feishu.cn/document/ukTMukTMukTM/ugjM14COyUjL4ITN
