### PR TITLE
Optimizing the SLA Report

### DIFF
--- a/docs/Manual.md
+++ b/docs/Manual.md
@@ -1287,7 +1287,9 @@ settings:
   sla:
     #  minutely, hourly, daily, weekly (Sunday), monthly (Last Day), none
     schedule : "daily"
-    # UTC time, the format is 'hour:min:sec'. Ignored on hourly and minutely schedules
+    # the time to send the SLA report. Ignored on hourly and minutely schedules
+    # - the format is 'hour:min:sec'.
+    # - the timezone can be configured by `settings.timezone`
     time: "23:59"
     # SLA data persistence file path.
     # The default location is `$CWD/data/data.yaml`

--- a/docs/Manual.md
+++ b/docs/Manual.md
@@ -1289,7 +1289,7 @@ settings:
     schedule : "daily"
     # the time to send the SLA report. Ignored on hourly and minutely schedules
     # - the format is 'hour:min:sec'.
-    # - the timezone can be configured by `settings.timezone`
+    # - the timezone can be configured by `settings.timezone`, default is UTC.
     time: "23:59"
     # SLA data persistence file path.
     # The default location is `$CWD/data/data.yaml`

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -369,7 +369,7 @@ notify:
 #     schedule : "daily"
 #     # the time to send the SLA report. Ignored on hourly and minutely schedules
       # - the format is 'hour:min:sec'
-#     # - the timezone can be configured by `settings.timezone`
+#     # - the timezone can be configured by `settings.timezone`, default is UTC
 #     time: "23:59"
 #     # SLA data persistence file path.
 #     # The default location is `$CWD/data/data.yaml`

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -365,9 +365,11 @@ notify:
 
 #   # SLA Report schedule
 #   sla:
-#     #  daily, weekly (Sunday), monthly (Last Day), none
+#     #  minutely, hourly, daily, weekly (Sunday), monthly (Last Day), none
 #     schedule : "daily"
-#     # UTC time, the format is 'hour:min:sec'
+#     # the time to send the SLA report. Ignored on hourly and minutely schedules
+      # - the format is 'hour:min:sec'
+#     # - the timezone can be configured by `settings.timezone`
 #     time: "23:59"
 #     # SLA data persistence file path.
 #     # The default location is `$CWD/data/data.yaml`


### PR DESCRIPTION
The PR is the continuous work for  PR #236, which optimize the following works:

- [x] make the `minutely` schedule at exact `mm:00`
- [x] make the `hourly` schedule at  exact `hh:mm:00`
- [x] set the gocron timezone as configured timezone instead of hard code UTC. such as: `timezone:  "Asia/Shanghai"` in config.yaml, so that the log message would output the configured timezone for `NextRun()`.
- [x] restore a log message which would log the `NextRun()` time when EaseProbe start.