### PR TITLE
Support the multiple YAML files

### DIFF
--- a/cmd/easeprobe/main.go
+++ b/cmd/easeprobe/main.go
@@ -75,10 +75,18 @@ func main() {
 	////////////////////////////////////////////////////////////////////////////
 
 	dryNotify := flag.Bool("d", os.Getenv("PROBE_DRY") == "true", "dry notification mode")
-	yamlFile := flag.String("f", getEnvOrDefault("PROBE_CONFIG", "config.yaml"), "configuration file")
+
+	var yamlFiles conf.FFlags
+	flag.Var(&yamlFiles, "f", "configuration file")
+
 	jsonSchema := flag.Bool("j", false, "show JSON schema")
 	version := flag.Bool("v", false, "prints version")
 	flag.Parse()
+
+	defaultYaml := getEnvOrDefault("PROBE_CONFIG", "config.yaml")
+	if len(yamlFiles) == 0 {
+		yamlFiles = append(yamlFiles, defaultYaml)
+	}
 
 	if *version {
 		showVersion()
@@ -94,7 +102,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	c, err := conf.New(yamlFile)
+	c, err := conf.New(yamlFiles)
 	if err != nil {
 		log.Errorln("Fatal: Cannot read the YAML configuration file!")
 		os.Exit(-1)

--- a/conf/conf_test.go
+++ b/conf/conf_test.go
@@ -674,6 +674,32 @@ func TestConfig(t *testing.T) {
 	monkey.UnpatchAll()
 }
 
+func TestConfigS(t *testing.T) {
+	myConf1 := confYAML
+	file1 := "./config_1.yaml"
+	err1 := writeConfig(file1, myConf1)
+	assert.Nil(t, err1)
+
+	myConf2 := confYAML
+	file2 := "./config_2.yaml"
+	err2 := writeConfig(file2, myConf2)
+	assert.Nil(t, err2)
+
+	ff := []string{file1, file2}
+	f := FFlags{}
+	f = ff
+
+	conf, err := New(f)
+
+	assert.Nil(t, err)
+	assert.Equal(t, 8, len(conf.HTTP))
+
+	os.RemoveAll(file1)
+	os.RemoveAll(file2)
+	os.RemoveAll("data")
+
+}
+
 func TestInitData(t *testing.T) {
 	c := Conf{}
 

--- a/docs/Manual.md
+++ b/docs/Manual.md
@@ -594,6 +594,15 @@ easeprobe -f path/to/config.yaml
 easeprobe -f https://example.com/config
 ```
 
+You can use multi `-f` parameters at the same time. 
+The all YAML files provide `HTTP` `TCP` `Shell` `Client` `TLS` configuration. 
+The first YAML file provides other configuration.
+
+```shell
+easeprobe -f path/to/config.yaml -f https://example.com/config
+```
+
+
 The following environment variables can be used to fine-tune the request to the configuration file
 
 * `HTTP_AUTHORIZATION`


### PR DESCRIPTION
#201 
I add some code to support the multiple YAML files. Now you can use multiple `-f` to split configuration. 
I am a new Golang user. Please review the code carefully.
Thanks.

