### PR TITLE
feat: support ping (icmp) probe

### DIFF
--- a/conf/conf.go
+++ b/conf/conf.go
@@ -37,6 +37,7 @@ import (
 	"github.com/megaease/easeprobe/probe/client"
 	"github.com/megaease/easeprobe/probe/host"
 	"github.com/megaease/easeprobe/probe/http"
+	"github.com/megaease/easeprobe/probe/ping"
 	"github.com/megaease/easeprobe/probe/shell"
 	"github.com/megaease/easeprobe/probe/ssh"
 	"github.com/megaease/easeprobe/probe/tcp"
@@ -143,6 +144,7 @@ type Conf struct {
 	SSH      ssh.SSH         `yaml:"ssh" json:"ssh,omitempty" jsonschema:"title=SSH Probe,description=SSH Probe Configuration"`
 	TLS      []tls.TLS       `yaml:"tls" json:"tls,omitempty" jsonschema:"title=TLS Probe,description=TLS Probe Configuration"`
 	Host     host.Host       `yaml:"host" json:"host,omitempty" jsonschema:"title=Host Probe,description=Host Probe Configuration"`
+	Ping     []ping.Ping     `yaml:"ping" json:"ping,omitempty" jsonschema:"title=Ping Probe,description=Ping Probe Configuration"`
 	Notify   notify.Config   `yaml:"notify" json:"notify,omitempty" jsonschema:"title=Notification,description=Notification Configuration"`
 	Settings Settings        `yaml:"settings" json:"settings,omitempty" jsonschema:"title=Global Settings,description=EaseProbe Global configuration"`
 }

--- a/docs/Manual.md
+++ b/docs/Manual.md
@@ -896,6 +896,7 @@ ping:
     host: 127.0.0.1
     count: 5 # number of packets to send, default: 3
     lost: 0.2 # 20% lost percentage threshold, mark it down if the loss is greater than this, default: 0
+    privileged: true # if true, the ping will be executed with icmp, otherwise use udp, default: false
     timeout: 10s # default is 30 seconds
     interval: 2m # default is 60 seconds
 ```

--- a/docs/Manual.md
+++ b/docs/Manual.md
@@ -62,7 +62,7 @@ EaseProbe supports the following probing methods: **HTTP**, **TCP**, **TLS**, **
 Each probe is identified by the method it supports (eg `http`), a unique name (across all probes in the configuration file) and the method specific parameters.
 - **HTTP**. Checking the HTTP status code, Support mTLS, HTTP Basic Auth, and can set the Request Header/Body. ( [HTTP Probe Configuration](#71-http-probe-configuration) )
 - **TCP**. Just simply check whether the TCP connection can be established or not. ( [TCP Probe Configuration](#72-tcp-probe-configuration) )
-- **Ping**. Just simply check whether can be ping or not. ( [Ping Probe Configuration](#73-ping-probe-configuration) )
+- **Ping**. Just simply check whether can be pinged or not. ( [Ping Probe Configuration](#73-ping-probe-configuration) )
 - **Shell**. Run a Shell command and check the result. ( [Shell Command Probe Configuration](#74-shell-command-probe-configuration) )
 - **SSH**. Run a remote command via SSH and check the result. Support the bastion/jump server  ([SSH Command Probe Configuration](#75-ssh-command-probe-configuration))
 - **TLS**. Ping the remote endpoint, can probe for revoked or expired certificates ( [TLS Probe Configuration](#76-tls-probe-configuration) )

--- a/docs/Manual.md
+++ b/docs/Manual.md
@@ -588,6 +588,9 @@ And for the different Probers, the following metrics are available:
   - `max_rtt`: Maximum round-trip time in milliseconds
   - `avg_rtt`: Average round-trip time in milliseconds
   - `stddev_rtt`: Standard deviation of round-trip time in milliseconds
+  - `privileged`: Whether to use ICMP (`true`) or UDP (`false`) based ping probes, default `false`. 
+  
+Please note that `privileged: true` requires administrative privileges such as `root` (for more details see https://github.com/go-ping/ping#supported-operating-systems)
 
 - TLS Probe
   - `earliest_cert_expiry`: last TLS chain expiry in timestamp seconds

--- a/docs/Manual.md
+++ b/docs/Manual.md
@@ -896,7 +896,7 @@ ping:
     host: 127.0.0.1
     count: 5 # number of packets to send, default: 3
     lost: 0.2 # 20% lost percentage threshold, mark it down if the loss is greater than this, default: 0
-    privileged: true # if true, the ping will be executed with icmp, otherwise use udp, default: false
+    privileged: true # if true, the ping will be executed with icmp, otherwise use udp, default: false (Note: On Windows platform, this must be set to True)
     timeout: 10s # default is 30 seconds
     interval: 2m # default is 60 seconds
 ```

--- a/docs/Manual.md
+++ b/docs/Manual.md
@@ -40,13 +40,14 @@ EaseProbe is a simple, standalone, and lightweight tool that can do health/statu
     - [7.1.2 Complete HTTP Configuration](#712-complete-http-configuration)
     - [7.1.3 Expression Evaluation](#713-expression-evaluation)
   - [7.2 TCP Probe Configuration](#72-tcp-probe-configuration)
-  - [7.3 Shell Command Probe Configuration](#73-shell-command-probe-configuration)
-  - [7.4 SSH Command Probe Configuration](#74-ssh-command-probe-configuration)
-  - [7.5 TLS Probe Configuration](#75-tls-probe-configuration)
-  - [7.6 Host Resource Usage Probe Configuration](#76-host-resource-usage-probe-configuration)
-  - [7.7 Native Client Probe Configuration](#77-native-client-probe-configuration)
-  - [7.8 Notification Configuration](#78-notification-configuration)
-  - [7.9 Global Setting Configuration](#79-global-setting-configuration)
+  - [7.3 Ping Probe Configuration](#73-ping-probe-configuration)
+  - [7.4 Shell Command Probe Configuration](#74-shell-command-probe-configuration)
+  - [7.5 SSH Command Probe Configuration](#75-ssh-command-probe-configuration)
+  - [7.6 TLS Probe Configuration](#76-tls-probe-configuration)
+  - [7.7 Host Resource Usage Probe Configuration](#77-host-resource-usage-probe-configuration)
+  - [7.8 Native Client Probe Configuration](#78-native-client-probe-configuration)
+  - [7.9 Notification Configuration](#79-notification-configuration)
+  - [7.10 Global Setting Configuration](#710-global-setting-configuration)
 - [8. Tools](#8-tools)
   - [8.1 EaseProbe JSON Schema](#81-easeprobe-json-schema)
 
@@ -61,11 +62,12 @@ EaseProbe supports the following probing methods: **HTTP**, **TCP**, **TLS**, **
 Each probe is identified by the method it supports (eg `http`), a unique name (across all probes in the configuration file) and the method specific parameters.
 - **HTTP**. Checking the HTTP status code, Support mTLS, HTTP Basic Auth, and can set the Request Header/Body. ( [HTTP Probe Configuration](#71-http-probe-configuration) )
 - **TCP**. Just simply check whether the TCP connection can be established or not. ( [TCP Probe Configuration](#72-tcp-probe-configuration) )
-- **Shell**. Run a Shell command and check the result. ( [Shell Command Probe Configuration](#73-shell-command-probe-configuration) )
-- **SSH**. Run a remote command via SSH and check the result. Support the bastion/jump server  ([SSH Command Probe Configuration](#74-ssh-command-probe-configuration))
-- **TLS**. Ping the remote endpoint, can probe for revoked or expired certificates ( [TLS Probe Configuration](#75-tls-probe-configuration) )
-- **Host**. Run an SSH command on a remote host and check the CPU, Memory, and Disk usage. ( [Host Load Probe](#76-host-resource-usage-probe-configuration) )
-- **Client**. Currently, support the following native client. Support the mTLS. ( refer to: [Native Client Probe Configuration](#77-native-client-probe-configuration) )
+- **Ping**. Just simply check whether can be ping or not. ( [Ping Probe Configuration](#73-ping-probe-configuration) )
+- **Shell**. Run a Shell command and check the result. ( [Shell Command Probe Configuration](#74-shell-command-probe-configuration) )
+- **SSH**. Run a remote command via SSH and check the result. Support the bastion/jump server  ([SSH Command Probe Configuration](#75-ssh-command-probe-configuration))
+- **TLS**. Ping the remote endpoint, can probe for revoked or expired certificates ( [TLS Probe Configuration](#76-tls-probe-configuration) )
+- **Host**. Run an SSH command on a remote host and check the CPU, Memory, and Disk usage. ( [Host Load Probe](#77-host-resource-usage-probe-configuration) )
+- **Client**. Currently, support the following native client. Support the mTLS. ( refer to: [Native Client Probe Configuration](#78-native-client-probe-configuration) )
   - **MySQL**. Connect to the MySQL server and run the `SHOW STATUS` SQL.
   - **Redis**. Connect to the Redis server and run the `PING` command.
   - **Memcache**. Connect to a Memcache server and run the `version` command or check based on key/value checks.
@@ -126,7 +128,7 @@ And please be aware that the following configuration:
           interval: 10s # retry interval, default is 5s
     ```
 
-For a complete list of examples using all the notifications please check the [Notification Configuration](#78-notification-configuration) section.
+For a complete list of examples using all the notifications please check the [Notification Configuration](#79-notification-configuration) section.
 
 ## 2.1 Slack
 This notification method utilizes the Slack webhooks to deliver status updates as messages.
@@ -428,7 +430,7 @@ You can use the following URL query options for both HTML and JSON:
   - `gte`: filter the probers with SLA greater than or equal to the given percentage (ex. `?gte=50` filter only hosts with SLA percentage `>= 50%`)
   - `lte`:filter the probers with SLA less than or equal to the given percentage (ex. `?lte=90` filter only hosts with SLA percentage `<= 90%` )
 
-  Refer to the [Global Setting Configuration](#79-global-setting-configuration) to see how to configure the access log.
+  Refer to the [Global Setting Configuration](#710-global-setting-configuration) to see how to configure the access log.
 
 
 ## 3.3 SLA Data Persistence
@@ -447,7 +449,7 @@ sla:
     data: /path/to/data/file.yaml
 ```
 
-For more information, please check the [Global Setting Configuration](#79-global-setting-configuration)
+For more information, please check the [Global Setting Configuration](#710-global-setting-configuration)
 
 
 # 4. Channel
@@ -578,6 +580,15 @@ And for the different Probers, the following metrics are available:
   - `transfer_duration`: HTTP transfer duration in milliseconds
   - `total_duration`: HTTP total duration in milliseconds
 
+- Ping Probe
+  - `sent`: Number of sent packets
+  - `recv`: Number of received packets
+  - `loss`: Packet loss percentage
+  - `min_rtt`: Minimum round-trip time in milliseconds
+  - `max_rtt`: Maximum round-trip time in milliseconds
+  - `avg_rtt`: Average round-trip time in milliseconds
+  - `stddev_rtt`: Standard deviation of round-trip time in milliseconds
+
 - TLS Probe
   - `earliest_cert_expiry`: last TLS chain expiry in timestamp seconds
   - `last_chain_expiry_timestamp_seconds`: earliest TLS cert expiry in Unix time
@@ -596,7 +607,7 @@ The following snapshot is the Grafana panel for host CPU metrics
 
 ![](./grafana.demo.png)
 
-Refer to the [Global Setting Configuration](#79-global-setting-configuration) for further details on how to configure the HTTP server.
+Refer to the [Global Setting Configuration](#710-global-setting-configuration) for further details on how to configure the HTTP server.
 
 
 # 7. Configuration
@@ -877,7 +888,19 @@ tcp:
     host: kafka.server:9093
 ```
 
-## 7.3 Shell Command Probe Configuration
+## 7.3 Ping Probe Configuration
+
+```YAML
+ping:
+  - name: Localhost
+    host: 127.0.0.1
+    count: 5 # number of packets to send, default: 3
+    lost: 0.2 # 20% lost percentage threshold, mark it down if the lost greater than this, default: 0
+    timeout: 10s # default is 30 seconds
+    interval: 2m # default is 60 seconds
+```
+
+## 7.4 Shell Command Probe Configuration
 
 The shell command probe is used to execute a shell command and check the output.
 
@@ -923,7 +946,7 @@ shell:
 >
 > The Regular Expression supported refer to https://github.com/google/re2/wiki/Syntax
 
-## 7.4 SSH Command Probe Configuration
+## 7.5 SSH Command Probe Configuration
 
 SSH probe is similar to Shell probe.
 - Support Password and Private key authentication.
@@ -983,7 +1006,7 @@ ssh:
 >
 > The Regular Expression supported refer to https://github.com/google/re2/wiki/Syntax
 
-## 7.5 TLS Probe Configuration
+## 7.6 TLS Probe Configuration
 
 TLS ping to remote endpoint, can probe for revoked or expired certificates
 
@@ -1008,7 +1031,7 @@ tls:
     #   -----BEGIN CERTIFICATE-----
 ```
 
-## 7.6 Host Resource Usage Probe Configuration
+## 7.7 Host Resource Usage Probe Configuration
 
 The host resource usage probe allows for collecting information and alerting when certain resource utilization thresholds are exceeded.
 
@@ -1045,7 +1068,7 @@ host:
       key: /Users/user/.ssh/id_rsa
 ```
 
-## 7.7 Native Client Probe Configuration
+## 7.8 Native Client Probe Configuration
 
 Native Client probe uses the native GO SDK to communicate with the remote endpoints. Additionally to simple connectivity checks, you can also define key and data validity checks for EaseProbe, it will query for the given keys and verify the data stored on each service.
 
@@ -1135,7 +1158,7 @@ client:
 ```
 
 
-## 7.8 Notification Configuration
+## 7.9 Notification Configuration
 
 ```YAML
 # Notification Configuration
@@ -1252,7 +1275,7 @@ notify:
 >     ```
 
 
-## 7.9 Global Setting Configuration
+## 7.10 Global Setting Configuration
 
 ```YAML
 # Global settings for all probes and notifiers.

--- a/docs/Manual.md
+++ b/docs/Manual.md
@@ -895,7 +895,7 @@ ping:
   - name: Localhost
     host: 127.0.0.1
     count: 5 # number of packets to send, default: 3
-    lost: 0.2 # 20% lost percentage threshold, mark it down if the lost greater than this, default: 0
+    lost: 0.2 # 20% lost percentage threshold, mark it down if the loss is greater than this, default: 0
     timeout: 10s # default is 30 seconds
     interval: 2m # default is 60 seconds
 ```

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -53,7 +53,7 @@ The project principles, of EaseProbe' features are separated into two main categ
 
 ... with new notification backends been added constantly.
 
-## Roadmap 
+## Roadmap
 Some of the features that are planned/considered for 2022 can be broken down into three categories: *General*, *Probe*, *Notify*
 
 ### General
@@ -76,7 +76,7 @@ Some of the features that are planned/considered for 2022 can be broken down int
 
 ### Probes
 * [ ] add automatic service discovery which includes probing details
-* [ ] add plain old `icmp` ping probe
+* [x] add plain old `icmp` ping probe
 * [ ] `shell` probe command improvements in handling stdout/stderr
 * [x] megaease/easeprobe#108 add support to define destination notification channels for probe (see https://github.com/megaease/easeprobe/discussions/82)
 * [ ] work on cleaner distinction between `host`, `ssh` and `shell` (certain areas seem overlapping):

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -54,7 +54,7 @@ The project principles, of EaseProbe' features are separated into two main categ
 ... with new notification backends been added constantly.
 
 ## Roadmap
-Some of the features that we plan to implement in the future fall under one these categories: *General*, *Probe*, *Notify*
+Some of the features that we plan to implement in the future fall under one of these categories: *General*, *Probe*, *Notify*
 
 ### General
 * [x] Work on detailed documentation (megaease/easeprobe#210)

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -76,7 +76,7 @@ Some of the features that are planned/considered for 2022 can be broken down int
 
 ### Probes
 * [ ] add automatic service discovery which includes probing details
-* [x] add plain old `icmp` ping probe
+* [x] add plain old `icmp` ping probe (megaease/easeprobe#251)
 * [ ] `shell` probe command improvements in handling stdout/stderr
 * [x] megaease/easeprobe#108 add support to define destination notification channels for probe (see https://github.com/megaease/easeprobe/discussions/82)
 * [ ] work on cleaner distinction between `host`, `ssh` and `shell` (certain areas seem overlapping):

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -54,7 +54,7 @@ The project principles, of EaseProbe' features are separated into two main categ
 ... with new notification backends been added constantly.
 
 ## Roadmap
-Some of the features that are planned/considered for 2022 can be broken down into three categories: *General*, *Probe*, *Notify*
+Some of the features that we plan to implement in the future fall under one these categories: *General*, *Probe*, *Notify*
 
 ### General
 * [x] Work on detailed documentation (megaease/easeprobe#210)

--- a/go.mod
+++ b/go.mod
@@ -24,8 +24,8 @@ require (
 	go.mongodb.org/mongo-driver v1.11.0
 	golang.org/x/crypto v0.0.0-20220826181053-bd7e27e6170d
 	golang.org/x/exp v0.0.0-20220328175248-053ad81199eb
-	golang.org/x/net v0.0.0-20220811182439-13a9a731de15
-	golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64
+	golang.org/x/net v0.2.0
+	golang.org/x/sys v0.2.0
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/op/go-logging.v1 v1.0.0-20160211212156-b2cb9fa56473
@@ -38,8 +38,10 @@ require (
 	github.com/dimchansky/utfbom v1.1.1 // indirect
 	github.com/elliotchance/orderedmap v1.5.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
+	github.com/go-ping/ping v1.1.0 // indirect
 	github.com/goccy/go-json v0.9.11 // indirect
 	github.com/goccy/go-yaml v1.9.6 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/jinzhu/copier v0.3.5 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
@@ -83,8 +85,8 @@ require (
 	github.com/xdg-go/scram v1.1.1 // indirect
 	github.com/xdg-go/stringprep v1.0.3 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
-	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f // indirect
-	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/sync v0.1.0 // indirect
+	golang.org/x/text v0.4.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	mellium.im/sasl v0.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
+github.com/go-ping/ping v1.1.0 h1:3MCGhVX4fyEUuhsfwPrsEdQw6xspHkv5zHsiSoDFZYw=
+github.com/go-ping/ping v1.1.0/go.mod h1:xIFjORFzTxqIV/tDVGO4eDy/bLuSyawEeojSm3GfRGk=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
@@ -181,6 +183,9 @@ github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -414,6 +419,7 @@ golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
@@ -421,6 +427,8 @@ golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220706163947-c90051bbdb60/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220811182439-13a9a731de15 h1:cik0bxZUSJVDyaHf1hZPSDsU8SZHGQZQMeueXCE7yBQ=
 golang.org/x/net v0.0.0-20220811182439-13a9a731de15/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.2.0 h1:sZfSu1wtKLGlWI4ZZayP0ck9Y73K1ynO6gqzTdBVdPU=
+golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -440,6 +448,8 @@ golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f h1:Ax0t5p6N38Ga0dThY21weqDEyz2oklo4IvDkpigvkD8=
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -474,6 +484,7 @@ golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -486,9 +497,12 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64 h1:UiNENfZ8gDvpiWw7IpOMQ27spWmThO1RwwdQVbJahJM=
 golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.2.0 h1:z85xZCsEl7bi/KwbNADeBYoOP0++7W1ipu+aGnpwzRM=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -497,6 +511,8 @@ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/text v0.4.0 h1:BrVqGRd7+k1DiOgtnFvAkoQEWQvBc25ouMJM6429SFg=
+golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/probe/ping/metrics.go
+++ b/probe/ping/metrics.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ping
+
+import (
+	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/metric"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type metrics struct {
+	PacketsSent *prometheus.CounterVec
+	PacketsRecv *prometheus.CounterVec
+	PacketLoss  *prometheus.GaugeVec
+	MinRtt      *prometheus.GaugeVec
+	MaxRtt      *prometheus.GaugeVec
+	AvgRtt      *prometheus.GaugeVec
+	StdDevRtt   *prometheus.GaugeVec
+}
+
+// newMetrics create the metrics
+func newMetrics(subsystem, name string) *metrics {
+	namespace := global.GetEaseProbe().Name
+	return &metrics{
+		PacketsSent: metric.NewCounter(namespace, subsystem, name, "sent",
+			"Total Package Sent", []string{"name"}),
+		PacketsRecv: metric.NewCounter(namespace, subsystem, name, "recv",
+			"Total Package Received", []string{"name"}),
+		PacketLoss: metric.NewGauge(namespace, subsystem, name, "loss",
+			"Package Loss Percentage", []string{"name"}),
+		MinRtt: metric.NewGauge(namespace, subsystem, name, "min_rtt",
+			"Minimum Round Trip Time", []string{"name"}),
+		MaxRtt: metric.NewGauge(namespace, subsystem, name, "max_rtt",
+			"Maximum Round Trip Time", []string{"name"}),
+		AvgRtt: metric.NewGauge(namespace, subsystem, name, "avg_rtt",
+			"Average Round Trip Time", []string{"name"}),
+		StdDevRtt: metric.NewGauge(namespace, subsystem, name, "stddev_rtt",
+			"Standard Deviation of Round Trip Time", []string{"name"}),
+	}
+}

--- a/probe/ping/ping.go
+++ b/probe/ping/ping.go
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package ping is the ping probe package
+package ping
+
+import (
+	"fmt"
+
+	"github.com/go-ping/ping"
+	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/probe/base"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+)
+
+// Ping implements a config for ping
+type Ping struct {
+	base.DefaultProbe `yaml:",inline"`
+	Host              string  `yaml:"host" json:"host" jsonschema:"required,title=Host,description=The host to ping"`
+	Count             int     `yaml:"count" json:"count" jsonschema:"title=Count,description=The number of ping packets to send,minimum=1,default=3"`
+	LostThreshold     float64 `yaml:"lost" json:"lost" jsonschema:"title=Lost Threshold,description=The threshold of packet loss,minimum=0,maximum=1,default=0"`
+
+	metrics *metrics `yaml:"-" json:"-"`
+}
+
+// DefaultPingCount is the default ping count
+const DefaultPingCount = 3
+
+// DefaultLostThreshold is the default lost threshold - 0% lost
+const DefaultLostThreshold = 0.0
+
+// Config Ping Config Object
+func (p *Ping) Config(gConf global.ProbeSettings) error {
+	kind := "ping"
+	tag := ""
+	name := p.ProbeName
+	p.DefaultProbe.Config(gConf, kind, tag, name, p.Host, p.DoProbe)
+
+	if p.Count <= 0 {
+		log.Debugf("[%s / %s] ping count is not set, use default value: %d", p.ProbeKind, p.ProbeName, DefaultPingCount)
+		p.Count = DefaultPingCount
+	}
+
+	if p.LostThreshold < 0 || p.LostThreshold > 1 {
+		log.Debugf("[%s / %s] lost threshold is not set, use default value: %f", p.ProbeKind, p.ProbeName, DefaultLostThreshold)
+		p.LostThreshold = DefaultLostThreshold
+	}
+
+	p.metrics = newMetrics(kind, tag)
+
+	log.Debugf("[%s / %s] configuration: %+v", p.ProbeKind, p.ProbeName, p)
+	return nil
+}
+
+// DoProbe return the checking result
+func (p *Ping) DoProbe() (bool, string) {
+	pinger, err := ping.NewPinger(p.Host)
+	if err != nil {
+		return false, err.Error()
+	}
+	pinger.Timeout = p.ProbeTimeout
+	pinger.Count = p.Count
+	err = pinger.Run() // Blocks until finished.
+	if err != nil {
+		return false, err.Error()
+	}
+	stats := pinger.Statistics() // get send/receive/rtt stats
+	p.ExportMetrics(stats)
+
+	stat := ""
+	stat += fmt.Sprintf("%d packets transmitted, %d packets received, %v%% packet loss\n",
+		stats.PacketsSent, stats.PacketsRecv, stats.PacketLoss)
+	stat += fmt.Sprintf("round-trip min/avg/max/stddev = %v/%v/%v/%v\n",
+		stats.MinRtt, stats.AvgRtt, stats.MaxRtt, stats.StdDevRtt)
+
+	log.Debugf("[%s / %s] --- %s ping statistics ---", p.ProbeKind, p.ProbeName, stats.Addr)
+	log.Debugf("[%s / %s] %d packets transmitted, %d packets received, %v%% packet loss\n",
+		p.ProbeKind, p.ProbeName, stats.PacketsSent, stats.PacketsRecv, stats.PacketLoss)
+	log.Debugf("[%s / %s] round-trip min/avg/max/stddev = %v/%v/%v/%v\n",
+		p.ProbeKind, p.ProbeName, stats.MinRtt, stats.AvgRtt, stats.MaxRtt, stats.StdDevRtt)
+
+	result := true
+	message := "Ping Succeeded!"
+	// if half of the packets are lost, return false
+	if stats.PacketLoss > p.LostThreshold*100 {
+		result = false
+		message = "Ping Failed!"
+	}
+	return result, fmt.Sprintf("%s: %d/%d\n%s", message, stats.PacketsRecv, stats.PacketsSent, stat)
+}
+
+// ExportMetrics export Ping metrics
+func (p *Ping) ExportMetrics(stats *ping.Statistics) {
+	p.metrics.PacketsSent.With(prometheus.Labels{
+		"name": p.ProbeName,
+	}).Add(float64(stats.PacketsSent))
+
+	p.metrics.PacketsRecv.With(prometheus.Labels{
+		"name": p.ProbeName,
+	}).Add(float64(stats.PacketsRecv))
+
+	p.metrics.PacketLoss.With(prometheus.Labels{
+		"name": p.ProbeName,
+	}).Set(stats.PacketLoss)
+
+	p.metrics.MaxRtt.With(prometheus.Labels{
+		"name": p.ProbeName,
+	}).Set(float64(stats.MaxRtt.Milliseconds()))
+
+	p.metrics.MinRtt.With(prometheus.Labels{
+		"name": p.ProbeName,
+	}).Set(float64(stats.MinRtt.Milliseconds()))
+
+	p.metrics.AvgRtt.With(prometheus.Labels{
+		"name": p.ProbeName,
+	}).Set(float64(stats.AvgRtt.Milliseconds()))
+
+	p.metrics.StdDevRtt.With(prometheus.Labels{
+		"name": p.ProbeName,
+	}).Set(float64(stats.StdDevRtt.Milliseconds()))
+}

--- a/probe/ping/ping.go
+++ b/probe/ping/ping.go
@@ -83,9 +83,8 @@ func (p *Ping) DoProbe() (bool, string) {
 	p.ExportMetrics(stats)
 
 	stat := ""
-	stat += fmt.Sprintf("%d packets transmitted, %d packets received, %v%% packet loss\n",
-		stats.PacketsSent, stats.PacketsRecv, stats.PacketLoss)
-	stat += fmt.Sprintf("round-trip min/avg/max/stddev = %v/%v/%v/%v\n",
+	stat += fmt.Sprintf("%d sent, %d received, %v%% loss, RTT min/avg/max/stddev = %v/%v/%v/%v",
+		stats.PacketsSent, stats.PacketsRecv, stats.PacketLoss,
 		stats.MinRtt, stats.AvgRtt, stats.MaxRtt, stats.StdDevRtt)
 
 	log.Debugf("[%s / %s] --- %s ping statistics ---", p.ProbeKind, p.ProbeName, stats.Addr)
@@ -101,7 +100,7 @@ func (p *Ping) DoProbe() (bool, string) {
 		result = false
 		message = "Ping Failed!"
 	}
-	return result, fmt.Sprintf("%s: %d/%d\n%s", message, stats.PacketsRecv, stats.PacketsSent, stat)
+	return result, fmt.Sprintf("%s: %d/%d ( %s )", message, stats.PacketsRecv, stats.PacketsSent, stat)
 }
 
 // ExportMetrics export Ping metrics

--- a/probe/ping/ping.go
+++ b/probe/ping/ping.go
@@ -34,7 +34,7 @@ type Ping struct {
 	Host              string  `yaml:"host" json:"host" jsonschema:"required,title=Host,description=The host to ping"`
 	Count             int     `yaml:"count" json:"count" jsonschema:"title=Count,description=The number of ping packets to send,minimum=1,default=3"`
 	LostThreshold     float64 `yaml:"lost" json:"lost" jsonschema:"title=Lost Threshold,description=The threshold of packet loss,minimum=0,maximum=1,default=0"`
-	Privileged	bool	`yaml:"privileged" json:"privileged" jsonschema:"title=Privileged,description=Run ping with privileged modem, default=false"`
+	Privileged        bool    `yaml:"privileged" json:"privileged" jsonschema:"title=Privileged,description=Run ping with privileged modem, default=false"`
 
 	metrics *metrics `yaml:"-" json:"-"`
 }

--- a/probe/ping/ping_test.go
+++ b/probe/ping/ping_test.go
@@ -86,5 +86,5 @@ func TestPingWithInvalidHost(t *testing.T) {
 	p.Config(global.ProbeSettings{})
 	s, m = p.DoProbe()
 	assert.False(t, s)
-	assert.Contains(t, m, "lookup unknown: no such host")
+	assert.Contains(t, m, "lookup unknown")
 }

--- a/probe/ping/ping_test.go
+++ b/probe/ping/ping_test.go
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ping
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"bou.ke/monkey"
+	"github.com/go-ping/ping"
+	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/probe/base"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPing(t *testing.T) {
+	ping := Ping{
+		DefaultProbe: base.DefaultProbe{ProbeName: "dummy ping"},
+		Host:         "127.0.0.1",
+	}
+	ping.Config(global.ProbeSettings{})
+	assert.Equal(t, "ping", ping.ProbeKind)
+	assert.Equal(t, DefaultPingCount, ping.Count)
+	assert.Equal(t, DefaultLostThreshold, ping.LostThreshold)
+
+	ping = Ping{
+		DefaultProbe:  base.DefaultProbe{ProbeName: "dummy ping"},
+		Host:          "127.0.0.1",
+		Count:         0,
+		LostThreshold: -1,
+	}
+	ping.Config(global.ProbeSettings{})
+	assert.Equal(t, "ping", ping.ProbeKind)
+	assert.Equal(t, DefaultPingCount, ping.Count)
+	assert.Equal(t, DefaultLostThreshold, ping.LostThreshold)
+
+	s, m := ping.DoProbe()
+	assert.True(t, s)
+	assert.Contains(t, m, "Succeeded")
+}
+
+func TestPingWithInvalidHost(t *testing.T) {
+
+	p := Ping{
+		DefaultProbe:  base.DefaultProbe{ProbeName: "dummy ping"},
+		Host:          "127.0.0.1",
+		LostThreshold: 0.5,
+	}
+	p.Config(global.ProbeSettings{})
+
+	var pinger *ping.Pinger
+	monkey.PatchInstanceMethod(reflect.TypeOf(pinger), "Statistics", func(_ *ping.Pinger) *ping.Statistics {
+		return &ping.Statistics{PacketLoss: 51}
+	})
+	s, m := p.DoProbe()
+	assert.False(t, s)
+	assert.Contains(t, m, "Ping Failed")
+
+	monkey.PatchInstanceMethod(reflect.TypeOf(pinger), "Run", func(_ *ping.Pinger) error {
+		return fmt.Errorf("ping error")
+	})
+	s, m = p.DoProbe()
+	assert.False(t, s)
+	assert.Contains(t, m, "ping error")
+
+	p = Ping{
+		DefaultProbe: base.DefaultProbe{ProbeName: "dummy ping"},
+		Host:         "unknown",
+	}
+	p.Config(global.ProbeSettings{})
+	s, m = p.DoProbe()
+	assert.False(t, s)
+	assert.Contains(t, m, "lookup unknown: no such host")
+}

--- a/probe/ping/ping_test.go
+++ b/probe/ping/ping_test.go
@@ -77,7 +77,7 @@ func TestPingWithInvalidHost(t *testing.T) {
 	}
 	s, m := p.DoProbe()
 	assert.False(t, s)
-	assert.Contains(t, m, "Ping Failed")
+	assert.Contains(t, m, "Failed")
 
 	monkey.PatchInstanceMethod(reflect.TypeOf(pinger), "Run", func(_ *ping.Pinger) error {
 		return fmt.Errorf("ping error")

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -62,6 +62,16 @@ http: # http probes
 #     failure: 2 # number of consecutive failed probes needed to determine the status down, default: 1
 #     success: 1 # number of consecutive successful probes needed to determine the status up, default: 1
 
+# --------------------- Ping Probe Configuration ---------------------
+#
+# ping:
+#   - name: Localhost
+#     host: 127.0.0.1
+#     count: 5 # number of packets to send, default: 3
+#     lost: 0.2 # 20% lost percentage threshold, mark it down if the lost greater than this, default: 0
+#     timeout: 10s # default is 30 seconds
+#     interval: 2m # default is 60 seconds
+
 # --------------------- Shell Probe Configuration ---------------------
 #
 # shell:

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -69,6 +69,7 @@ http: # http probes
 #     host: 127.0.0.1
 #     count: 5 # number of packets to send, default: 3
 #     lost: 0.2 # 20% lost percentage threshold, mark it down if the loss is greater than this, default: 0
+#     privileged: true # if true, the ping will be executed with icmp, otherwise use udp, default: false
 #     timeout: 10s # default is 30 seconds
 #     interval: 2m # default is 60 seconds
 

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -68,7 +68,7 @@ http: # http probes
 #   - name: Localhost
 #     host: 127.0.0.1
 #     count: 5 # number of packets to send, default: 3
-#     lost: 0.2 # 20% lost percentage threshold, mark it down if the lost greater than this, default: 0
+#     lost: 0.2 # 20% lost percentage threshold, mark it down if the loss is greater than this, default: 0
 #     timeout: 10s # default is 30 seconds
 #     interval: 2m # default is 60 seconds
 

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -69,7 +69,7 @@ http: # http probes
 #     host: 127.0.0.1
 #     count: 5 # number of packets to send, default: 3
 #     lost: 0.2 # 20% lost percentage threshold, mark it down if the loss is greater than this, default: 0
-#     privileged: true # if true, the ping will be executed with icmp, otherwise use udp, default: false
+#     privileged: true # if true, the ping will be executed with icmp, otherwise use udp, default: false (Note: On Windows platform, this must be set to True)
 #     timeout: 10s # default is 30 seconds
 #     interval: 2m # default is 60 seconds
 


### PR DESCRIPTION
support the following probe configuration
```yaml
ping:
   - name: Localhost
     host: 127.0.0.1
     count: 5 # number of packets to send, default: 3
     lost: 0.2 # 20% lost percentage threshold, mark it down if the loss is greater than this, default: 0
```