### PR TITLE
fix: use buffered os.Signal channel as argument to signal.Notify

### DIFF
--- a/cmd/easeprobe/main.go
+++ b/cmd/easeprobe/main.go
@@ -209,7 +209,7 @@ func main() {
 	////////////////////////////////////////////////////////////////////////////
 	//                              Graceful Shutdown                         //
 	////////////////////////////////////////////////////////////////////////////
-	done := make(chan os.Signal)
+	done := make(chan os.Signal, 1)
 	signal.Notify(done, syscall.SIGTERM)
 	select {
 	case <-done:


### PR DESCRIPTION
Use buffered os.Signal channel as argument to signal.Notify to ensure that we do not drop a signal notification.