### PR TITLE
feat: Support MySQL/Redis/MongoDB/PostgreSQL/Zookeeper Native Client  to check the data

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,12 +139,18 @@ On application startup, the configured probes are scheduled for their initial fi
   - **PostgreSQL**. Connect to PostgreSQL server and run `SELECT 1` SQL.
   - **Zookeeper**. Connect to Zookeeper server and run `get /` command.
 
+  Most of them are supported to check the data whether is stored correctly.
+
   ```YAML
   client:
-    - name: Kafka Native Client (local)
-      driver: "kafka"
-      host: "localhost:9093"
-      # mTLS
+    - name: MySQL Native Client (local)
+      driver: "mysql"
+      host: "localhost:3306"
+      user: "root"
+      password: "pass"
+      data: # Optional - Data to check
+        "database:table:column:id:100": "value"
+      # mTLS - Optional
       ca: /path/to/file.ca
       cert: /path/to/file.crt
       key: /path/to/file.key
@@ -741,6 +747,8 @@ host:
 ```
 
 ### 3.7 Native Client Probe Configuration
+
+Native Client probe using the SDK to communicate with the remote endpoint. And you can define multiple data, and EaseProbe would help to check the data whether is stored or not.
 
 ```YAML
 # Native Client Probe

--- a/README.md
+++ b/README.md
@@ -759,6 +759,8 @@ client:
     host: "localhost:3306"
     username: "root"
     password: "pass"
+    data:         # Optional
+      key: val    # Check that `key` exists and its value is `val`
 
   - name: MongoDB Native Client (local)
     driver: "mongo"

--- a/README.md
+++ b/README.md
@@ -749,6 +749,8 @@ client:
     driver: "redis"  # driver is redis
     host: "localhost:6379"  # server and port
     password: "abc123" # password
+    data:         # Optional
+      key: val    # Check that `key` exists and its value is `val`
     # mTLS
     ca: /path/to/file.ca
     cert: /path/to/file.crt
@@ -759,8 +761,10 @@ client:
     host: "localhost:3306"
     username: "root"
     password: "pass"
-    data:         # Optional
-      key: val    # Check that `key` exists and its value is `val`
+    data: # Optional, check the specific column value in the table
+      #  Usage: "database:table:column:primary_key:value" : "expected_value"
+      "test:product:name:id:1" : "iPhone X" # select name from test.product where id = 1
+      "test:employee:age:id:2" : 45 # select age from test.employee where id = 2
 
   - name: MongoDB Native Client (local)
     driver: "mongo"

--- a/README.md
+++ b/README.md
@@ -819,7 +819,9 @@ client:
     driver: "zookeeper"
     host: "localhost:2181"
     timeout: 5s
-    # mTLS
+    data: # Optional, check the specific value in the path
+      "/path/to/key": "value" # Check that the value of the `/path/to/key` is "value"
+    # mTLS - Optional
     ca: /path/to/file.ca
     cert: /path/to/file.crt
     key: /path/to/file.key

--- a/README.md
+++ b/README.md
@@ -751,7 +751,7 @@ client:
     password: "abc123" # password
     data:         # Optional
       key: val    # Check that `key` exists and its value is `val`
-    # mTLS
+    # mTLS - Optional
     ca: /path/to/file.ca
     cert: /path/to/file.crt
     key: /path/to/file.key
@@ -763,8 +763,14 @@ client:
     password: "pass"
     data: # Optional, check the specific column value in the table
       #  Usage: "database:table:column:primary_key:value" : "expected_value"
+      #         transfer to : "SELECT column FROM database.table WHERE primary_key = value"
+      #         the `value` for `primary_key` must be int
       "test:product:name:id:1" : "EaseProbe" # select name from test.product where id = 1
       "test:employee:age:id:2" : 45          # select age from test.employee where id = 2
+    # mTLS - Optional
+    ca: /path/to/file.ca
+    cert: /path/to/file.crt
+    key: /path/to/file.key
 
   - name: MongoDB Native Client (local)
     driver: "mongo"
@@ -788,7 +794,7 @@ client:
   - name: Kafka Native Client (local)
     driver: "kafka"
     host: "localhost:9093"
-    # mTLS
+    # mTLS - Optional
     ca: /path/to/file.ca
     cert: /path/to/file.crt
     key: /path/to/file.key
@@ -798,6 +804,16 @@ client:
     host: "localhost:5432"
     username: "postgres"
     password: "pass"
+    data: # Optional, check the specific column value in the table
+      #  Usage: "database:table:column:primary_key:value" : "expected_value"
+      #         transfer to : "SELECT column FROM table WHERE primary_key = value"
+      #         the `value` for `primary_key` must be int
+      "test:product:name:id:1" : "EaseProbe" # select name from product where id = 1
+      "test:employee:age:id:2" : 45          # select age from employee where id = 2
+    # mTLS - Optional
+    ca: /path/to/file.ca
+    cert: /path/to/file.crt
+    key: /path/to/file.key
 
   - name: Zookeeper Native Client (local)
     driver: "zookeeper"

--- a/README.md
+++ b/README.md
@@ -780,8 +780,8 @@ client:
     timeout: 5s
     data: # Optional, find the specific value in the table
       #  Usage: "database:collection" : "{JSON}"
-      "test.employee" : '{"name":"Hao Chen"}' # find the employee with name "Hao Chen"
-      "test.product" : '{"name":"EaseProbe"}' # find the product with name "EaseProbe"
+      "test:employee" : '{"name":"Hao Chen"}' # find the employee with name "Hao Chen"
+      "test:product" : '{"name":"EaseProbe"}' # find the product with name "EaseProbe"
 
   - name: Memcache Native Client (local)
     driver: "memcache"

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ On application startup, the configured probes are scheduled for their initial fi
   - **PostgreSQL**. Connect to PostgreSQL server and run `SELECT 1` SQL.
   - **Zookeeper**. Connect to Zookeeper server and run `get /` command.
 
-  Most of them are supported to check the data whether is stored correctly.
+  Most of the clients support the additional validity check of data pulled from the service (such as checking a redis or memcache key for specific values). Check the documentation of the corresponding client for details on how to enable.
 
   ```YAML
   client:
@@ -766,7 +766,7 @@ host:
 
 ### 3.7 Native Client Probe Configuration
 
-Native Client probe using the SDK to communicate with the remote endpoint. And you can define multiple data, and EaseProbe would help to check the data whether is stored or not.
+Native Client probe uses the native GO SDK to communicate with the remote endpoints. Additionally to simple connectivity checks, you can also define key and data validity checks for EaseProbe, it will query for the given keys and verify the data stored on each service.
 
 ```YAML
 # Native Client Probe

--- a/README.md
+++ b/README.md
@@ -763,8 +763,8 @@ client:
     password: "pass"
     data: # Optional, check the specific column value in the table
       #  Usage: "database:table:column:primary_key:value" : "expected_value"
-      "test:product:name:id:1" : "iPhone X" # select name from test.product where id = 1
-      "test:employee:age:id:2" : 45 # select age from test.employee where id = 2
+      "test:product:name:id:1" : "EaseProbe" # select name from test.product where id = 1
+      "test:employee:age:id:2" : 45          # select age from test.employee where id = 2
 
   - name: MongoDB Native Client (local)
     driver: "mongo"
@@ -772,6 +772,10 @@ client:
     username: "admin"
     password: "abc123"
     timeout: 5s
+    data: # Optional, find the specific value in the table
+      #  Usage: "database:collection" : "{JSON}"
+      "test.employee" : '{"name":"Hao Chen"}' # find the employee with name "Hao Chen"
+      "test.product" : '{"name":"EaseProbe"}' # find the product with name "EaseProbe"
 
   - name: Memcache Native Client (local)
     driver: "memcache"

--- a/probe/client/client.go
+++ b/probe/client/client.go
@@ -47,12 +47,17 @@ func (c *Client) Config(gConf global.ProbeSettings) error {
 	tag := c.DriverType.String()
 	name := c.ProbeName
 	c.DefaultProbe.Config(gConf, kind, tag, name, c.Host, c.DoProbe)
+	if err := c.Check(); err != nil {
+		return err
+	}
 	c.configClientDriver()
-
-	if c.DriverType == conf.Unknown {
-		return fmt.Errorf("[%s / %s ] unknown driver type", kind, name)
+	if c.client == nil {
+		return fmt.Errorf("Unknown Client Driver")
 	}
 
+	if err := c.client.Config(gConf); err != nil {
+		return err
+	}
 	log.Debugf("[%s] configuration: %+v, %+v", c.ProbeKind, c, c.Result())
 	return nil
 }

--- a/probe/client/client.go
+++ b/probe/client/client.go
@@ -50,38 +50,34 @@ func (c *Client) Config(gConf global.ProbeSettings) error {
 	if err := c.Check(); err != nil {
 		return err
 	}
-	c.configClientDriver()
-	if c.client == nil {
-		return fmt.Errorf("Unknown Client Driver")
-	}
-
-	if err := c.client.Config(gConf); err != nil {
+	if err := c.configClientDriver(); err != nil {
 		return err
 	}
 	log.Debugf("[%s] configuration: %+v, %+v", c.ProbeKind, c, c.Result())
 	return nil
 }
 
-func (c *Client) configClientDriver() {
+func (c *Client) configClientDriver() (err error) {
 	switch c.DriverType {
 	case conf.MySQL:
-		c.client = mysql.New(c.Options)
+		c.client, err = mysql.New(c.Options)
 	case conf.Redis:
-		c.client = redis.New(c.Options)
+		c.client, err = redis.New(c.Options)
 	case conf.Memcache:
-		c.client = memcache.New(c.Options)
+		c.client, err = memcache.New(c.Options)
 	case conf.Mongo:
-		c.client = mongo.New(c.Options)
+		c.client, err = mongo.New(c.Options)
 	case conf.Kafka:
-		c.client = kafka.New(c.Options)
+		c.client, err = kafka.New(c.Options)
 	case conf.PostgreSQL:
-		c.client = postgres.New(c.Options)
+		c.client, err = postgres.New(c.Options)
 	case conf.Zookeeper:
-		c.client = zookeeper.New(c.Options)
+		c.client, err = zookeeper.New(c.Options)
 	default:
 		c.DriverType = conf.Unknown
+		err = fmt.Errorf("Unknown Driver Type")
 	}
-
+	return
 }
 
 // DoProbe return the checking result

--- a/probe/client/conf/conf.go
+++ b/probe/client/conf/conf.go
@@ -20,6 +20,8 @@ package conf
 import (
 	"encoding/json"
 	"fmt"
+	"net"
+	"strconv"
 	"strings"
 
 	"github.com/megaease/easeprobe/global"
@@ -29,6 +31,7 @@ import (
 // Driver Interface
 type Driver interface {
 	Kind() string
+	Config(global.ProbeSettings) error
 	Probe() (bool, string)
 }
 
@@ -71,6 +74,21 @@ type Options struct {
 
 	//TLS
 	global.TLS `yaml:",inline"`
+}
+
+// Check do the configuration check
+func (d *Options) Check() error {
+	_, port, err := net.SplitHostPort(d.Host)
+	if err != nil {
+		return fmt.Errorf("Invalid Host: %s. %v", d.Host, err)
+	}
+	if p, err := strconv.Atoi(port); err != nil || p < 1 || p > 65535 {
+		return fmt.Errorf("Invalid Port: %s", port)
+	}
+	if d.DriverType == Unknown {
+		return fmt.Errorf("Unknown driver")
+	}
+	return nil
 }
 
 // DriverTypeMap is the map of driver [name, driver]

--- a/probe/client/conf/conf.go
+++ b/probe/client/conf/conf.go
@@ -31,7 +31,6 @@ import (
 // Driver Interface
 type Driver interface {
 	Kind() string
-	Config(global.ProbeSettings) error
 	Probe() (bool, string)
 }
 

--- a/probe/client/conf/conf_test.go
+++ b/probe/client/conf/conf_test.go
@@ -67,3 +67,42 @@ func TestDirverType(t *testing.T) {
 	assert.Equal(t, "unknown", d.String())
 
 }
+
+func TestOptionsCheck(t *testing.T) {
+	opts := Options{
+		Host:       "localhost:3306",
+		DriverType: MySQL,
+	}
+	err := opts.Check()
+	assert.Nil(t, err)
+
+	opts.Host = "127.0.0.1:3306"
+	err = opts.Check()
+	assert.Nil(t, err)
+
+	opts.Host = "localhost:3306"
+	opts.DriverType = Unknown
+	err = opts.Check()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Unknown driver")
+
+	opts.Host = "localhost"
+	err = opts.Check()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Invalid Host")
+
+	opts.Host = "localhost:3306:1234"
+	err = opts.Check()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Invalid Host")
+
+	opts.Host = "10.10.10.1:asdf"
+	err = opts.Check()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Invalid Port")
+
+	opts.Host = "10.10.10.1:123456"
+	err = opts.Check()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Invalid Port")
+}

--- a/probe/client/kafka/kafka.go
+++ b/probe/client/kafka/kafka.go
@@ -20,8 +20,8 @@ package kafka
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 
-	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe/client/conf"
 	"github.com/segmentio/kafka-go"
 	"github.com/segmentio/kafka-go/sasl/plain"
@@ -39,30 +39,27 @@ type Kafka struct {
 }
 
 // New create a Kafka client
-func New(opt conf.Options) Kafka {
+func New(opt conf.Options) (*Kafka, error) {
 	tls, err := opt.TLS.Config()
 	if err != nil {
-		log.Errorf("[%s / %s / %s] - TLS Config error - %v", opt.ProbeKind, opt.ProbeName, opt.ProbeTag, err)
+		log.Errorf("[%s / %s / %s] - TLS Config Error - %v", opt.ProbeKind, opt.ProbeName, opt.ProbeTag, err)
+		return nil, fmt.Errorf("TLS Config Error - %v", err)
 	}
-	return Kafka{
+	k := &Kafka{
 		Options: opt,
 		tls:     tls,
 		Context: context.Background(),
 	}
+	return k, nil
 }
 
 // Kind return the name of client
-func (k Kafka) Kind() string {
+func (k *Kafka) Kind() string {
 	return Kind
 }
 
-// Config do the config check
-func (k Kafka) Config(gConf global.ProbeSettings) error {
-	return nil
-}
-
 // Probe do the health check
-func (k Kafka) Probe() (bool, string) {
+func (k *Kafka) Probe() (bool, string) {
 
 	var dialer *kafka.Dialer
 

--- a/probe/client/kafka/kafka.go
+++ b/probe/client/kafka/kafka.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"crypto/tls"
 
+	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe/client/conf"
 	"github.com/segmentio/kafka-go"
 	"github.com/segmentio/kafka-go/sasl/plain"
@@ -53,6 +54,11 @@ func New(opt conf.Options) Kafka {
 // Kind return the name of client
 func (k Kafka) Kind() string {
 	return Kind
+}
+
+// Config do the config check
+func (k Kafka) Config(gConf global.ProbeSettings) error {
+	return nil
 }
 
 // Probe do the health check

--- a/probe/client/kafka/kafka_test.go
+++ b/probe/client/kafka/kafka_test.go
@@ -41,6 +41,7 @@ func TestKaf(t *testing.T) {
 
 	kaf := New(conf)
 	assert.Equal(t, "Kafka", kaf.Kind())
+	assert.Nil(t, kaf.Config(global.ProbeSettings{}))
 
 	var dialer *kafka.Dialer
 	monkey.PatchInstanceMethod(reflect.TypeOf(dialer), "DialContext", func(_ *kafka.Dialer, _ context.Context, _ string, _ string) (*kafka.Conn, error) {

--- a/probe/client/kafka/kafka_test.go
+++ b/probe/client/kafka/kafka_test.go
@@ -39,9 +39,9 @@ func TestKaf(t *testing.T) {
 		TLS:        global.TLS{},
 	}
 
-	kaf := New(conf)
+	kaf, err := New(conf)
 	assert.Equal(t, "Kafka", kaf.Kind())
-	assert.Nil(t, kaf.Config(global.ProbeSettings{}))
+	assert.Nil(t, err)
 
 	var dialer *kafka.Dialer
 	monkey.PatchInstanceMethod(reflect.TypeOf(dialer), "DialContext", func(_ *kafka.Dialer, _ context.Context, _ string, _ string) (*kafka.Conn, error) {
@@ -79,9 +79,15 @@ func TestKafkaFailed(t *testing.T) {
 		},
 	}
 
-	kaf := New(conf)
+	kaf, err := New(conf)
 	//TLS failed
-	assert.Nil(t, kaf.tls)
+	assert.Nil(t, kaf)
+	assert.NotNil(t, err)
+
+	conf.TLS = global.TLS{}
+	kaf, err = New(conf)
+	assert.NotNil(t, kaf)
+	assert.Nil(t, err)
 	assert.Equal(t, "Kafka", kaf.Kind())
 
 	var dialer *kafka.Dialer

--- a/probe/client/memcache/memcache.go
+++ b/probe/client/memcache/memcache.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	MemcacheClient "github.com/bradfitz/gomemcache/memcache"
+	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe/client/conf"
 	log "github.com/sirupsen/logrus"
 )
@@ -47,6 +48,11 @@ func New(opt conf.Options) Memcache {
 // Kind return the name of client
 func (m Memcache) Kind() string {
 	return Kind
+}
+
+// Config do the config check
+func (m Memcache) Config(gConf global.ProbeSettings) error {
+	return nil
 }
 
 // Probe do the health check

--- a/probe/client/memcache/memcache.go
+++ b/probe/client/memcache/memcache.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	MemcacheClient "github.com/bradfitz/gomemcache/memcache"
-	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe/client/conf"
 	log "github.com/sirupsen/logrus"
 )
@@ -38,25 +37,20 @@ type Memcache struct {
 }
 
 // New create a Memcache client
-func New(opt conf.Options) Memcache {
-	return Memcache{
+func New(opt conf.Options) (*Memcache, error) {
+	return &Memcache{
 		Options: opt,
 		Context: context.Background(),
-	}
+	}, nil
 }
 
 // Kind return the name of client
-func (m Memcache) Kind() string {
+func (m *Memcache) Kind() string {
 	return Kind
 }
 
-// Config do the config check
-func (m Memcache) Config(gConf global.ProbeSettings) error {
-	return nil
-}
-
 // Probe do the health check
-func (m Memcache) Probe() (bool, string) {
+func (m *Memcache) Probe() (bool, string) {
 	// TODO: Add SASL AUTH and protocol details
 	mc := MemcacheClient.New(m.Host)
 	mc.Timeout = m.Timeout()

--- a/probe/client/memcache/memcache_test.go
+++ b/probe/client/memcache/memcache_test.go
@@ -25,7 +25,6 @@ import (
 
 	"bou.ke/monkey"
 	"github.com/bradfitz/gomemcache/memcache"
-	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe/client/conf"
 	"github.com/stretchr/testify/assert"
 )
@@ -37,9 +36,9 @@ func TestMemcache(t *testing.T) {
 		Data:       map[string]string{"sysconfig:event_active": "1"},
 	}
 
-	m := New(conf)
+	m, e := New(conf)
 	assert.Equal(t, "Memcache", m.Kind())
-	assert.Nil(t, m.Config(global.ProbeSettings{}))
+	assert.Nil(t, e)
 
 	// since memcached is not running
 	// confirm that we get error

--- a/probe/client/memcache/memcache_test.go
+++ b/probe/client/memcache/memcache_test.go
@@ -25,6 +25,7 @@ import (
 
 	"bou.ke/monkey"
 	"github.com/bradfitz/gomemcache/memcache"
+	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe/client/conf"
 	"github.com/stretchr/testify/assert"
 )
@@ -38,6 +39,7 @@ func TestMemcache(t *testing.T) {
 
 	m := New(conf)
 	assert.Equal(t, "Memcache", m.Kind())
+	assert.Nil(t, m.Config(global.ProbeSettings{}))
 
 	// since memcached is not running
 	// confirm that we get error

--- a/probe/client/mongo/mongo.go
+++ b/probe/client/mongo/mongo.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe/client/conf"
 	log "github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
@@ -81,6 +82,22 @@ func New(opt conf.Options) Mongo {
 // Kind return the name of client
 func (r Mongo) Kind() string {
 	return Kind
+}
+
+// Config do the config check
+func (r Mongo) Config(gConf global.ProbeSettings) error {
+	if len(r.Data) > 0 {
+		for k, v := range r.Data {
+			if _, _, err := getDBCollection(k); err != nil {
+				return err
+			}
+			var bdoc interface{}
+			if err := bson.UnmarshalExtJSON([]byte(v), true, &bdoc); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // Probe do the health check

--- a/probe/client/mongo/mongo.go
+++ b/probe/client/mongo/mongo.go
@@ -137,9 +137,9 @@ func getDBCollection(str string) (database, collection string, err error) {
 	if len(strings.TrimSpace(str)) == 0 {
 		return "", "", fmt.Errorf("Database Collection name is empty")
 	}
-	fields := strings.Split(str, ".")
+	fields := strings.Split(str, ":")
 	if len(fields) != 2 {
-		err = fmt.Errorf("invalid format - [%s] (syntax: database.collection) ", str)
+		err = fmt.Errorf("Invalid Format - [%s] (syntax: database.collection) ", str)
 		return
 	}
 	database = fields[0]

--- a/probe/client/mongo/mongo.go
+++ b/probe/client/mongo/mongo.go
@@ -92,17 +92,17 @@ func (r *Mongo) Kind() string {
 
 // checkData do the data checking
 func (r *Mongo) checkData() error {
-	if len(r.Data) > 0 {
-		for k, v := range r.Data {
-			if _, _, err := getDBCollection(k); err != nil {
-				return err
-			}
-			var bdoc interface{}
-			if err := bson.UnmarshalExtJSON([]byte(v), true, &bdoc); err != nil {
-				return err
-			}
+
+	for k, v := range r.Data {
+		if _, _, err := getDBCollection(k); err != nil {
+			return err
+		}
+		var bdoc interface{}
+		if err := bson.UnmarshalExtJSON([]byte(v), true, &bdoc); err != nil {
+			return err
 		}
 	}
+
 	return nil
 }
 

--- a/probe/client/mongo/mongo.go
+++ b/probe/client/mongo/mongo.go
@@ -20,9 +20,11 @@ package mongo
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/megaease/easeprobe/probe/client/conf"
 	log "github.com/sirupsen/logrus"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
@@ -49,6 +51,8 @@ func New(opt conf.Options) Mongo {
 		conn = fmt.Sprintf("mongodb://%s/?connectTimeoutMS=%d",
 			opt.Host, opt.Timeout().Milliseconds())
 	}
+
+	log.Debugf("[%s / %s / %s] - Connection - %s", opt.ProbeKind, opt.ProbeName, opt.ProbeTag, conn)
 
 	var maxConn uint64 = 1
 	client := options.Client().ApplyURI(conn)
@@ -92,15 +96,53 @@ func (r Mongo) Probe() (bool, string) {
 
 	defer db.Disconnect(ctx)
 
-	// Call Ping to verify that the deployment is up and the Client was
-	// configured successfully. As mentioned in the Ping documentation, this
-	// reduces application resiliency as the server may be temporarily
-	// unavailable when Ping is called.
-	err = db.Ping(ctx, readpref.Primary())
-	if err != nil {
-		return false, err.Error()
+	if len(r.Data) > 0 {
+		for key, value := range r.Data {
+			log.Debugf("[%s / %s / %s] - Verifying Data - [%s]: [%s]", r.ProbeKind, r.ProbeName, r.ProbeTag, key, value)
+			dbName, collectionName, err := getDBCollection(key)
+			if err != nil {
+				return false, fmt.Sprintf("[%s] Error - %v", key, err)
+			}
+			collection := db.Database(dbName).Collection(collectionName)
+			var bdoc interface{}
+			err = bson.UnmarshalExtJSON([]byte(value), true, &bdoc)
+			if err != nil {
+				return false, fmt.Sprintf("[%s] Error - %v", value, err)
+			}
+			result := collection.FindOne(ctx, bdoc)
+			if err := result.Err(); err != nil {
+				return false, fmt.Sprintf("Find [%s] Error - %v", value, err)
+			}
+			var doc bson.M
+			result.Decode(&doc)
+			log.Debugf("[%s / %s / %s] - Find [%s] - %+v", r.ProbeKind, r.ProbeName, r.ProbeTag, value, doc)
+			log.Debugf("[%s / %s / %s] - Data Verified Successfully - [%s]: [%s]", r.ProbeKind, r.ProbeName, r.ProbeTag, key, value)
+		}
+	} else {
+		// Call Ping to verify that the deployment is up and the Client was
+		// configured successfully. As mentioned in the Ping documentation, this
+		// reduces application resiliency as the server may be temporarily
+		// unavailable when Ping is called.
+		err = db.Ping(ctx, readpref.Primary())
+		if err != nil {
+			return false, err.Error()
+		}
 	}
 
 	return true, "Check MongoDB Server Successfully!"
 
+}
+
+func getDBCollection(str string) (database, collection string, err error) {
+	if len(strings.TrimSpace(str)) == 0 {
+		return "", "", fmt.Errorf("Database Collection name is empty")
+	}
+	fields := strings.Split(str, ".")
+	if len(fields) != 2 {
+		err = fmt.Errorf("invalid format - [%s] (syntax: database.collection) ", str)
+		return
+	}
+	database = fields[0]
+	collection = fields[1]
+	return
 }

--- a/probe/client/mongo/mongo_test.go
+++ b/probe/client/mongo/mongo_test.go
@@ -49,6 +49,7 @@ func TestMongo(t *testing.T) {
 
 	mg := New(conf)
 	assert.Equal(t, "Mongo", mg.Kind())
+	assert.Nil(t, mg.Config(global.ProbeSettings{}))
 	connStr := fmt.Sprintf("mongodb://%s:%s@%s/?connectTimeoutMS=%d",
 		conf.Username, conf.Password, conf.Host, conf.Timeout().Milliseconds())
 	assert.Equal(t, connStr, mg.ConnStr)
@@ -133,6 +134,8 @@ func TestDta(t *testing.T) {
 	}
 
 	mg := New(conf)
+	err := mg.Config(global.ProbeSettings{})
+	assert.NotNil(t, err)
 	s, m := mg.Probe()
 	assert.False(t, s)
 	assert.Contains(t, m, "Database Collection name is empty")
@@ -149,6 +152,8 @@ func TestDta(t *testing.T) {
 		"database:collection": "{'key' : 'value'}",
 	}
 	mg = New(conf)
+	err = mg.Config(global.ProbeSettings{})
+	assert.NotNil(t, err)
 	s, m = mg.Probe()
 	assert.False(t, s)
 	assert.Contains(t, m, "invalid JSON input")

--- a/probe/client/mysql/mysql.go
+++ b/probe/client/mysql/mysql.go
@@ -93,6 +93,7 @@ func (r MySQL) Probe() (bool, string) {
 			if err != nil {
 				return false, err.Error()
 			}
+			log.Debugf("[%s / %s / %s] - SQL - [%s]", r.ProbeKind, r.ProbeName, r.ProbeTag, sql)
 			rows, err := db.Query(sql)
 			if err != nil {
 				return false, err.Error()
@@ -127,6 +128,9 @@ func (r MySQL) Probe() (bool, string) {
 
 }
 
+// getSQL get the SQL statement
+// input: database:table:column:key:value
+// output: SELECT column FROM database.table WHERE key = value
 func (r MySQL) getSQL(str string) (string, error) {
 	if len(strings.TrimSpace(str)) == 0 {
 		return "", fmt.Errorf("Empty SQL data")

--- a/probe/client/mysql/mysql.go
+++ b/probe/client/mysql/mysql.go
@@ -75,7 +75,7 @@ func (r MySQL) Kind() string {
 // Config do the config check
 func (r MySQL) Config(gConf global.ProbeSettings) error {
 	if len(r.Data) > 0 {
-		for k, _ := range r.Data {
+		for k := range r.Data {
 			if _, err := r.getSQL(k); err != nil {
 				return err
 			}

--- a/probe/client/mysql/mysql.go
+++ b/probe/client/mysql/mysql.go
@@ -80,13 +80,13 @@ func (r *MySQL) Kind() string {
 
 // checkData do the data checking
 func (r *MySQL) checkData() error {
-	if len(r.Data) > 0 {
-		for k := range r.Data {
-			if _, err := r.getSQL(k); err != nil {
-				return err
-			}
+
+	for k := range r.Data {
+		if _, err := r.getSQL(k); err != nil {
+			return err
 		}
 	}
+
 	return nil
 }
 

--- a/probe/client/mysql/mysql.go
+++ b/probe/client/mysql/mysql.go
@@ -98,18 +98,21 @@ func (r MySQL) Probe() (bool, string) {
 			if err != nil {
 				return false, err.Error()
 			}
-			defer rows.Close()
 			if !rows.Next() {
+				rows.Close()
 				return false, fmt.Sprintf("No data found for [%s]", k)
 			}
 			//check the value is equal to the value in data
 			var value string
 			if err := rows.Scan(&value); err != nil {
+				rows.Close()
 				return false, err.Error()
 			}
 			if value != v {
+				rows.Close()
 				return false, fmt.Sprintf("Value not match for [%s] expected [%s] got [%s] ", k, v, value)
 			}
+			rows.Close()
 			log.Debugf("[%s / %s / %s] - Data Verified Successfully! - [%s] : [%s]", r.ProbeKind, r.ProbeName, r.ProbeTag, k, v)
 		}
 	} else {

--- a/probe/client/mysql/mysql.go
+++ b/probe/client/mysql/mysql.go
@@ -109,7 +109,7 @@ func (r MySQL) Probe() (bool, string) {
 			if value != v {
 				return false, fmt.Sprintf("Value not match for [%s] expected [%s] got [%s] ", k, v, value)
 			}
-			log.Debugf("[%s / %s / %s] - Verify Data Successfully! - [%s] : [%s]", r.ProbeKind, r.ProbeName, r.ProbeTag, k, v)
+			log.Debugf("[%s / %s / %s] - Data Verified Successfully! - [%s] : [%s]", r.ProbeKind, r.ProbeName, r.ProbeTag, k, v)
 		}
 	} else {
 		err = db.Ping()
@@ -133,7 +133,7 @@ func (r MySQL) getSQL(str string) (string, error) {
 	}
 	fields := strings.Split(str, ":")
 	if len(fields) != 5 {
-		return "", fmt.Errorf("Invalid SQL data - [%s], the pattern is `database:table:field:key:value`", str)
+		return "", fmt.Errorf("Invalid SQL data - [%s]. (syntax: database:table:field:key:value)", str)
 	}
 	db := fields[0]
 	table := fields[1]

--- a/probe/client/mysql/mysql.go
+++ b/probe/client/mysql/mysql.go
@@ -72,6 +72,18 @@ func (r MySQL) Kind() string {
 	return Kind
 }
 
+// Config do the config check
+func (r MySQL) Config(gConf global.ProbeSettings) error {
+	if len(r.Data) > 0 {
+		for k, _ := range r.Data {
+			if _, err := r.getSQL(k); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // Probe do the health check
 func (r MySQL) Probe() (bool, string) {
 

--- a/probe/client/mysql/mysql_test.go
+++ b/probe/client/mysql/mysql_test.go
@@ -50,6 +50,7 @@ func TestMySQL(t *testing.T) {
 	connStr := fmt.Sprintf("%s:%s@tcp(%s)/?timeout=%s",
 		conf.Username, conf.Password, conf.Host, conf.Timeout().Round(time.Second))
 	assert.Equal(t, connStr, my.ConnStr)
+	assert.Nil(t, my.Config(global.ProbeSettings{}))
 
 	conf.Password = ""
 	my = New(conf)
@@ -138,6 +139,8 @@ func TestData(t *testing.T) {
 		},
 	}
 	my := New(conf)
+	err := my.Config(global.ProbeSettings{})
+	assert.NotNil(t, err)
 	s, m := my.Probe()
 	assert.False(t, s)
 	assert.Contains(t, m, "Empty SQL data")

--- a/probe/client/postgres/postgres.go
+++ b/probe/client/postgres/postgres.go
@@ -81,14 +81,14 @@ func (r *PostgreSQL) Kind() string {
 
 // checkData do the data checking
 func (r *PostgreSQL) checkData() error {
-	if len(r.Data) > 0 {
-		for k := range r.Data {
-			_, _, err := r.getSQL(k)
-			if err != nil {
-				return err
-			}
+
+	for k := range r.Data {
+		_, _, err := r.getSQL(k)
+		if err != nil {
+			return err
 		}
 	}
+
 	return nil
 }
 

--- a/probe/client/postgres/postgres.go
+++ b/probe/client/postgres/postgres.go
@@ -97,17 +97,20 @@ func (r PostgreSQL) Probe() (bool, string) {
 				return false, fmt.Sprintf("Query error - [%s], %v", v, err)
 			}
 			if !rows.Next() {
-				return false, fmt.Sprintf("Query error - [%s], no data", v)
+				rows.Close()
+				return false, fmt.Sprintf("No data found for [%s]", k)
 			}
 			//check the value is equal to the value in data
 			var value string
 			if err := rows.Scan(&value); err != nil {
+				rows.Close()
 				return false, err.Error()
 			}
 			if value != v {
+				rows.Close()
 				return false, fmt.Sprintf("Value not match for [%s] expected [%s] got [%s] ", k, v, value)
 			}
-
+			rows.Close()
 			db.Close()
 			log.Debugf("[%s / %s / %s] - Data Verified Successfully! - [%s] : [%s]", r.ProbeKind, r.ProbeName, r.ProbeTag, k, v)
 		}

--- a/probe/client/postgres/postgres.go
+++ b/probe/client/postgres/postgres.go
@@ -74,6 +74,19 @@ func (r PostgreSQL) Kind() string {
 	return Kind
 }
 
+// Config do the config check
+func (r PostgreSQL) Config(gConf global.ProbeSettings) error {
+	if len(r.Data) > 0 {
+		for k, _ := range r.Data {
+			_, _, err := r.getSQL(k)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // Probe do the health check
 func (r PostgreSQL) Probe() (bool, string) {
 

--- a/probe/client/postgres/postgres.go
+++ b/probe/client/postgres/postgres.go
@@ -77,7 +77,7 @@ func (r PostgreSQL) Kind() string {
 // Config do the config check
 func (r PostgreSQL) Config(gConf global.ProbeSettings) error {
 	if len(r.Data) > 0 {
-		for k, _ := range r.Data {
+		for k := range r.Data {
 			_, _, err := r.getSQL(k)
 			if err != nil {
 				return err

--- a/probe/client/postgres/postgres_test.go
+++ b/probe/client/postgres/postgres_test.go
@@ -47,6 +47,7 @@ func TestPostgreSQL(t *testing.T) {
 
 	pg := New(conf)
 	assert.Equal(t, "PostgreSQL", pg.Kind())
+	assert.Nil(t, pg.Config(global.ProbeSettings{}))
 	pgd := pgdriver.NewConnector(pg.ClientOptions...)
 	assert.Equal(t, conf.Host, pgd.Config().Addr)
 	assert.Equal(t, conf.Username, pgd.Config().User)
@@ -129,6 +130,8 @@ func TestData(t *testing.T) {
 	}
 
 	pg := New(conf)
+	err := pg.Config(global.ProbeSettings{})
+	assert.NotNil(t, err)
 	s, m := pg.Probe()
 	assert.False(t, s)
 	assert.Contains(t, m, "Empty SQL data")

--- a/probe/client/postgres/postgres_test.go
+++ b/probe/client/postgres/postgres_test.go
@@ -116,3 +116,110 @@ func TestPostgreSQL(t *testing.T) {
 	monkey.UnpatchAll()
 
 }
+
+func TestData(t *testing.T) {
+	conf := conf.Options{
+		Host:       "example.com",
+		DriverType: conf.PostgreSQL,
+		Username:   "username",
+		Password:   "password",
+		Data: map[string]string{
+			"": "",
+		},
+	}
+
+	pg := New(conf)
+	s, m := pg.Probe()
+	assert.False(t, s)
+	assert.Contains(t, m, "Empty SQL data")
+
+	conf.Data = map[string]string{
+		"sql": "",
+	}
+	pg = New(conf)
+	s, m = pg.Probe()
+	assert.False(t, s)
+	assert.Contains(t, m, "Invalid SQL data")
+
+	conf.Data = map[string]string{
+		"database:table:column:key:value": "excepted",
+	}
+	pg = New(conf)
+	s, m = pg.Probe()
+	assert.False(t, s)
+	assert.Contains(t, m, "the value must be int")
+
+	monkey.Patch(sql.OpenDB, func(c driver.Connector) *sql.DB {
+		return &sql.DB{}
+	})
+	var db *sql.DB
+	monkey.PatchInstanceMethod(reflect.TypeOf(db), "Close", func(_ *sql.DB) error {
+		return nil
+	})
+	monkey.PatchInstanceMethod(reflect.TypeOf(db), "Query", func(_ *sql.DB, query string, args ...interface{}) (*sql.Rows, error) {
+		return &sql.Rows{}, nil
+	})
+	var r *sql.Rows
+	monkey.PatchInstanceMethod(reflect.TypeOf(r), "Close", func(_ *sql.Rows) error {
+		return nil
+	})
+	monkey.PatchInstanceMethod(reflect.TypeOf(r), "Next", func(_ *sql.Rows) bool {
+		return true
+	})
+	monkey.PatchInstanceMethod(reflect.TypeOf(r), "Scan", func(_ *sql.Rows, args ...interface{}) error {
+		v := args[0].(*string)
+		*v = "expected"
+		return nil
+	})
+
+	conf.Data = map[string]string{
+		"database:table:column:key:1": "expected",
+	}
+	pg = New(conf)
+	s, m = pg.Probe()
+	assert.True(t, s)
+	assert.Contains(t, m, "Successfully")
+
+	monkey.PatchInstanceMethod(reflect.TypeOf(r), "Scan", func(_ *sql.Rows, args ...interface{}) error {
+		v := args[0].(*string)
+		*v = "unexpected"
+		return nil
+	})
+	s, m = pg.Probe()
+	assert.False(t, s)
+	assert.Contains(t, m, "Value not match")
+
+	// scan error
+	monkey.PatchInstanceMethod(reflect.TypeOf(r), "Scan", func(_ *sql.Rows, args ...interface{}) error {
+		return fmt.Errorf("scan error")
+	})
+	s, m = pg.Probe()
+	assert.False(t, s)
+	assert.Contains(t, m, "scan error")
+
+	// next error
+	monkey.PatchInstanceMethod(reflect.TypeOf(r), "Next", func(_ *sql.Rows) bool {
+		return false
+	})
+	s, m = pg.Probe()
+	assert.False(t, s)
+	assert.Contains(t, m, "No data")
+
+	// query error
+	monkey.PatchInstanceMethod(reflect.TypeOf(db), "Query", func(_ *sql.DB, query string, args ...interface{}) (*sql.Rows, error) {
+		return nil, fmt.Errorf("query error")
+	})
+	s, m = pg.Probe()
+	assert.False(t, s)
+	assert.Contains(t, m, "query error")
+
+	// OpenDB error
+	monkey.Patch(sql.OpenDB, func(c driver.Connector) *sql.DB {
+		return nil
+	})
+	s, m = pg.Probe()
+	assert.False(t, s)
+	assert.Contains(t, m, "OpenDB error")
+
+	monkey.UnpatchAll()
+}

--- a/probe/client/redis/redis.go
+++ b/probe/client/redis/redis.go
@@ -83,7 +83,7 @@ func (r Redis) Probe() (bool, string) {
 			if val != v {
 				return false, fmt.Sprintf("Key [%s] expected [%s] got [%s]", k, v, val)
 			}
-			log.Debugf("[%s / %s / %s] Verify Data Successfully! key= [%s], value = [%s]", r.ProbeKind, r.ProbeName, r.ProbeTag, k, v)
+			log.Debugf("[%s / %s / %s] Data Verified Successfully! key= [%s], value = [%s]", r.ProbeKind, r.ProbeName, r.ProbeTag, k, v)
 		}
 	} else {
 		_, err := rdb.Ping(ctx).Result()

--- a/probe/client/redis/redis.go
+++ b/probe/client/redis/redis.go
@@ -75,7 +75,7 @@ func (r Redis) Probe() (bool, string) {
 	// Check if we need to query specific keys or not
 	if len(r.Data) > 0 {
 		for k, v := range r.Data {
-			log.Debugf("[%s / %s / %s] Verifying key= [%s], value = [%s]", r.ProbeKind, r.ProbeName, r.ProbeTag, k, v)
+			log.Debugf("[%s / %s / %s] Verifying Data -  key = [%s], value = [%s]", r.ProbeKind, r.ProbeName, r.ProbeTag, k, v)
 			val, err := rdb.Get(ctx, k).Result()
 			if err != nil {
 				return false, fmt.Sprintf("Get Key [%s] Error - %v", k, err)
@@ -83,7 +83,7 @@ func (r Redis) Probe() (bool, string) {
 			if val != v {
 				return false, fmt.Sprintf("Key [%s] expected [%s] got [%s]", k, v, val)
 			}
-			log.Debugf("[%s / %s / %s] Verify Successfully! key= [%s], value = [%s]", r.ProbeKind, r.ProbeName, r.ProbeTag, k, v)
+			log.Debugf("[%s / %s / %s] Verify Data Successfully! key= [%s], value = [%s]", r.ProbeKind, r.ProbeName, r.ProbeTag, k, v)
 		}
 	} else {
 		_, err := rdb.Ping(ctx).Result()

--- a/probe/client/redis/redis.go
+++ b/probe/client/redis/redis.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 
 	"github.com/go-redis/redis/v8"
-	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe/client/conf"
 	log "github.com/sirupsen/logrus"
 )
@@ -39,32 +38,29 @@ type Redis struct {
 }
 
 // New create a Redis client
-func New(opt conf.Options) Redis {
+func New(opt conf.Options) (*Redis, error) {
 
 	tls, err := opt.TLS.Config()
 	if err != nil {
-		log.Errorf("[%s / %s / %s] - TLS Config error - %v", opt.ProbeKind, opt.ProbeName, opt.ProbeTag, err)
+		log.Errorf("[%s / %s / %s] - TLS Config Error - %v", opt.ProbeKind, opt.ProbeName, opt.ProbeTag, err)
+		return nil, fmt.Errorf("TLS Config Error - %v", err)
 	}
 
-	return Redis{
+	r := Redis{
 		Options: opt,
 		tls:     tls,
 		Context: context.Background(),
 	}
+	return &r, nil
 }
 
 // Kind return the name of client
-func (r Redis) Kind() string {
+func (r *Redis) Kind() string {
 	return Kind
 }
 
-// Config do the config check
-func (r Redis) Config(gConf global.ProbeSettings) error {
-	return nil
-}
-
 // Probe do the health check
-func (r Redis) Probe() (bool, string) {
+func (r *Redis) Probe() (bool, string) {
 
 	rdb := redis.NewClient(&redis.Options{
 		Addr:        r.Host,

--- a/probe/client/redis/redis.go
+++ b/probe/client/redis/redis.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/go-redis/redis/v8"
+	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe/client/conf"
 	log "github.com/sirupsen/logrus"
 )
@@ -55,6 +56,11 @@ func New(opt conf.Options) Redis {
 // Kind return the name of client
 func (r Redis) Kind() string {
 	return Kind
+}
+
+// Config do the config check
+func (r Redis) Config(gConf global.ProbeSettings) error {
+	return nil
 }
 
 // Probe do the health check

--- a/probe/client/redis/redis_test.go
+++ b/probe/client/redis/redis_test.go
@@ -44,10 +44,17 @@ func TestRedis(t *testing.T) {
 		},
 	}
 
-	r := New(conf)
+	r, err := New(conf)
+	assert.Nil(t, r)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "TLS Config Error")
+
+	conf.TLS = global.TLS{}
+	r, err = New(conf)
+	assert.NotNil(t, r)
+	assert.Nil(t, err)
 	assert.Equal(t, "Redis", r.Kind())
 	assert.Nil(t, r.tls)
-	assert.Nil(t, r.Config(global.ProbeSettings{}))
 
 	var client *redis.Client
 	monkey.PatchInstanceMethod(reflect.TypeOf(client), "Ping", func(_ *redis.Client, ctx context.Context) *redis.StatusCmd {
@@ -70,7 +77,10 @@ func TestRedis(t *testing.T) {
 	monkey.PatchInstanceMethod(reflect.TypeOf(tc), "Config", func(_ *global.TLS) (*tls.Config, error) {
 		return &tls.Config{}, nil
 	})
-	r = New(conf)
+
+	r, err = New(conf)
+	assert.NotNil(t, r)
+	assert.Nil(t, err)
 	assert.NotNil(t, r.tls)
 
 	s, m = r.Probe()
@@ -100,7 +110,9 @@ func TestData(t *testing.T) {
 		},
 	}
 
-	r := New(conf)
+	r, err := New(conf)
+	assert.NotNil(t, r)
+	assert.Nil(t, err)
 
 	var client *redis.Client
 	monkey.PatchInstanceMethod(reflect.TypeOf(client), "Get", func(_ *redis.Client, ctx context.Context, key string) *redis.StringCmd {

--- a/probe/client/redis/redis_test.go
+++ b/probe/client/redis/redis_test.go
@@ -47,6 +47,7 @@ func TestRedis(t *testing.T) {
 	r := New(conf)
 	assert.Equal(t, "Redis", r.Kind())
 	assert.Nil(t, r.tls)
+	assert.Nil(t, r.Config(global.ProbeSettings{}))
 
 	var client *redis.Client
 	monkey.PatchInstanceMethod(reflect.TypeOf(client), "Ping", func(_ *redis.Client, ctx context.Context) *redis.StatusCmd {

--- a/probe/client/zookeeper/zookeeper.go
+++ b/probe/client/zookeeper/zookeeper.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/go-zookeeper/zk"
+	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe/client/conf"
 	log "github.com/sirupsen/logrus"
 )
@@ -55,6 +56,11 @@ func New(opt conf.Options) Zookeeper {
 // Kind return the name of client
 func (z Zookeeper) Kind() string {
 	return Kind
+}
+
+// Config do the config check
+func (z Zookeeper) Config(gConf global.ProbeSettings) error {
+	return nil
 }
 
 // Probe do the health check

--- a/probe/client/zookeeper/zookeeper.go
+++ b/probe/client/zookeeper/zookeeper.go
@@ -20,6 +20,7 @@ package zookeeper
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"time"
 
@@ -40,31 +41,34 @@ type Zookeeper struct {
 }
 
 // New create a Zookeeper client
-func New(opt conf.Options) Zookeeper {
+func New(opt conf.Options) (*Zookeeper, error) {
 	tls, err := opt.TLS.Config()
 	if err != nil {
-		log.Errorf("[%s / %s / %s] - TLS Config error - %v", opt.ProbeKind, opt.ProbeName, opt.ProbeTag, err)
+		log.Errorf("[%s / %s / %s] - TLS Config Error - %v", opt.ProbeKind, opt.ProbeName, opt.ProbeTag, err)
+		return nil, fmt.Errorf("TLS Config Error - %v", err)
 	}
 
-	return Zookeeper{
+	z := &Zookeeper{
 		Options: opt,
 		tls:     tls,
 		Context: context.Background(),
 	}
+
+	return z, nil
 }
 
 // Kind return the name of client
-func (z Zookeeper) Kind() string {
+func (z *Zookeeper) Kind() string {
 	return Kind
 }
 
 // Config do the config check
-func (z Zookeeper) Config(gConf global.ProbeSettings) error {
+func (z *Zookeeper) Config(gConf global.ProbeSettings) error {
 	return nil
 }
 
 // Probe do the health check
-func (z Zookeeper) Probe() (bool, string) {
+func (z *Zookeeper) Probe() (bool, string) {
 	var (
 		conn *zk.Conn
 		err  error
@@ -85,7 +89,7 @@ func (z Zookeeper) Probe() (bool, string) {
 	return true, "Check Zookeeper Server Successfully!"
 }
 
-func getDialer(z Zookeeper) func(network string, address string, _ time.Duration) (net.Conn, error) {
+func getDialer(z *Zookeeper) func(network string, address string, _ time.Duration) (net.Conn, error) {
 	if z.tls == nil {
 		return net.DialTimeout
 	}

--- a/probe/client/zookeeper/zookeeper_test.go
+++ b/probe/client/zookeeper/zookeeper_test.go
@@ -46,7 +46,15 @@ func TestZooKeeper(t *testing.T) {
 		},
 	}
 
-	z := New(conf)
+	z, e := New(conf)
+	assert.Nil(t, z)
+	assert.NotNil(t, e)
+	assert.Contains(t, e.Error(), "TLS Config Error")
+
+	conf.TLS = global.TLS{}
+	z, e = New(conf)
+	assert.NotNil(t, z)
+	assert.Nil(t, e)
 	assert.Equal(t, "ZooKeeper", z.Kind())
 	assert.Nil(t, z.Config(global.ProbeSettings{}))
 
@@ -74,7 +82,9 @@ func TestZooKeeper(t *testing.T) {
 	monkey.PatchInstanceMethod(reflect.TypeOf(tc), "Config", func(_ *global.TLS) (*tls.Config, error) {
 		return &tls.Config{}, nil
 	})
-	z = New(conf)
+	z, e = New(conf)
+	assert.NotNil(t, z)
+	assert.Nil(t, e)
 	assert.NotNil(t, z.tls)
 
 	s, m = z.Probe()
@@ -101,7 +111,7 @@ func TestZooKeeper(t *testing.T) {
 }
 
 func TestGetDialer(t *testing.T) {
-	zConf := Zookeeper{
+	zConf := &Zookeeper{
 		Options: conf.Options{
 			Host:       "127.0.0.0:2181",
 			DriverType: conf.Redis,

--- a/probe/client/zookeeper/zookeeper_test.go
+++ b/probe/client/zookeeper/zookeeper_test.go
@@ -48,6 +48,7 @@ func TestZooKeeper(t *testing.T) {
 
 	z := New(conf)
 	assert.Equal(t, "ZooKeeper", z.Kind())
+	assert.Nil(t, z.Config(global.ProbeSettings{}))
 
 	monkey.Patch(net.DialTimeout, func(network, address string, timeout time.Duration) (net.Conn, error) {
 		return &net.TCPConn{}, nil


### PR DESCRIPTION
## Redis

```yaml
client:
  - name: Redis Native Client (local)
    driver: "redis"  # driver is redis
    host: "localhost:6379"  # server and port
    data:         # Optional
      key: val    # Check that `key` exists and its value is `val`
```
## MySQL

```yaml
client
   - name: MySQL Native Client (local)
      driver: "mysql"
      host: "localhost:3306"
      data: # Optional, check the specific column value in the table
        #  Usage: "database:table:column:primary_key:value" : "expected_value"
        #         transfer to : "SELECT column FROM database.table WHERE primary_key = value"
        #         the `value` for `primary_key` must be int
        "test:product:name:id:1" : "EaseProbe" # select name from test.product where id = 1
        "test:employee:age:id:2" : 45          # select age from test.employee where id = 2

```
##  MongoDB

```yaml
client:
  - name: MongoDB Native Client (local)
    driver: "mongo"
    host: "localhost:27017"
    data: # Optional, find the specific value in the table
      #  Usage: "database:collection" : "{JSON}"
      "test:employee" : '{"name":"Hao Chen"}' # find the employee with name "Hao Chen"
      "test:product" : '{"name":"EaseProbe"}' # find the product with name "EaseProbe"
```
## PostgreSQL
```yaml
client:
  - name: PostgreSQL Native Client (local)
    driver: "postgres"
    host: "localhost:5432"
    data: # Optional, check the specific column value in the table
      #  Usage: "database:table:column:primary_key:value" : "expected_value"
      #         transfer to : "SELECT column FROM table WHERE primary_key = value"
      #         the `value` for `primary_key` must be int
      "test:product:name:id:1" : "EaseProbe" # select name from product where id = 1
      "test:employee:age:id:2" : 45          # select age from employee where id = 2
```

## Zookeeper

```yaml
client:
  - name: Zookeeper Native Client (local)
    driver: "zookeeper"
    host: "localhost:2181"
    data: # Optional, check the specific value in the path
      "/path/to/key": "value" # Check that the value of the `/path/to/key` is "value"
```