### PR TITLE
change log.Fatal to log.Error to make subsequent os.Exit executable

### DIFF
--- a/cmd/easeprobe/main.go
+++ b/cmd/easeprobe/main.go
@@ -85,7 +85,7 @@ func main() {
 
 	c, err := conf.New(yamlFile)
 	if err != nil {
-		log.Fatalln("Fatal: Cannot read the YAML configuration file!")
+		log.Errorln("Fatal: Cannot read the YAML configuration file!")
 		os.Exit(-1)
 	}
 
@@ -93,7 +93,7 @@ func main() {
 	if len(strings.TrimSpace(c.Settings.PIDFile)) > 0 {
 		d, err := daemon.NewPIDFile(c.Settings.PIDFile)
 		if err != nil {
-			log.Fatalf("Fatal: Cannot create the PID file: %s!", err)
+			log.Errorf("Fatal: Cannot create the PID file: %s!", err)
 			os.Exit(-1)
 		}
 		log.Infof("Successfully created the PID file: %s", d.PIDFile)


### PR DESCRIPTION
We use `log "github.com/sirupsen/logrus"` for log package:
https://github.com/megaease/easeprobe/blob/88fc4e4dbd0eb2f3d191bff6b7f8697ba85ed75f/cmd/easeprobe/main.go#L37
And we use version 1.9 (show in go.mod)
https://github.com/megaease/easeprobe/blob/88fc4e4dbd0eb2f3d191bff6b7f8697ba85ed75f/go.mod#L17

we use `os.Exit(-1)` after line 88 `log.Fatalln` and line 96 `log.Fatalf`
From [Fatalln doc](https://pkg.go.dev/github.com/sirupsen/logrus@v1.9.0#Fatalln):
> Fatalln logs a message at level Fatal on the standard logger then the process will exit with status set to 1.

So subsequent `os.Exit(-1)` will not executable.

Same with `log.Fatalf`.

So, here are 2 solutions:
option 1: just delete `os.Exit(-1)`;
option 2: change `log.Fatal` to `log.Error`

I think option 2 is more appropriate.

