### PR TITLE
bug-fixing: http probe report the unsupported document type

### DIFF
--- a/conf/merge_test.go
+++ b/conf/merge_test.go
@@ -34,7 +34,7 @@ import (
 // refer to https://github.com/golang/go/issues/51442
 // using the workaround to remove the directory by a retry loop
 func removeDir(dir string) {
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 100; i++ {
 		if err := os.RemoveAll(dir); err == nil {
 			return
 		}

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -20,6 +20,7 @@ package eval
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Knetic/govaluate"
@@ -68,6 +69,11 @@ func NewEvaluator(doc string, t DocType, exp string) *Evaluator {
 
 // Config is the function to config the evaluator
 func (e *Evaluator) Config() error {
+	// if Eval is not configured, do nothing
+	if e.DocType == Unsupported && len(strings.TrimSpace( e.Expression))<=0 {
+		return nil
+	}
+
 	e.configExtractor()
 	e.configEvalFunctions()
 	return nil

--- a/eval/eval.go
+++ b/eval/eval.go
@@ -20,7 +20,6 @@ package eval
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/Knetic/govaluate"
@@ -69,11 +68,6 @@ func NewEvaluator(doc string, t DocType, exp string) *Evaluator {
 
 // Config is the function to config the evaluator
 func (e *Evaluator) Config() error {
-	// if Eval is not configured, do nothing
-	if e.DocType == Unsupported && len(strings.TrimSpace( e.Expression))<=0 {
-		return nil
-	}
-
 	e.configExtractor()
 	e.configEvalFunctions()
 	return nil

--- a/probe/http/http.go
+++ b/probe/http/http.go
@@ -164,8 +164,11 @@ func (h *HTTP) Config(gConf global.ProbeSettings) error {
 		return err
 	}
 
-	if err := h.Evaluator.Config(); err != nil {
-		return err
+	// if the evaluator is set, config it
+	if h.Evaluator.DocType != eval.Unsupported && len(strings.TrimSpace(h.Evaluator.Expression)) > 0 {
+		if err := h.Evaluator.Config(); err != nil {
+			return err
+		}
 	}
 
 	h.metrics = newMetrics(kind, tag)

--- a/probe/http/http_test.go
+++ b/probe/http/http_test.go
@@ -18,6 +18,7 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"fmt"
@@ -25,6 +26,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"reflect"
 	"testing"
 
@@ -33,6 +35,7 @@ import (
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe"
 	"github.com/megaease/easeprobe/probe/base"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -68,9 +71,28 @@ func createHTTP() *HTTP {
 		},
 	}
 }
+
+func createSimpleHTTP() *HTTP {
+	return &HTTP{
+		DefaultProbe:    base.DefaultProbe{ProbeName: "dummy http"},
+		URL:             "http://localhost:8888",
+		ContentEncoding: "text/json",
+		Headers:         map[string]string{"header1": "value1", "header2": "value2", "Host": "host.com"},
+		Body:            "{ \"key1\": \"value1\", \"key2\": \"value2\" }",
+	}
+}
+
 func TestHTTPConfig(t *testing.T) {
-	h := createHTTP()
+	h := createSimpleHTTP()
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
 	err := h.Config(global.ProbeSettings{})
+	assert.NoError(t, err)
+	assert.NotContains(t, buf.String(), "Unsupported document type")
+	log.SetOutput(os.Stdout)
+
+	h = createHTTP()
+	err = h.Config(global.ProbeSettings{})
 	assert.Error(t, err)
 
 	//TLS config success


### PR DESCRIPTION
If http probe didn't configure the `eval/doc`,  EaseProbe would report the error - `Unsupported document type: unsupported`

This bug only can be reproduced after PR #192 

here is the fix - check if the `eval` configuration is not configured, then skip the eval configration.


