### PR TITLE
Add Helm charts release workflow

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -1,0 +1,35 @@
+name: Release Helm Charts
+
+on:
+  push:
+    tags:
+      - 'v*'
+    paths:
+      - "helm/**"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Add repositories
+        run: |
+          for dir in $(ls -d helm/*/); do
+            helm dependency list $dir 2> /dev/null | tail +2 | head -n -1 | awk '{ print "helm repo add " $1 " " $3 }' | while read cmd; do $cmd; done
+          done
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        with:
+          charts_dir: helm
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -12,6 +12,7 @@
     - [4.2 Creating a PV/PVC for EaseProbe SLA data persistent.](#42-creating-a-pvpvc-for-easeprobe-sla-data-persistent)
     - [4.3 Deploy EaseProbe](#43-deploy-easeprobe)
     - [4.4 Create the EaseProbe Service](#44-create-the-easeprobe-service)
+  - [5. Kubernetes Deployment Using Helm](#5-kubernetes-deployment-using-helm)
 
 
 ## 1. Overview
@@ -339,4 +340,23 @@ spec:
     protocol: TCP
     targetPort: 8181
   type: ClusterIP
+```
+
+## 5 Kubernetes Deployment Using Helm
+
+**Add repository**
+```
+helm repo add easeprobe https://megaease.github.io/easeprobe
+```
+
+**Install and run**
+```
+helm install [RELEASE_NAME] megaease/easeprobe
+```
+> **Note**:
+  > Persistence for EaseProbe using Helm is not enabled by default, you must enable it for production environment, refer to [Helm README](../helm/easeprobe/README.md#parameters) for more details.
+
+**Uninstall**
+```
+helm uninstall [RELEASE_NAME]
 ```

--- a/helm/easeprobe/README.md
+++ b/helm/easeprobe/README.md
@@ -28,7 +28,14 @@ EaseProbe is a simple, standalone, and lightweight tool that can do health/statu
   > Persistence for Prometheus and Grafana is not enabled by default, you must enable it for production environment.
 
 ### From Repo
-- (TBD)
+- Add repository
+  ```shell
+  helm repo add easeprobe https://megaease.github.io/easeprobe
+  ```
+- Install and run
+  ```shell
+  helm install [RELEASE_NAME] megaease/easeprobe
+  ```
 
 ## Uninstallation
 ```shell
@@ -38,7 +45,7 @@ helm uninstall [RELEASE_NAME]
 ## Parameters
 | Name | Description | Value |
 | ---- | ----------- | ----- |
-| `config` | Configuration for EaseProbe, refer [Manual](https://github.com/megaease/easeprobe/blob/main/docs/Manual.md) | `{}`
+| `config` | Configuration for EaseProbe, refer to [Manual](https://github.com/megaease/easeprobe/blob/main/docs/Manual.md) | `{}`
 | `image.repository` | Image repository | `megaease/easeprobe`
 | `image.tag` | Image tag | `latest`
 | `image.pullPolicy` | Image pull policy | `IfNotPresent`
@@ -47,7 +54,7 @@ helm uninstall [RELEASE_NAME]
 | `persistence.existingClaim` | Existing PVC name | `""`
 | `persistence.storageClassName` | Storage class name | `""`
 | `persistence.size` | Volume size for persistence | `1Gi`
-| `prometheus` | Configuration for Prometheus, refer [https://artifacthub.io/packages/helm/prometheus-community/prometheus](https://artifacthub.io/packages/helm/prometheus-community/prometheus) | `{}`
+| `prometheus` | Configuration for Prometheus, refer to [https://artifacthub.io/packages/helm/prometheus-community/prometheus](https://artifacthub.io/packages/helm/prometheus-community/prometheus) | `{}`
 | `prometheus.enabled` | Whether to enable Prometheus | `false`
-| `grafana` | Configuration for Grafana, refer [https://artifacthub.io/packages/helm/grafana/grafana](https://artifacthub.io/packages/helm/grafana/grafana) | `{}`
+| `grafana` | Configuration for Grafana, refer to [https://artifacthub.io/packages/helm/grafana/grafana](https://artifacthub.io/packages/helm/grafana/grafana) | `{}`
 | `grafana.enabled` | Whether to enable Grafana | `false`


### PR DESCRIPTION
To automatically release Helm charts, we also need to set up GitHub Pages for this repository @haoel 