### PR TITLE
bugfix:strategy type error

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -415,7 +415,8 @@
     "global_NotificationStrategySettings": {
       "properties": {
         "strategy": {
-          "type": "integer",
+          "type": "string",
+          "enum": ["regular", "increment","exponent"],
           "title": "Alert Interval Strategy",
           "description": "the notification interval strategy such as regular",
           "default": 0


### PR DESCRIPTION
The type definition of the "strategy" field in the schema.json is incorrect. It should be defined as a string type, but it is currently defined as an integer.