### PR TITLE
custom host header

### DIFF
--- a/probe/http/http.go
+++ b/probe/http/http.go
@@ -188,7 +188,11 @@ func (h *HTTP) DoProbe() (bool, string) {
 	}
 	req.Header.Set("User-Agent", global.OrgProgVer)
 	for k, v := range h.Headers {
-		req.Header.Set(k, v)
+		if strings.EqualFold(k, "host") {
+			req.Host = v
+		} else {
+			req.Header.Set(k, v)
+		}
 	}
 
 	// client close the connection


### PR DESCRIPTION
 * https://pkg.go.dev/net/http#Request

	// For client requests, Host optionally overrides the Host
	// header to send. If empty, the Request.Write method uses
	// the value of URL.Host. Host may contain an international
	// domain name.
	Host string