### PR TITLE
bug-fixing: PostgreSQL failed to check if the server wasn't turn on the SSL

### DIFF
--- a/probe/client/postgres/postgres.go
+++ b/probe/client/postgres/postgres.go
@@ -62,8 +62,9 @@ func New(opt conf.Options) (*PostgreSQL, error) {
 		return nil, fmt.Errorf("TLS Config Error - %v", err)
 	} else if tls != nil {
 		tls.InsecureSkipVerify = true
-		clientOptions = append(clientOptions, pgdriver.WithTLSConfig(tls))
 	}
+	// if the tls is nil which means `sslmode=disable`
+	clientOptions = append(clientOptions, pgdriver.WithTLSConfig(tls))
 
 	pg := &PostgreSQL{
 		Options:       opt,
@@ -97,60 +98,75 @@ func (r *PostgreSQL) checkData() error {
 func (r *PostgreSQL) Probe() (bool, string) {
 
 	if len(r.Data) > 0 {
-		for k, v := range r.Data {
-			log.Debugf("[%s / %s / %s] - Verifying Data - [%s] : [%s]", r.ProbeKind, r.ProbeName, r.ProbeTag, k, v)
-			//connect to the database
-			dbName, sqlstr, err := r.getSQL(k)
-			if err != nil {
-				return false, fmt.Sprintf("Invalid SQL data - [%s], %v", v, err)
-			}
-			clientOptions := append(r.ClientOptions, pgdriver.WithDatabase(dbName))
-			db := sql.OpenDB(pgdriver.NewConnector(clientOptions...))
-			if db == nil {
-				return false, "OpenDB error"
-			}
-			// query the data
-			log.Debugf("[%s / %s / %s] - SQL - [%s]", r.ProbeKind, r.ProbeName, r.ProbeTag, sqlstr)
-			rows, err := db.Query(sqlstr)
-			if err != nil {
-				return false, fmt.Sprintf("Query error - [%s], %v", v, err)
-			}
-			if !rows.Next() {
-				rows.Close()
-				return false, fmt.Sprintf("No data found for [%s]", k)
-			}
-			//check the value is equal to the value in data
-			var value string
-			if err := rows.Scan(&value); err != nil {
-				rows.Close()
-				return false, err.Error()
-			}
-			if value != v {
-				rows.Close()
-				return false, fmt.Sprintf("Value not match for [%s] expected [%s] got [%s] ", k, v, value)
-			}
-			rows.Close()
-			db.Close()
-			log.Debugf("[%s / %s / %s] - Data Verified Successfully! - [%s] : [%s]", r.ProbeKind, r.ProbeName, r.ProbeTag, k, v)
+		return r.ProbeWithDataChecking()
+	}
+	return r.ProbeWithPing()
+}
+
+// ProbeWithPing do the health check with ping & Select 1;
+func (r *PostgreSQL) ProbeWithPing() (bool, string) {
+	r.ClientOptions = append(r.ClientOptions, pgdriver.WithDatabase("template1"))
+	db := sql.OpenDB(pgdriver.NewConnector(r.ClientOptions...))
+	if db == nil {
+		return false, "OpenDB error"
+	}
+	defer db.Close()
+
+	if err := db.Ping(); err != nil {
+		return false, err.Error()
+	}
+
+	// run a SQL to test
+	row, err := db.Query(`SELECT 1`)
+	if err != nil {
+		return false, err.Error()
+	}
+	row.Close()
+	return true, "Check PostgreSQL Server Successfully!"
+}
+
+// ProbeWithDataChecking do the health check with data checking
+func (r *PostgreSQL) ProbeWithDataChecking() (bool, string) {
+	if len(r.Data) == 0 {
+		log.Warnf("[%s / %s / %s] - No data found, use ping instead", r.ProbeKind, r.ProbeName, r.ProbeTag)
+		return r.ProbeWithPing()
+	}
+
+	for k, v := range r.Data {
+		log.Debugf("[%s / %s / %s] - Verifying Data - [%s] : [%s]", r.ProbeKind, r.ProbeName, r.ProbeTag, k, v)
+		//connect to the database
+		dbName, sqlstr, err := r.getSQL(k)
+		if err != nil {
+			return false, fmt.Sprintf("Invalid SQL data - [%s], %v", v, err)
 		}
-	} else {
-		r.ClientOptions = append(r.ClientOptions, pgdriver.WithDatabase("template1"))
-		db := sql.OpenDB(pgdriver.NewConnector(r.ClientOptions...))
+		clientOptions := append(r.ClientOptions, pgdriver.WithDatabase(dbName))
+		db := sql.OpenDB(pgdriver.NewConnector(clientOptions...))
 		if db == nil {
 			return false, "OpenDB error"
 		}
-		defer db.Close()
-
-		if err := db.Ping(); err != nil {
-			return false, err.Error()
-		}
-
-		// run a SQL to test
-		row, err := db.Query(`SELECT 1`)
+		// query the data
+		log.Debugf("[%s / %s / %s] - SQL - [%s]", r.ProbeKind, r.ProbeName, r.ProbeTag, sqlstr)
+		rows, err := db.Query(sqlstr)
 		if err != nil {
+			return false, fmt.Sprintf("Query error - [%s], %v", v, err)
+		}
+		if !rows.Next() {
+			rows.Close()
+			return false, fmt.Sprintf("No data found for [%s]", k)
+		}
+		//check the value is equal to the value in data
+		var value string
+		if err := rows.Scan(&value); err != nil {
+			rows.Close()
 			return false, err.Error()
 		}
-		row.Close()
+		if value != v {
+			rows.Close()
+			return false, fmt.Sprintf("Value not match for [%s] expected [%s] got [%s] ", k, v, value)
+		}
+		rows.Close()
+		db.Close()
+		log.Debugf("[%s / %s / %s] - Data Verified Successfully! - [%s] : [%s]", r.ProbeKind, r.ProbeName, r.ProbeTag, k, v)
 	}
 
 	return true, "Check PostgreSQL Server Successfully!"

--- a/probe/client/postgres/postgres_test.go
+++ b/probe/client/postgres/postgres_test.go
@@ -61,7 +61,7 @@ func TestPostgreSQL(t *testing.T) {
 	assert.Equal(t, conf.Timeout(), pgd.Config().DialTimeout)
 	assert.Equal(t, conf.Timeout(), pgd.Config().ReadTimeout)
 	assert.Equal(t, conf.Timeout(), pgd.Config().WriteTimeout)
-	assert.Nil(t, pgd.Config().TLSConfig.ClientCAs)
+	assert.Nil(t, pgd.Config().TLSConfig)
 
 	monkey.Patch(sql.OpenDB, func(c driver.Connector) *sql.DB {
 		return &sql.DB{}
@@ -83,6 +83,10 @@ func TestPostgreSQL(t *testing.T) {
 	})
 
 	s, m := pg.Probe()
+	assert.True(t, s)
+	assert.Contains(t, m, "Successfully")
+
+	s, m = pg.ProbeWithDataChecking()
 	assert.True(t, s)
 	assert.Contains(t, m, "Successfully")
 


### PR DESCRIPTION
close #285 

## How to Reproduce

disable the SSL in `prostgresql.conf` by commenting on the following configuration 
```
#ssl = on
 #ssl_ca_file = '/path/to/certs/ca.crt'
 #ssl_cert_file = '/path/to/certs/server.crt'
 #ssl_key_file = '/path/to/certs/server.key'
```

EaseProbe config.yaml

```yaml
client:
  - name: PostgreSQL Native Client (local)
    driver: "postgres"
    host: "localhost:5432"
    username: user
    password: password
```

## Fix

if TLS in the client is not configured,  we need to configure it with a nil

```diff
@@ -62,8 +62,9 @@ func New(opt conf.Options) (*PostgreSQL, error) {
                return nil, fmt.Errorf("TLS Config Error - %v", err)
        } else if tls != nil {
                tls.InsecureSkipVerify = true
-               clientOptions = append(clientOptions, pgdriver.WithTLSConfig(tls))
        }
+       // if the tls is nil which means `sslmode=disable`
+       clientOptions = append(clientOptions, pgdriver.WithTLSConfig(tls))
```

> **Note**
> The other code change just move the code from the `Probe()` to `ProbeWithPing()` and `ProbeWithDataChecking()`, no code logics changes.
