### PR TITLE
Add more test cases

### DIFF
--- a/.github/workflows/code.yaml
+++ b/.github/workflows/code.yaml
@@ -11,7 +11,7 @@ on:
       - ".github/workflows/code.yml"
 
 env:
-  GO_VERSION: 1.18
+  GO_VERSION: 1.19
 
 jobs:
 
@@ -34,7 +34,7 @@ jobs:
       - name: Spelling Check
         uses: reviewdog/action-misspell@v1.12.2
       - name: Revive Action
-        uses: morphy2k/revive-action@v2.3.1
+        uses: morphy2k/revive-action@v2
       - name: "Restore Permissions"
         run: |
           sudo chown -R $(id -u) $GITHUB_WORKSPACE

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -160,7 +160,7 @@ func (c *Channel) WatchEvent(wg *sync.WaitGroup) {
 			log.Infof("[%s / %s]: %s (%s) - Status changed [%s] ==> [%s]",
 				kind, c.Name, result.Name, result.Endpoint, result.PreStatus, result.Status)
 			for _, n := range c.Notifiers {
-				if GetDryNotify() == true {
+				if IsDryNotify() == true {
 					n.DryNotify(result)
 				} else {
 					go n.Notify(result)

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package channel implements the channel interface
 package channel
 
 import (

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -159,7 +159,7 @@ func (c *Channel) WatchEvent(wg *sync.WaitGroup) {
 			log.Infof("[%s / %s]: %s (%s) - Status changed [%s] ==> [%s]",
 				kind, c.Name, result.Name, result.Endpoint, result.PreStatus, result.Status)
 			for _, n := range c.Notifiers {
-				if dryNotify {
+				if GetDryNotify() == true {
 					n.DryNotify(result)
 				} else {
 					go n.Notify(result)

--- a/channel/manager.go
+++ b/channel/manager.go
@@ -38,8 +38,8 @@ func SetDryNotify(dry bool) {
 	dryNotify.Store(dry)
 }
 
-// GetDryNotify returns the dry run flag
-func GetDryNotify() bool {
+// IsDryNotify returns the dry run flag
+func IsDryNotify() bool {
 	return dryNotify.Load().(bool)
 }
 

--- a/channel/manager.go
+++ b/channel/manager.go
@@ -19,6 +19,7 @@ package channel
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/megaease/easeprobe/notify"
 	"github.com/megaease/easeprobe/probe"
@@ -26,11 +27,16 @@ import (
 
 var channel = make(map[string]*Channel)
 var wg sync.WaitGroup
-var dryNotify bool
+var dryNotify atomic.Value
 
 // SetDryNotify sets the global dry run flag
 func SetDryNotify(dry bool) {
-	dryNotify = dry
+	dryNotify.Store(dry)
+}
+
+// GetDryNotify returns the dry run flag
+func GetDryNotify() bool {
+	return dryNotify.Load().(bool)
 }
 
 // GetAllChannels returns all channels
@@ -107,6 +113,7 @@ func GetNotifiers(channel []string) map[string]notify.Notify {
 
 // ConfigAllChannels config all channels
 func ConfigAllChannels() {
+	SetDryNotify(false)
 	for _, c := range channel {
 		c.Config()
 	}

--- a/channel/manager.go
+++ b/channel/manager.go
@@ -33,7 +33,6 @@ func init() {
 	SetDryNotify(false)
 }
 
-
 // SetDryNotify sets the global dry run flag
 func SetDryNotify(dry bool) {
 	dryNotify.Store(dry)

--- a/channel/manager.go
+++ b/channel/manager.go
@@ -29,6 +29,11 @@ var channel = make(map[string]*Channel)
 var wg sync.WaitGroup
 var dryNotify atomic.Value
 
+func init() {
+	SetDryNotify(false)
+}
+
+
 // SetDryNotify sets the global dry run flag
 func SetDryNotify(dry bool) {
 	dryNotify.Store(dry)

--- a/channel/manager.go
+++ b/channel/manager.go
@@ -113,7 +113,6 @@ func GetNotifiers(channel []string) map[string]notify.Notify {
 
 // ConfigAllChannels config all channels
 func ConfigAllChannels() {
-	SetDryNotify(false)
 	for _, c := range channel {
 		c.Config()
 	}

--- a/channel/manager_test.go
+++ b/channel/manager_test.go
@@ -188,7 +188,7 @@ func TestManager(t *testing.T) {
 
 	// test the dry notification
 	SetDryNotify(true)
-	assert.True(t, GetDryNotify())
+	assert.True(t, IsDryNotify())
 	for _, ch := range chs {
 		for _, p := range ch.Probers {
 			res := p.Probe()

--- a/channel/manager_test.go
+++ b/channel/manager_test.go
@@ -186,5 +186,16 @@ func TestManager(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 	assert.Equal(t, nGoroutine, runtime.NumGoroutine())
 
+	// test the dry notification
+	SetDryNotify(true)
+	assert.True(t, GetDryNotify())
+	for _, ch := range chs {
+		for _, p := range ch.Probers {
+			res := p.Probe()
+			assert.NotNil(t, res)
+			ch.Send(res)
+		}
+	}
+
 	AllDone()
 }

--- a/cmd/easeprobe/main.go
+++ b/cmd/easeprobe/main.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package main is the entry point for the easeprobe command.
 package main
 
 import (

--- a/cmd/easeprobe/main.go
+++ b/cmd/easeprobe/main.go
@@ -107,13 +107,10 @@ func main() {
 	// if dry notification mode is specified in command line, overwrite the configuration
 	if *dryNotify {
 		c.Settings.Notify.Dry = *dryNotify
+		log.Infoln("Dry Notification Mode...")
 	}
 	// set the dry notify flag to channel
 	channel.SetDryNotify(c.Settings.Notify.Dry)
-
-	if c.Settings.Notify.Dry {
-		log.Infoln("Dry Notification Mode...")
-	}
 
 	////////////////////////////////////////////////////////////////////////////
 	//                          Start the HTTP Server                         //

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package conf is the configuration of the application
 package conf
 
 import (

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package daemon is the daemon implementation.
 package daemon
 
 import (

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package eval is the package to eval the expression and extract the value from the document
 package eval
 
 import (

--- a/global/easeprobe.go
+++ b/global/easeprobe.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package global is the package for EaseProbe
 package global
 
 import (

--- a/metric/prometheus.go
+++ b/metric/prometheus.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package metric is the package to report the metrics to Prometheus
 package metric
 
 import (

--- a/notify/aws/conf.go
+++ b/notify/aws/conf.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package aws is the AWS notification package
 package aws
 
 import (

--- a/notify/base/base.go
+++ b/notify/base/base.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package base is the base implementation of the notification.
 package base
 
 import (

--- a/notify/dingtalk/dingtalk.go
+++ b/notify/dingtalk/dingtalk.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package dingtalk is the notification package for dingtalk.
 package dingtalk
 
 import (

--- a/notify/discord/discord.go
+++ b/notify/discord/discord.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package discord is the notification for Discord
 package discord
 
 import (

--- a/notify/email/email.go
+++ b/notify/email/email.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package email is the email notification package
 package email
 
 import (

--- a/notify/lark/lark.go
+++ b/notify/lark/lark.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package lark is the lark notification package.
 package lark
 
 import (

--- a/notify/log/format.go
+++ b/notify/log/format.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package log is the log package for easeprobe.
 package log
 
 import (

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package notify contains the notify implementation.
 package notify
 
 import (

--- a/notify/shell/shell.go
+++ b/notify/shell/shell.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package shell is the shell probe package
 package shell
 
 import (

--- a/notify/slack/slack.go
+++ b/notify/slack/slack.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package slack is the slack notification package.
 package slack
 
 import (

--- a/notify/sms/conf/conf.go
+++ b/notify/sms/conf/conf.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package conf is the configuration package for SMS notification
 package conf
 
 import (

--- a/notify/sms/nexmo/nexmo.go
+++ b/notify/sms/nexmo/nexmo.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package nexmo is the nexmo sms notification package
 package nexmo
 
 import (

--- a/notify/sms/sms.go
+++ b/notify/sms/sms.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package sms contains the sms implementation.
 package sms
 
 import (

--- a/notify/sms/twilio/twilio.go
+++ b/notify/sms/twilio/twilio.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package twilio is the twilio sms notification
 package twilio
 
 import (

--- a/notify/sms/yunpian/yunpian.go
+++ b/notify/sms/yunpian/yunpian.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package yunpian is the yunpian sms notification.
 package yunpian
 
 import (

--- a/notify/teams/teams.go
+++ b/notify/teams/teams.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package teams is the teams notification
 package teams
 
 import (

--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package telegram is the telegram notification package.
 package telegram
 
 import (

--- a/notify/wecom/wecom.go
+++ b/notify/wecom/wecom.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package wecom is the wecom notification package.
 package wecom
 
 import (

--- a/probe/base/base.go
+++ b/probe/base/base.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package base is the base package for all probes
 package base
 
 import (

--- a/probe/client/client.go
+++ b/probe/client/client.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package client is the native client probe package
 package client
 
 import (

--- a/probe/client/conf/conf.go
+++ b/probe/client/conf/conf.go
@@ -119,7 +119,11 @@ func (d *DriverType) DriverType(name string) DriverType {
 
 // MarshalYAML is marshal the driver type
 func (d DriverType) MarshalYAML() (interface{}, error) {
-	return d.String(), nil
+	v := d.String()
+	if v == "unknown" {
+		return nil, fmt.Errorf("Unknown driver")
+	}
+	return v, nil
 }
 
 // UnmarshalYAML is unmarshal the driver type
@@ -128,7 +132,9 @@ func (d *DriverType) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err := unmarshal(&s); err != nil {
 		return err
 	}
-	*d = d.DriverType(strings.ToLower(s))
+	if *d = d.DriverType(strings.ToLower(s)); *d == Unknown {
+		return fmt.Errorf("Unknown driver: %s", s)
+	}
 	return nil
 }
 
@@ -138,11 +144,17 @@ func (d *DriverType) UnmarshalJSON(b []byte) (err error) {
 	if err = json.Unmarshal(b, &s); err != nil {
 		return err
 	}
-	*d = d.DriverType(strings.ToLower(s))
+	if *d = d.DriverType(strings.ToLower(s)); *d == Unknown {
+		return fmt.Errorf("Unknown driver: %s", s)
+	}
 	return nil
 }
 
 // MarshalJSON is marshal the driver
 func (d DriverType) MarshalJSON() (b []byte, err error) {
-	return []byte(fmt.Sprintf(`"%s"`, d.String())), nil
+	v := d.String()
+	if v == "unknown" {
+		return nil, fmt.Errorf("Unknown driver")
+	}
+	return []byte(fmt.Sprintf(`"%s"`, v)), nil
 }

--- a/probe/client/conf/conf.go
+++ b/probe/client/conf/conf.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package conf is the configuration package for native client
 package conf
 
 import (

--- a/probe/client/kafka/kafka.go
+++ b/probe/client/kafka/kafka.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package kafka is the native client probe for kafka.
 package kafka
 
 import (

--- a/probe/client/memcache/memcache.go
+++ b/probe/client/memcache/memcache.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package memcache is the native client probe for memcache
 package memcache
 
 import (

--- a/probe/client/mongo/mongo.go
+++ b/probe/client/mongo/mongo.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package mongo implements a probe client for the MongoDB database.
 package mongo
 
 import (

--- a/probe/client/mysql/mysql.go
+++ b/probe/client/mysql/mysql.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package mysql is the client probe for MySQL.
 package mysql
 
 import (

--- a/probe/client/postgres/postgres.go
+++ b/probe/client/postgres/postgres.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package postgres is the native client probe for  PostgreSQL
 package postgres
 
 import (

--- a/probe/client/redis/redis.go
+++ b/probe/client/redis/redis.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package redis is the native client probe for Redis
 package redis
 
 import (

--- a/probe/client/zookeeper/zookeeper.go
+++ b/probe/client/zookeeper/zookeeper.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package zookeeper is the zookeeper client probe
 package zookeeper
 
 import (

--- a/probe/data_test.go
+++ b/probe/data_test.go
@@ -79,13 +79,13 @@ var testResults = []Result{
 }
 
 func newDataFile(file string) error {
-	makeAll(file)
+	makeAllDir(file)
 	SetResultsData(testResults)
 	return SaveDataToFile(file)
 }
 
 func newDataFileWithOutMeta(file string) error {
-	makeAll(file)
+	makeAllDir(file)
 	SetResultsData(testResults)
 	buf, err := yaml.Marshal(resultData)
 	if err != nil {
@@ -108,7 +108,7 @@ func removeDataFile(file string) {
 	os.Remove(file)
 }
 
-func makeAll(file string) {
+func makeAllDir(file string) {
 	dir, _ := filepath.Split(file)
 	os.MkdirAll(dir, 0755)
 }
@@ -142,7 +142,7 @@ func TestNewDataFile(t *testing.T) {
 
 	//custom data file
 	file = "x/y/z/mydata.yaml"
-	makeAll(file)
+	makeAllDir(file)
 	newDataFile(file)
 	assert.True(t, isDataFileExisted(file))
 	removeAll("x/")
@@ -185,7 +185,8 @@ func TestCleanDataFile(t *testing.T) {
 			t.Fatal(err)
 		}
 		files, _ := filepath.Glob(file + "-*")
-		fmt.Printf("n=%d, files=%v\n", n, files)
+		fmt.Printf("i=%d, files=%v\n", i, files)
+		time.Sleep(100 * time.Millisecond)
 	}
 	assert.Equal(t, n, numOfBackup(file))
 

--- a/probe/host/host.go
+++ b/probe/host/host.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package host is the host probe package
 package host
 
 import (

--- a/probe/http/http.go
+++ b/probe/http/http.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package http is the HTTP probe package.
 package http
 
 import (

--- a/probe/http/http_test.go
+++ b/probe/http/http_test.go
@@ -99,6 +99,13 @@ func TestHTTPConfig(t *testing.T) {
 	err = h.Config(global.ProbeSettings{})
 	assert.NoError(t, err)
 
+	var e *eval.Evaluator
+	monkey.PatchInstanceMethod(reflect.TypeOf(e), "Config", func(_ *eval.Evaluator) error {
+		return fmt.Errorf("Eval Config Error")
+	})
+	err = h.Config(global.ProbeSettings{})
+	assert.Error(t, err)
+
 	h.Proxy = "\nexample.com"
 	err = h.Config(global.ProbeSettings{})
 	assert.Error(t, err)

--- a/probe/probe.go
+++ b/probe/probe.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package probe contains the probe implementation.
 package probe
 
 import (

--- a/probe/result_test.go
+++ b/probe/result_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"bou.ke/monkey"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 )
@@ -211,6 +212,20 @@ func TestDebug(t *testing.T) {
 	if str != expected {
 		t.Errorf("%s != %s", str, expected)
 	}
+
+	monkey.Patch(json.Marshal, func(v interface{}) ([]byte, error) {
+		return nil, fmt.Errorf("marshal error")
+	})
+	monkey.Patch(json.MarshalIndent, func(v any, prefix string, indent string) ([]byte, error) {
+		return nil, fmt.Errorf("marshal error")
+	})
+
+	str = r.DebugJSON()
+	assert.Empty(t, str)
+	str = r.DebugJSONIndent()
+	assert.Empty(t, str)
+
+	monkey.UnpatchAll()
 }
 
 func TestSLAPercent(t *testing.T) {

--- a/probe/shell/shell.go
+++ b/probe/shell/shell.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package shell is the shell probe package
 package shell
 
 import (

--- a/probe/ssh/endpoint_test.go
+++ b/probe/ssh/endpoint_test.go
@@ -111,4 +111,11 @@ DX4y9QvXoaUiQ5vB63voiqRTBT4hTYBDVi2G7NEjIczNs9S8JQM5Mg52mZsdH77g6ChUPp
 	config, err = e.SSHConfig("ssh", "test", 30*time.Second)
 	assert.Nil(t, err)
 	assert.NotNil(t, config)
+
+	monkey.Patch(ioutil.ReadFile, func(filename string) ([]byte, error) {
+		return []byte(``), nil
+	})
+	config, err = e.SSHConfig("ssh", "test", 30*time.Second)
+	assert.Nil(t, config)
+	assert.NotNil(t, err)
 }

--- a/probe/ssh/ssh.go
+++ b/probe/ssh/ssh.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package ssh is the ssh probe package
 package ssh
 
 import (

--- a/probe/status.go
+++ b/probe/status.go
@@ -19,6 +19,7 @@ package probe
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/megaease/easeprobe/global"
@@ -84,29 +85,43 @@ func (s *Status) Emoji() string {
 // UnmarshalYAML is Unmarshal the status
 func (s *Status) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var status string
+	*s = StatusUnknown
 	if err := unmarshal(&status); err != nil {
 		return err
 	}
-	s.Status(status)
-	return nil
+	if val, ok := toStatus[strings.ToLower(status)]; ok {
+		*s = val
+		return nil
+	}
+	return fmt.Errorf("Unknown status: %s", status)
 }
 
 // MarshalYAML is Marshal the status
 func (s Status) MarshalYAML() (interface{}, error) {
-	return s.String(), nil
+	if val, ok := toString[s]; ok {
+		return val, nil
+	}
+	return "unknown", fmt.Errorf("Unknown status: %s", s)
 }
 
 // UnmarshalJSON is Unmarshal the status
 func (s *Status) UnmarshalJSON(b []byte) (err error) {
 	var str string
+	*s = StatusUnknown
 	if err = json.Unmarshal(b, &str); err != nil {
 		return err
 	}
-	s.Status(str)
-	return nil
+	if val, ok := toStatus[strings.ToLower(str)]; ok {
+		*s = val
+		return nil
+	}
+	return fmt.Errorf("Unknown status: %s", str)
 }
 
 // MarshalJSON is marshal the status
 func (s Status) MarshalJSON() (b []byte, err error) {
-	return json.Marshal(s.String())
+	if val, ok := toString[s]; ok {
+		return []byte(fmt.Sprintf(`"%s"`, val)), nil
+	}
+	return []byte("unknown"), fmt.Errorf("Unknown status: %s", s)
 }

--- a/probe/status_test.go
+++ b/probe/status_test.go
@@ -25,6 +25,54 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func testMarshalUnmarshal(t *testing.T, str string, status Status, good bool,
+	marshal func(in interface{}) ([]byte, error),
+	unmarshal func(in []byte, out interface{}) (err error)) {
+
+	var s Status
+	err := unmarshal([]byte(str), &s)
+	if good {
+		assert.Nil(t, err)
+		assert.Equal(t, status, s)
+	} else {
+		assert.Error(t, err)
+		assert.Equal(t, StatusUnknown, s)
+	}
+
+	buf, err := marshal(status)
+	if good {
+		assert.Nil(t, err)
+		assert.Equal(t, str, string(buf))
+	} else {
+		assert.Error(t, err)
+		assert.Nil(t, buf)
+	}
+}
+
+func testYamlJSON(t *testing.T, str string, status Status, good bool) {
+	testYaml(t, str+"\n", status, good)
+	testJSON(t, `"`+str+`"`, status, good)
+}
+func testYaml(t *testing.T, str string, status Status, good bool) {
+	testMarshalUnmarshal(t, str, status, good, yaml.Marshal, yaml.Unmarshal)
+}
+func testJSON(t *testing.T, str string, status Status, good bool) {
+	testMarshalUnmarshal(t, str, status, good, json.Marshal, json.Unmarshal)
+}
+
+func TestYamlJSON(t *testing.T) {
+	testYamlJSON(t, "init", StatusInit, true)
+	testYamlJSON(t, "up", StatusUp, true)
+	testYamlJSON(t, "down", StatusDown, true)
+	testYamlJSON(t, "unknown", StatusUnknown, true)
+	testYamlJSON(t, "bad", StatusBad, true)
+
+	testYamlJSON(t, "xxx", 10, false)
+
+	testYaml(t, "- xxx", 10, false)
+	testJSON(t, `{"x":"y"}`, 10, false)
+}
+
 func TestStatus(t *testing.T) {
 	s := StatusUp
 	assert.Equal(t, "up", s.String())
@@ -34,6 +82,10 @@ func TestStatus(t *testing.T) {
 	s.Status("up")
 	assert.Equal(t, StatusUp, s)
 	assert.Equal(t, "✅", s.Emoji())
+	s.Status("xxx")
+	assert.Equal(t, StatusUnknown, s)
+	s = 10
+	assert.Equal(t, "⛔️", s.Emoji())
 
 	err := yaml.Unmarshal([]byte("down"), &s)
 	assert.Nil(t, err)
@@ -48,7 +100,7 @@ func TestStatus(t *testing.T) {
 	assert.Equal(t, "\"down\"", string(buf))
 
 	err = yaml.Unmarshal([]byte("xxx"), &s)
-	assert.Nil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, StatusUnknown, s)
 
 	err = yaml.Unmarshal([]byte{1, 2}, &s)

--- a/probe/tcp/tcp.go
+++ b/probe/tcp/tcp.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package tcp is the tcp probe package
 package tcp
 
 import (

--- a/probe/tls/tls.go
+++ b/probe/tls/tls.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package tls is the tls probe package
 package tls
 
 import (

--- a/report/common_test.go
+++ b/report/common_test.go
@@ -18,9 +18,11 @@
 package report
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
+	"bou.ke/monkey"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -74,6 +76,14 @@ func TestJSONEscape(t *testing.T) {
 	expected = `hello\\nworld`
 	result = JSONEscape(`hello\nworld`)
 	assert.Equal(t, expected, result)
+
+	monkey.Patch(json.Marshal, func(v interface{}) ([]byte, error) {
+		return nil, fmt.Errorf("error")
+	})
+	expected = `{hello}`
+	result = JSONEscape(`{hello}`)
+	assert.Equal(t, expected, result)
+	monkey.UnpatchAll()
 }
 
 func TestAutoRefreshJS(t *testing.T) {

--- a/report/filter_test.go
+++ b/report/filter_test.go
@@ -104,10 +104,19 @@ func TestFilter(t *testing.T) {
 	assert.Equal(t, len(_probes), len(probes))
 	assert.Equal(t, _probes, probes)
 
+	filter.PageSize = -1
+	err := filter.Check()
+	assert.NotNil(t, err)
+
+	filter.PageNum = -1
+	err = filter.Check()
+	assert.NotNil(t, err)
+
+	filter = NewEmptyFilter()
 	// sla >= 60  && sla <= 40
 	filter.SLAGreater = 60
 	filter.SLALess = 40
-	err := filter.Check()
+	err = filter.Check()
 	assert.NotNil(t, err)
 	// sla >= 60  && sla <= 200
 	filter.SLALess = 200
@@ -255,5 +264,4 @@ func TestPage(t *testing.T) {
 	probes = filter.Filter(_probes)
 	assert.Equal(t, 1, len(probes))
 	assert.Equal(t, _probes[3], probes[0])
-
 }

--- a/report/sla.go
+++ b/report/sla.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package report is the package for SLA report
 package report
 
 import (

--- a/report/types_test.go
+++ b/report/types_test.go
@@ -65,3 +65,10 @@ func TestFormatYAML(t *testing.T) {
 	testFormatYAML(t, SMS, "sms\n")
 	testFormatYAML(t, Unknown, "unknown\n")
 }
+
+func TestBadFormat(t *testing.T) {
+	buf := ([]byte)("- asdf::")
+	var f Format
+	err := yaml.Unmarshal(buf, &f)
+	assert.NotNil(t, err)
+}

--- a/web/server.go
+++ b/web/server.go
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+// Package web is the web server of easeprobe.
 package web
 
 import (


### PR DESCRIPTION
Improvements
- Add test cases for the `channel`, `conf`, `report`, `probe` package
- Add test cases for the `ssh` and `http` probe
- Using go 1.19 for lint
- Using atomic for set/get `DryNotify` variable