### PR TITLE
Fix the version bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ MKFILE_DIR := $(dir $(MKFILE_PATH))
 RELEASE_DIR := ${MKFILE_DIR}/build/bin
 
 # Version
-RELEASE_VER := $(shell git describe --tag --abbrev=0)
+RELEASE_VER := $(shell git tag --list --sort=-creatordate  "v*" | head -n 1 )
 
 # Go MOD
 GO_MOD := $(shell go list -m)


### PR DESCRIPTION
since #307 introduced the tag for Helm Chart, the PR impacts the easeprobe's build version, because the Makefile always retrieved the latest tag. 

Before this fix:

```shell
> easeprobe -v
EaseProbe easeprobe-helm-charts-v1.0.0 8b36e4424 2023-03-11T01:02:40Z go1.19.4
```

After this fix

```shell
> easeprobe -v                                                                                                                                                                   ─╯
EaseProbe v2.0.1 8b36e4424 2023-03-11T01:02:40Z go1.19.4
```