### PR TITLE
Optimize the ordering of status display in the SLA report

### DIFF
--- a/report/sla.go
+++ b/report/sla.go
@@ -23,6 +23,7 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -356,8 +357,15 @@ func SLAStatusText(s probe.Stat, t Format) string {
 	case Log:
 		format = "%s:%d "
 	}
-	for k, v := range s.Status {
-		status += fmt.Sprintf(format, k.String(), v)
+
+	// sort status
+	var statusKeys []int
+	for statusKey, _ := range s.Status {
+		statusKeys = append(statusKeys, int(statusKey))
+	}
+	sort.Ints(statusKeys)
+	for _, k := range statusKeys {
+		status += fmt.Sprintf(format, probe.Status(k).String(), s.Status[probe.Status(k)])
 	}
 	return strings.TrimSpace(status)
 }


### PR DESCRIPTION
SLA Report 默认 HTML 显示状态是乱序的，在展示之前添加了排序。
<img width="262" alt="image" src="https://github.com/megaease/easeprobe/assets/32095100/2ac42864-7145-47ce-afa8-57bdcfa395a7">
