### PR TITLE
Embed git tags as Version into go binary, remove Slack `channel` field

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,6 +28,7 @@ builds:
       - arm64
     ldflags:
       - -s -w
+      - -X github.com/megaease/easeprobe/global.Ver={{ .Tag }}
       - -X github.com/megaease/easeprobe/pkg/version.RELEASE={{ .Tag }}
       - -X github.com/megaease/easeprobe/pkg/version.COMMIT={{.Commit}}
       - -X github.com/megaease/easeprobe/pkg/version.REPO=megaease/easeprobe

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,10 @@ MKFILE_DIR := $(dir $(MKFILE_PATH))
 RELEASE_DIR := ${MKFILE_DIR}/build/bin
 
 # Version
-RELEASE?=v0.1.0
+RELEASE_VER := $(shell git describe --tag --abbrev=0)
+
+# Go MOD
+GO_MOD := $(shell go list -m)
 
 # Git Related
 GIT_REPO_INFO=$(shell cd ${MKFILE_DIR} && git config --get remote.origin.url)
@@ -27,7 +30,7 @@ all: ${TARGET}
 ${TARGET}: ${SOURCE}
 	mkdir -p ${RELEASE_DIR}
 	go mod tidy
-	CGO_ENABLED=0 go build -a -ldflags '-s -w -extldflags "-static"' -o ${TARGET} github.com/megaease/easeprobe/cmd/easeprobe
+	CGO_ENABLED=0 go build -a -ldflags "-s -w -extldflags -static -X ${GO_MOD}/global.Ver=${RELEASE_VER}" -o ${TARGET} ${GO_MOD}/cmd/easeprobe
 
 build: all
 

--- a/global/global.go
+++ b/global/global.go
@@ -37,16 +37,19 @@ const (
 	Org = "MegaEase"
 	// DefaultProg is the program name
 	DefaultProg = "EaseProbe"
-	// Ver is the program version
-	Ver = "v1.7.0"
+	// DefaultIconURL is the default icon which used in Slack or Discord
+	DefaultIconURL = "https://megaease.com/favicon.png"
+)
 
+var (
+	// Ver is the program version
+	// It will be set by the build script
+	// go build -ldflags "-X github.com/megaease/easegress/pkg/global.Ver=1.0.0"
+	Ver = "v1.7.0"
 	//OrgProg combine organization and program
 	OrgProg = Org + " " + DefaultProg
 	//OrgProgVer combine organization and program and version
 	OrgProgVer = Org + " " + DefaultProg + "/" + Ver
-
-	// DefaultIconURL is the default icon which used in Slack or Discord
-	DefaultIconURL = "https://megaease.com/favicon.png"
 )
 
 const (

--- a/report/result.go
+++ b/report/result.go
@@ -162,7 +162,6 @@ func ToSlack(r probe.Result) string {
 
 	json := `
 	{
-		"channel": "Alert",
 		"text": "%s",
 		"blocks": [
 			{

--- a/report/sla.go
+++ b/report/sla.go
@@ -277,7 +277,6 @@ func SLASlackSection(r *probe.Result) string {
 func SLASlack(probers []probe.Prober) string {
 	summary := SLASummary(probers)
 	json := `{
-		"channel": "Report",
 		"text": "Overall SLA Report - ` + summary + ` ",
 		"blocks": [
 		{


### PR DESCRIPTION
- [x] Embed git tags as Version into go binary, 
- [x] Remove Slack hard code `channel` field to fix the old  `incoming webhook`.