### PR TITLE
support the proxy for HTTP probe and can customized the User-Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,10 +548,16 @@ http:
   # A completed HTTP Probe configuration
   - name: Special Website
     url: https://megaease.cn
+    # Proxy setting, support sock5, http, https, for example:
+    #   proxy: http://proxy.server:8080
+    #   proxy: socks5://localhost:1085
+    #   proxy: https://user:password@proxy.example.com:443
+    proxy: http://proxy.server:8080
     # Request Method
     method: GET
     # Request Header
     headers:
+      User-Agent: Customized User-Agent # default: "MegaEase EaseProbe / v1.6.0"
       X-head-one: xxxxxx
       X-head-two: yyyyyy
       X-head-THREE: zzzzzzX-

--- a/probe/http/http.go
+++ b/probe/http/http.go
@@ -41,7 +41,7 @@ import (
 type HTTP struct {
 	base.DefaultProbe `yaml:",inline"`
 	URL               string            `yaml:"url"`
-	Proxy			 string            `yaml:"proxy"`
+	Proxy             string            `yaml:"proxy"`
 	ContentEncoding   string            `yaml:"content_encoding,omitempty"`
 	Method            string            `yaml:"method,omitempty"`
 	Headers           map[string]string `yaml:"headers,omitempty"`
@@ -113,8 +113,8 @@ func (h *HTTP) Config(gConf global.ProbeSettings) error {
 			if ok {
 				log.Debugf("[%s / %s] dial %s:%s", h.ProbeKind, h.ProbeName, network, addr)
 				tcpConn.SetLinger(0) // disable the default TCP delayed-close behavior,
-									 // which send the RST to the peer when the connection is closed.
-									 // this would remove the TIME_wAIT state of the TCP connection.
+				// which send the RST to the peer when the connection is closed.
+				// this would remove the TIME_wAIT state of the TCP connection.
 				return tcpConn, nil
 			}
 			return conn, nil
@@ -133,7 +133,7 @@ func (h *HTTP) Config(gConf global.ProbeSettings) error {
 	}
 
 	h.client = &http.Client{
-		Timeout: h.Timeout(),
+		Timeout:   h.Timeout(),
 		Transport: transport,
 	}
 

--- a/probe/http/http_test.go
+++ b/probe/http/http_test.go
@@ -82,6 +82,14 @@ func TestHTTPConfig(t *testing.T) {
 	assert.NotNil(t, h.TLS)
 	assert.Equal(t, "GET", h.Method)
 
+	h.Proxy = "http://uername:password@proxy.example.com:8080"
+	err = h.Config(global.ProbeSettings{})
+	assert.NoError(t, err)
+
+	h.Proxy = "\nexample.com"
+	err = h.Config(global.ProbeSettings{})
+	assert.Error(t, err)
+
 	monkey.UnpatchAll()
 }
 


### PR DESCRIPTION
close #176 

Support the http proxy setting and user-defined User-Agent

Example:

```yaml
http:
  - name: Youtube
    url: https://youtube.com
    proxy:  socks5://localhost:1085
    #proxy: https://user:password@proxy.example.com:443
    headers:
      User-Agent: Customized User-Agent
```