### PR TITLE
refactor: avoid copying mutex

### DIFF
--- a/probe/ping/ping.go
+++ b/probe/ping/ping.go
@@ -76,7 +76,7 @@ func (p *Ping) Config(gConf global.ProbeSettings) error {
 
 // using reflect to get the network and protocol (private fields)
 func protocol(p *ping.Pinger) (network string, protocol string) {
-	v := reflect.ValueOf(*p)
+	v := reflect.ValueOf(p).Elem()
 	net := v.FieldByName("network")
 	proto := v.FieldByName("protocol")
 	return net.String(), proto.String()


### PR DESCRIPTION
`ping.Pinger` contains `sync.RWMutex`, `reflect.ValueOf(*p)` will copy the lock value.