### PR TITLE
feat: support the failure/success threshold for probe

### DIFF
--- a/cmd/easeprobe/probe.go
+++ b/cmd/easeprobe/probe.go
@@ -30,8 +30,9 @@ import (
 
 func configProbers(probers []probe.Prober) []probe.Prober {
 	gProbeConf := global.ProbeSettings{
-		Interval: conf.Get().Settings.Probe.Interval,
-		Timeout:  conf.Get().Settings.Probe.Timeout,
+		Interval:                      conf.Get().Settings.Probe.Interval,
+		Timeout:                       conf.Get().Settings.Probe.Timeout,
+		StatusChangeThresholdSettings: conf.Get().Settings.Probe.StatusChangeThresholdSettings,
 	}
 	log.Debugf("Global Probe Configuration: %+v", gProbeConf)
 

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -94,8 +94,9 @@ type Notify struct {
 
 // Probe is the settings of prober
 type Probe struct {
-	Interval time.Duration `yaml:"interval" json:"interval,omitempty" jsonschema:"type=string,format=duration,title=Probe Interval,description=the interval of probe,default=1m"`
-	Timeout  time.Duration `yaml:"timeout" json:"timeout,omitempty" jsonschema:"type=string,format=duration,title=Probe Timeout,description=the timeout of probe,default=30s"`
+	Interval                             time.Duration `yaml:"interval" json:"interval,omitempty" jsonschema:"type=string,format=duration,title=Probe Interval,description=the interval of probe,default=1m"`
+	Timeout                              time.Duration `yaml:"timeout" json:"timeout,omitempty" jsonschema:"type=string,format=duration,title=Probe Timeout,description=the timeout of probe,default=30s"`
+	global.StatusChangeThresholdSettings `yaml:",inline" json:",inline"`
 }
 
 // SLAReport is the settings for SLA report

--- a/docs/Manual.md
+++ b/docs/Manual.md
@@ -627,8 +627,8 @@ The following example configurations illustrate the EaseProbe supported features
 
 - `timeout` - the maximum time to wait for the probe to complete. default: `30s`.
 - `interval` - the interval time to run the probe. default: `1m`.
-- `failure` - number of continuously failed probes needed to determine the status down, default: 1
-- `success` - number of continuously successful probes needed to determine the status up, default: 1
+- `failure` - number of consecutive failed probes needed to determine the status down, default: 1
+- `success` - number of consecutive successful probes needed to determine the status up, default: 1
 
 ## 7.1 HTTP Probe Configuration
 
@@ -1309,8 +1309,8 @@ settings:
   probe:
     timeout: 30s # the time out for all probes
     interval: 1m # probe every minute for all probes
-    failure: 2 # number of continuously failed probes needed to determine the status down, default: 1
-    success: 1 # number of continuously successful probes needed to determine the status up, default: 1
+    failure: 2 # number of consecutive failed probes needed to determine the status down, default: 1
+    success: 1 # number of consecutive successful probes needed to determine the status up, default: 1
 
 
   # easeprobe program running log file.

--- a/docs/Manual.md
+++ b/docs/Manual.md
@@ -627,7 +627,8 @@ The following example configurations illustrate the EaseProbe supported features
 
 - `timeout` - the maximum time to wait for the probe to complete. default: `30s`.
 - `interval` - the interval time to run the probe. default: `1m`.
-
+- `failure` - number of continuously failed probes needed to determine the status down, default: 1
+- `success` - number of continuously successful probes needed to determine the status down, default: 1
 
 ## 7.1 HTTP Probe Configuration
 
@@ -1308,6 +1309,9 @@ settings:
   probe:
     timeout: 30s # the time out for all probes
     interval: 1m # probe every minute for all probes
+    failure: 2 # number of continuously failed probes needed to determine the status down, default: 1
+    success: 1 # number of continuously successful probes needed to determine the status down, default: 1
+
 
   # easeprobe program running log file.
   log:

--- a/docs/Manual.md
+++ b/docs/Manual.md
@@ -628,7 +628,7 @@ The following example configurations illustrate the EaseProbe supported features
 - `timeout` - the maximum time to wait for the probe to complete. default: `30s`.
 - `interval` - the interval time to run the probe. default: `1m`.
 - `failure` - number of continuously failed probes needed to determine the status down, default: 1
-- `success` - number of continuously successful probes needed to determine the status down, default: 1
+- `success` - number of continuously successful probes needed to determine the status up, default: 1
 
 ## 7.1 HTTP Probe Configuration
 
@@ -1310,7 +1310,7 @@ settings:
     timeout: 30s # the time out for all probes
     interval: 1m # probe every minute for all probes
     failure: 2 # number of continuously failed probes needed to determine the status down, default: 1
-    success: 1 # number of continuously successful probes needed to determine the status down, default: 1
+    success: 1 # number of continuously successful probes needed to determine the status up, default: 1
 
 
   # easeprobe program running log file.

--- a/global/global.go
+++ b/global/global.go
@@ -64,6 +64,8 @@ const (
 	DefaultTimeOut = time.Second * 30
 	// DefaultChannelName  is the default wide channel name
 	DefaultChannelName = "__EaseProbe_Channel__"
+	// DefaultStatusChangeThresholdSetting is the threshold of status change
+	DefaultStatusChangeThresholdSetting = 1
 )
 
 const (

--- a/global/probe.go
+++ b/global/probe.go
@@ -22,9 +22,9 @@ import "time"
 // StatusChangeThresholdSettings is the settings for probe threshold
 type StatusChangeThresholdSettings struct {
 	// the failures threshold such as 2, 5
-	Failure int `yaml:"failure,omitempty" json:"failure,omitempty" jsonschema:"description=the failures threshold to change the status such as 3, 5,default=1"`
+	Failure int `yaml:"failure,omitempty" json:"failure,omitempty" jsonschema:"title=Failure Threshold,description=the failures threshold to change the status such as 3,default=1"`
 	// the success threshold such as 2, 5
-	Success int `yaml:"success,omitempty" json:"success,omitempty" jsonschema:"description=the success threshold to change the status such as 3, 5,default=1"`
+	Success int `yaml:"success,omitempty" json:"success,omitempty" jsonschema:"title=Success Threshold,description=the success threshold to change the status such as 2,default=1"`
 }
 
 // ProbeSettings is the global probe setting

--- a/global/probe.go
+++ b/global/probe.go
@@ -19,10 +19,19 @@ package global
 
 import "time"
 
+// StatusChangeThresholdSettings is the settings for probe threshold
+type StatusChangeThresholdSettings struct {
+	// the failures threshold such as 2, 5
+	Failure int `yaml:"failure,omitempty" json:"failure,omitempty" jsonschema:"description=the failures threshold to change the status such as 3, 5,default=1"`
+	// the success threshold such as 2, 5
+	Success int `yaml:"success,omitempty" json:"success,omitempty" jsonschema:"description=the success threshold to change the status such as 3, 5,default=1"`
+}
+
 // ProbeSettings is the global probe setting
 type ProbeSettings struct {
 	Interval time.Duration
 	Timeout  time.Duration
+	StatusChangeThresholdSettings
 }
 
 // NormalizeTimeOut return a normalized timeout value
@@ -33,4 +42,12 @@ func (p *ProbeSettings) NormalizeTimeOut(t time.Duration) time.Duration {
 // NormalizeInterval return a normalized time interval value
 func (p *ProbeSettings) NormalizeInterval(t time.Duration) time.Duration {
 	return normalize(p.Interval, t, 0, DefaultProbeInterval)
+}
+
+// NormalizeThreshold return a normalized threshold value
+func (p *ProbeSettings) NormalizeThreshold(t StatusChangeThresholdSettings) StatusChangeThresholdSettings {
+	return StatusChangeThresholdSettings{
+		Failure: normalize(p.Failure, t.Failure, 0, DefaultStatusChangeThresholdSetting),
+		Success: normalize(p.Success, t.Success, 0, DefaultStatusChangeThresholdSetting),
+	}
 }

--- a/global/probe_test.go
+++ b/global/probe_test.go
@@ -46,5 +46,67 @@ func TestProbe(t *testing.T) {
 	p.Interval = 20
 	r = p.NormalizeInterval(0)
 	assert.Equal(t, time.Duration(20), r)
+}
 
+func TestStatusChangeThresholdSettings(t *testing.T) {
+	p := ProbeSettings{}
+
+	r := p.NormalizeThreshold(StatusChangeThresholdSettings{})
+	assert.Equal(t, StatusChangeThresholdSettings{
+		Failure: DefaultStatusChangeThresholdSetting,
+		Success: DefaultStatusChangeThresholdSetting,
+	}, r)
+
+	p.Failure = 2
+	p.Success = 3
+
+	r = p.NormalizeThreshold(StatusChangeThresholdSettings{
+		Failure: 1,
+	})
+	assert.Equal(t, StatusChangeThresholdSettings{
+		Failure: 1,
+		Success: 3,
+	}, r)
+
+	r = p.NormalizeThreshold(StatusChangeThresholdSettings{
+		Success: 2,
+	})
+	assert.Equal(t, StatusChangeThresholdSettings{
+		Failure: 2,
+		Success: 2,
+	}, r)
+
+	r = p.NormalizeThreshold(StatusChangeThresholdSettings{
+		Failure: 5,
+		Success: 6,
+	})
+	assert.Equal(t, StatusChangeThresholdSettings{
+		Failure: 5,
+		Success: 6,
+	}, r)
+
+	r = p.NormalizeThreshold(StatusChangeThresholdSettings{
+		Failure: 0,
+	})
+	assert.Equal(t, StatusChangeThresholdSettings{
+		Failure: 2,
+		Success: 3,
+	}, r)
+
+	r = p.NormalizeThreshold(StatusChangeThresholdSettings{
+		Success: -1,
+	})
+	assert.Equal(t, StatusChangeThresholdSettings{
+		Failure: 2,
+		Success: 3,
+	}, r)
+
+	p.Failure = -1
+	r = p.NormalizeThreshold(StatusChangeThresholdSettings{
+		Failure: 0,
+	})
+	assert.Equal(t, StatusChangeThresholdSettings{
+		Failure: 1,
+		Success: 3,
+	}, r)
 }

--- a/probe/base/base.go
+++ b/probe/base/base.go
@@ -44,15 +44,16 @@ type ProbeFuncType func() (bool, string)
 
 // DefaultProbe is the default options for all probe
 type DefaultProbe struct {
-	ProbeKind         string        `yaml:"-" json:"-"`
-	ProbeTag          string        `yaml:"-" json:"-"`
-	ProbeName         string        `yaml:"name" json:"name" jsonschema:"required,title=Probe Name,description=the name of probe must be unique"`
-	ProbeChannels     []string      `yaml:"channels" json:"channels,omitempty" jsonschema:"title=Probe Channels,description=the channels of probe message need to send to"`
-	ProbeTimeout      time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" jsonschema:"type=string,format=duration,title=Probe Timeout,description=the timeout of probe"`
-	ProbeTimeInterval time.Duration `yaml:"interval,omitempty" json:"interval,omitempty" jsonschema:"type=string,format=duration,title=Probe Interval,description=the interval of probe"`
-	ProbeFunc         ProbeFuncType `yaml:"-" json:"-"`
-	ProbeResult       *probe.Result `yaml:"-" json:"-"`
-	metrics           *metrics      `yaml:"-" json:"-"`
+	ProbeKind                            string        `yaml:"-" json:"-"`
+	ProbeTag                             string        `yaml:"-" json:"-"`
+	ProbeName                            string        `yaml:"name" json:"name" jsonschema:"required,title=Probe Name,description=the name of probe must be unique"`
+	ProbeChannels                        []string      `yaml:"channels" json:"channels,omitempty" jsonschema:"title=Probe Channels,description=the channels of probe message need to send to"`
+	ProbeTimeout                         time.Duration `yaml:"timeout,omitempty" json:"timeout,omitempty" jsonschema:"type=string,format=duration,title=Probe Timeout,description=the timeout of probe"`
+	ProbeTimeInterval                    time.Duration `yaml:"interval,omitempty" json:"interval,omitempty" jsonschema:"type=string,format=duration,title=Probe Interval,description=the interval of probe"`
+	global.StatusChangeThresholdSettings `yaml:",inline" json:",inline"`
+	ProbeFunc                            ProbeFuncType `yaml:"-" json:"-"`
+	ProbeResult                          *probe.Result `yaml:"-" json:"-"`
+	metrics                              *metrics      `yaml:"-" json:"-"`
 }
 
 // Kind return the probe kind
@@ -85,6 +86,35 @@ func (d *DefaultProbe) Result() *probe.Result {
 	return d.ProbeResult
 }
 
+// LogTitle return the log title
+func (d *DefaultProbe) LogTitle() string {
+	if len(d.ProbeTag) > 0 {
+		return fmt.Sprintf("[%s / %s / %s]", d.ProbeKind, d.ProbeTag, d.ProbeName)
+	}
+	return fmt.Sprintf("[%s / %s]", d.ProbeKind, d.ProbeName)
+}
+
+// CheckStatusThreshold check the status threshold
+func (d *DefaultProbe) CheckStatusThreshold() probe.Status {
+	s := d.StatusChangeThresholdSettings
+	c := d.ProbeResult.Stat.StatusCounter
+	title := d.LogTitle()
+	log.Debugf(" %s - Status Threshold Checking - Current[%v], StatusCnt[%d], FailureThread[%d], SuccessThread[%d]",
+		title, c.CurrentStatus, c.StatusCount, s.Failure, s.Success)
+
+	if c.CurrentStatus == true && c.StatusCount >= s.Success {
+		log.Infof("%s - Status is UP! Meet the Success Threshold [%d/%d]", title, c.StatusCount, s.Success)
+		return probe.StatusUp
+	}
+	if c.CurrentStatus == false && c.StatusCount >= s.Failure {
+		log.Infof("%s - Status is DOWN! Meet the Failure Threshold [%d/%d]", title, c.StatusCount, s.Failure)
+		return probe.StatusDown
+	}
+	log.Infof("%s - Keep the Status as %s! Not meet the Threshold - Current[%v], StatusCnt[%d], FailureThread[%d], SuccessThread[%d]",
+		title, d.ProbeResult.PreStatus, c.CurrentStatus, c.StatusCount, s.Failure, s.Success)
+	return d.ProbeResult.PreStatus
+}
+
 // Config default config
 func (d *DefaultProbe) Config(gConf global.ProbeSettings,
 	kind, tag, name, endpoint string, fn ProbeFuncType) error {
@@ -96,20 +126,25 @@ func (d *DefaultProbe) Config(gConf global.ProbeSettings,
 
 	d.ProbeTimeout = gConf.NormalizeTimeOut(d.ProbeTimeout)
 	d.ProbeTimeInterval = gConf.NormalizeInterval(d.ProbeTimeInterval)
+	d.StatusChangeThresholdSettings = gConf.NormalizeThreshold(d.StatusChangeThresholdSettings)
 
 	d.ProbeResult = probe.NewResultWithName(name)
 	d.ProbeResult.Name = name
 	d.ProbeResult.Endpoint = endpoint
 
+	// Set the new length of the status counter
+	maxLen := d.StatusChangeThresholdSettings.Failure
+	if d.StatusChangeThresholdSettings.Success > maxLen {
+		maxLen = d.StatusChangeThresholdSettings.Success
+	}
+	d.ProbeResult.Stat.StatusCounter.SetMaxLen(maxLen)
+
+	// if there no channels, use the default channel
 	if len(d.ProbeChannels) == 0 {
 		d.ProbeChannels = append(d.ProbeChannels, global.DefaultChannelName)
 	}
 
-	if len(d.ProbeTag) > 0 {
-		log.Infof("Probe [%s / %s] - [%s] base options are configured!", d.ProbeKind, d.ProbeTag, d.ProbeName)
-	} else {
-		log.Infof("Probe [%s] - [%s] base options are configured!", d.ProbeKind, d.ProbeName)
-	}
+	log.Infof("Probe %s base options are configured!", d.LogTitle())
 
 	d.metrics = newMetrics(kind, tag)
 
@@ -130,20 +165,18 @@ func (d *DefaultProbe) Probe() probe.Result {
 
 	d.ProbeResult.RoundTripTime = time.Since(now)
 
-	status := probe.StatusUp
-	title := "Success"
-	if stat != true {
-		status = probe.StatusDown
-		title = "Error"
-	}
+	// check the status threshold
+	d.ProbeResult.Stat.StatusCounter.AppendStatus(stat, msg)
+	status := d.CheckStatusThreshold()
+	title := status.Title()
 
 	if len(d.ProbeTag) > 0 {
 		d.ProbeResult.Message = fmt.Sprintf("%s (%s/%s): %s", title, d.ProbeKind, d.ProbeTag, msg)
-		log.Debugf("[%s / %s / %s] - %s", d.ProbeKind, d.ProbeTag, d.ProbeName, msg)
 	} else {
 		d.ProbeResult.Message = fmt.Sprintf("%s (%s): %s", title, d.ProbeKind, msg)
-		log.Debugf("[%s / %s] - %s", d.ProbeKind, d.ProbeName, msg)
 	}
+
+	log.Debugf("%s - %s", d.LogTitle(), msg)
 
 	d.ProbeResult.PreStatus = d.ProbeResult.Status
 	d.ProbeResult.Status = status

--- a/probe/data_test.go
+++ b/probe/data_test.go
@@ -51,8 +51,9 @@ var testResults = []Result{
 				StatusUp:   70,
 				StatusDown: 30,
 			},
-			UpTime:   70 * time.Minute,
-			DownTime: 30 * time.Minute,
+			UpTime:        70 * time.Minute,
+			DownTime:      30 * time.Minute,
+			StatusCounter: *NewStatusCounter(1),
 		},
 	},
 	{
@@ -74,8 +75,9 @@ var testResults = []Result{
 				StatusUp:   270,
 				StatusDown: 30,
 			},
-			UpTime:   270 * time.Minute,
-			DownTime: 30 * time.Minute,
+			UpTime:        270 * time.Minute,
+			DownTime:      30 * time.Minute,
+			StatusCounter: *NewStatusCounter(2),
 		},
 	},
 }

--- a/probe/result.go
+++ b/probe/result.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/megaease/easeprobe/global"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -32,6 +33,7 @@ type Stat struct {
 	Status   map[Status]int64 `json:"status" yaml:"status"`
 	UpTime   time.Duration    `json:"uptime" yaml:"uptime"`
 	DownTime time.Duration    `json:"downtime" yaml:"downtime"`
+	StatusCounter
 }
 
 // Result is the status of health check
@@ -63,11 +65,12 @@ func NewResult() *Result {
 		LatestDownTime:   time.Time{},
 		RecoveryDuration: 0,
 		Stat: Stat{
-			Since:    time.Now().UTC(),
-			Total:    0,
-			Status:   map[Status]int64{},
-			UpTime:   0,
-			DownTime: 0,
+			Since:         time.Now().UTC(),
+			Total:         0,
+			Status:        map[Status]int64{},
+			UpTime:        0,
+			DownTime:      0,
+			StatusCounter: *NewStatusCounter(global.DefaultStatusChangeThresholdSetting),
 		},
 	}
 }
@@ -112,6 +115,7 @@ func (s *Stat) Clone() Stat {
 	}
 	dst.UpTime = s.UpTime
 	dst.DownTime = s.DownTime
+	dst.StatusCounter = s.StatusCounter.Clone()
 	return dst
 }
 

--- a/probe/result_test.go
+++ b/probe/result_test.go
@@ -47,11 +47,12 @@ func CreateTestResult() *Result {
 		LatestDownTime:   now.Add(-20 * time.Hour),
 		RecoveryDuration: 5 * time.Minute,
 		Stat: Stat{
-			Since:    now,
-			Total:    1000,
-			Status:   m,
-			UpTime:   50 * time.Second,
-			DownTime: 10 * time.Second,
+			Since:         now,
+			Total:         1000,
+			Status:        m,
+			UpTime:        50 * time.Second,
+			DownTime:      10 * time.Second,
+			StatusCounter: *NewStatusCounter(2),
 		},
 	}
 	return r
@@ -180,7 +181,7 @@ func TestDebug(t *testing.T) {
 	up := fmt.Sprintf("%d", StatusUp)
 	down := fmt.Sprintf("%d", StatusDown)
 
-	expected := `{"name":"Test Name","endpoint":"http://example.com","time":"2022-01-01T00:00:00Z","timestamp":1640995200,"rtt":30000000000,"status":"up","prestatus":"down","message":"This is a test message","latestdowntime":"2021-12-31T04:00:00Z","recoverytime":300000000000,"stat":{"since":"2022-01-01T00:00:00Z","total":1001,"status":{"` + up + `":51,"` + down + `":10},"uptime":1850000000000,"downtime":10000000000}}`
+	expected := `{"name":"Test Name","endpoint":"http://example.com","time":"2022-01-01T00:00:00Z","timestamp":1640995200,"rtt":30000000000,"status":"up","prestatus":"down","message":"This is a test message","latestdowntime":"2021-12-31T04:00:00Z","recoverytime":300000000000,"stat":{"since":"2022-01-01T00:00:00Z","total":1001,"status":{"1":51,"2":10},"uptime":1850000000000,"downtime":10000000000,"StatusHistory":[],"MaxLen":1,"CurrentStatus":true,"StatusCount":0}}`
 	if r.DebugJSON() != expected {
 		t.Errorf("%s != %s", r.DebugJSON(), expected)
 	}
@@ -204,7 +205,11 @@ func TestDebug(t *testing.T) {
             "` + down + `": 10
         },
         "uptime": 1850000000000,
-        "downtime": 10000000000
+        "downtime": 10000000000,
+        "StatusHistory": [],
+        "MaxLen": 1,
+        "CurrentStatus": true,
+        "StatusCount": 0
     }
 }`
 

--- a/probe/status.go
+++ b/probe/status.go
@@ -36,6 +36,13 @@ const (
 )
 
 var (
+	toTitle = map[Status]string{
+		StatusInit:    "Initialization",
+		StatusUp:      "Success",
+		StatusDown:    "Error",
+		StatusUnknown: "Unknown",
+		StatusBad:     "Bad",
+	}
 	toString = map[Status]string{
 		StatusInit:    "init",
 		StatusUp:      "up",
@@ -54,6 +61,14 @@ var (
 		StatusBad:     "🚫",
 	}
 )
+
+// Title convert the Status to title
+func (s Status) Title() string {
+	if val, ok := toTitle[s]; ok {
+		return val
+	}
+	return "Unknown"
+}
 
 // String convert the Status to string
 func (s Status) String() string {

--- a/probe/status_counter.go
+++ b/probe/status_counter.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package probe
+
+// StatusHistory is a history of status
+type StatusHistory struct {
+	Status  bool
+	Message string
+}
+
+// StatusCounter is the object to count the status
+type StatusCounter struct {
+	StatusHistory []StatusHistory // the status history
+	MaxLen        int             // the max length of the status history
+	CurrentStatus bool            // the current status
+	StatusCount   int             // the count of the same status
+}
+
+// NewStatusCounter return a StatusCounter object
+func NewStatusCounter(maxLen int) *StatusCounter {
+	threshold := &StatusCounter{
+		StatusHistory: make([]StatusHistory, 0),
+		MaxLen:        maxLen,
+		CurrentStatus: true,
+		StatusCount:   0,
+	}
+	return threshold
+}
+
+// AppendStatus appends the status
+func (s *StatusCounter) AppendStatus(status bool, message string) {
+
+	if status != s.CurrentStatus { // status change, reset the status count
+		s.StatusCount = 0
+		s.CurrentStatus = status
+	}
+	if s.StatusCount < s.MaxLen { // count the status if it is less than the max length
+		s.StatusCount++
+	}
+
+	h := StatusHistory{
+		Status:  status,
+		Message: message,
+	}
+	// append the status
+	s.StatusHistory = append(s.StatusHistory, h)
+
+	// pop up the first element
+	if len(s.StatusHistory) > s.MaxLen {
+		s.StatusHistory = s.StatusHistory[1:]
+	}
+}
+
+// SetMaxLen sets the max length of the status history
+func (s *StatusCounter) SetMaxLen(maxLen int) {
+	s.MaxLen = maxLen
+	if len(s.StatusHistory) > s.MaxLen {
+		s.StatusHistory = s.StatusHistory[len(s.StatusHistory)-s.MaxLen:]
+	}
+}
+
+// Clone returns a copy of the StatusThreshold
+func (s *StatusCounter) Clone() StatusCounter {
+	return StatusCounter{
+		StatusHistory: s.StatusHistory,
+		MaxLen:        s.MaxLen,
+		CurrentStatus: s.CurrentStatus,
+		StatusCount:   s.StatusCount,
+	}
+}

--- a/probe/status_counter_test.go
+++ b/probe/status_counter_test.go
@@ -52,4 +52,8 @@ func TestNewStatusCounter(t *testing.T) {
 
 	s1 := s.Clone()
 	assert.True(t, reflect.DeepEqual(s, &s1))
+
+	s1.SetMaxLen(2)
+	assert.Equal(t, 2, s1.MaxLen)
+	assert.Equal(t, 2, len(s1.StatusHistory))
 }

--- a/probe/status_counter_test.go
+++ b/probe/status_counter_test.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package probe
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewStatusCounter(t *testing.T) {
+	const Len = 3
+	s := NewStatusCounter(Len)
+	assert.Equal(t, Len, s.MaxLen)
+	assert.True(t, s.CurrentStatus)
+
+	for i := 1; i <= Len+2; i++ {
+		s.AppendStatus(false, "failure")
+		assert.False(t, s.CurrentStatus)
+		if i <= Len {
+			assert.Equal(t, i, s.StatusCount)
+		} else {
+			assert.Equal(t, Len, s.StatusCount)
+		}
+	}
+
+	for i := 1; i <= Len+2; i++ {
+		s.AppendStatus(true, "success")
+		assert.True(t, s.CurrentStatus)
+		if i <= Len {
+			assert.Equal(t, i, s.StatusCount)
+		} else {
+			assert.Equal(t, Len, s.StatusCount)
+		}
+	}
+
+	s1 := s.Clone()
+	assert.True(t, reflect.DeepEqual(s, &s1))
+}

--- a/probe/status_test.go
+++ b/probe/status_test.go
@@ -106,3 +106,23 @@ func TestStatus(t *testing.T) {
 	err = yaml.Unmarshal([]byte{1, 2}, &s)
 	assert.NotNil(t, err)
 }
+
+func TestStatusTitle(t *testing.T) {
+	s := StatusInit
+	assert.Equal(t, "Initialization", s.Title())
+
+	s = StatusUp
+	assert.Equal(t, "Success", s.Title())
+
+	s = StatusDown
+	assert.Equal(t, "Error", s.Title())
+
+	s = StatusUnknown
+	assert.Equal(t, "Unknown", s.Title())
+
+	s = StatusBad
+	assert.Equal(t, "Bad", s.Title())
+
+	s = -1
+	assert.Equal(t, "Unknown", s.Title())
+}

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -43,7 +43,7 @@
 #     # configuration
 #     timeout: 10s # default is 30 seconds
 #     failure: 2 # number of continuously failed probes needed to determine the status down, default: 1
-#     success: 1 # number of continuously successful probes needed to determine the status down , default: 1
+#     success: 1 # number of continuously successful probes needed to determine the status up , default: 1
 
 http: # http probes
   - name: EaseProbe Github
@@ -60,7 +60,7 @@ http: # http probes
 #     proxy: socks5://proxy.server:1080 # Optional. Only support socks5.
 #                                       # Also support the `ALL_PROXY` environment.
 #     failure: 2 # number of continuously failed probes needed to determine the status down, default: 1
-#     success: 1 # number of continuously successful probes needed to determine the status down, default: 1
+#     success: 1 # number of continuously successful probes needed to determine the status up, default: 1
 
 # --------------------- Shell Probe Configuration ---------------------
 #
@@ -391,7 +391,7 @@ notify:
 #     timeout: 30s # the time out for all probes
 #     interval: 1m # probe every minute for all probes
 #     failure: 2 # number of continuously failed probes needed to determine the status down, default: 1
-#     success: 1 # number of continuously successful probes needed to determine the status down, default: 1
+#     success: 1 # number of continuously successful probes needed to determine the status up, default: 1
 
 #   # easeprobe program running log file.
 #   log:

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -42,8 +42,8 @@
 #       expression: "x_time('//feed/updated') > '2022-07-01'" # the expression to evaluate.
 #     # configuration
 #     timeout: 10s # default is 30 seconds
-#     failure: 2 # number of continuously failed probes needed to determine the status down, default: 1
-#     success: 1 # number of continuously successful probes needed to determine the status up , default: 1
+#     failure: 2 # number of consecutive failed probes needed to determine the status down, default: 1
+#     success: 1 # number of consecutive successful probes needed to determine the status up , default: 1
 
 http: # http probes
   - name: EaseProbe Github
@@ -59,8 +59,8 @@ http: # http probes
 #     interval: 2m # default is 60 seconds
 #     proxy: socks5://proxy.server:1080 # Optional. Only support socks5.
 #                                       # Also support the `ALL_PROXY` environment.
-#     failure: 2 # number of continuously failed probes needed to determine the status down, default: 1
-#     success: 1 # number of continuously successful probes needed to determine the status up, default: 1
+#     failure: 2 # number of consecutive failed probes needed to determine the status down, default: 1
+#     success: 1 # number of consecutive successful probes needed to determine the status up, default: 1
 
 # --------------------- Shell Probe Configuration ---------------------
 #
@@ -390,8 +390,8 @@ notify:
 #   probe:
 #     timeout: 30s # the time out for all probes
 #     interval: 1m # probe every minute for all probes
-#     failure: 2 # number of continuously failed probes needed to determine the status down, default: 1
-#     success: 1 # number of continuously successful probes needed to determine the status up, default: 1
+#     failure: 2 # number of consecutive failed probes needed to determine the status down, default: 1
+#     success: 1 # number of consecutive successful probes needed to determine the status up, default: 1
 
 #   # easeprobe program running log file.
 #   log:

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -42,6 +42,8 @@
 #       expression: "x_time('//feed/updated') > '2022-07-01'" # the expression to evaluate.
 #     # configuration
 #     timeout: 10s # default is 30 seconds
+#     failure: 2 # number of continuously failed probes needed to determine the status down, default: 1
+#     success: 1 # number of continuously successful probes needed to determine the status down , default: 1
 
 http: # http probes
   - name: EaseProbe Github
@@ -57,6 +59,8 @@ http: # http probes
 #     interval: 2m # default is 60 seconds
 #     proxy: socks5://proxy.server:1080 # Optional. Only support socks5.
 #                                       # Also support the `ALL_PROXY` environment.
+#     failure: 2 # number of continuously failed probes needed to determine the status down, default: 1
+#     success: 1 # number of continuously successful probes needed to determine the status down, default: 1
 
 # --------------------- Shell Probe Configuration ---------------------
 #
@@ -386,6 +390,8 @@ notify:
 #   probe:
 #     timeout: 30s # the time out for all probes
 #     interval: 1m # probe every minute for all probes
+#     failure: 2 # number of continuously failed probes needed to determine the status down, default: 1
+#     success: 1 # number of continuously successful probes needed to determine the status down, default: 1
 
 #   # easeprobe program running log file.
 #   log:


### PR DESCRIPTION
This PR supports the failure/success threshold features - we can configure the number of continuously failed/successful probes to determine whether the endpoint status is DOWN or UP.

for example:

```yaml
probe:
    failure: 2 # number of consecutive failed probes needed to determine the status down, default: 1
    success: 1 # number of consecutive successful probes needed to determine the status down, default: 1
```


close #230 