### PR TITLE
fix unix test compiling failed on MAC M1

### DIFF
--- a/conf/conf_test.go
+++ b/conf/conf_test.go
@@ -28,7 +28,6 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/notify"
 	"github.com/megaease/easeprobe/notify/discord"
@@ -42,6 +41,7 @@ import (
 	"github.com/megaease/easeprobe/probe/shell"
 	"github.com/megaease/easeprobe/probe/ssh"
 	"github.com/megaease/easeprobe/probe/tcp"
+	"github.com/procodr/monkey"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"

--- a/conf/log_test.go
+++ b/conf/log_test.go
@@ -24,7 +24,7 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
+	"github.com/procodr/monkey"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/natefinch/lumberjack.v2"

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -23,10 +23,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"bou.ke/monkey"
-	"github.com/megaease/easeprobe/global"
-
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/megaease/easeprobe/global"
 )
 
 func testPIDFile(pidfile string, t *testing.T) {

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -24,8 +24,8 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
 	"github.com/Knetic/govaluate"
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/eval/extract_test.go
+++ b/eval/extract_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/html"
 )

--- a/global/easeprobe_test.go
+++ b/global/easeprobe_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/global/global_test.go
+++ b/global/global_test.go
@@ -33,7 +33,7 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/megaease/easeprobe
 go 1.20
 
 require (
-	bou.ke/monkey v1.0.2
 	github.com/Knetic/govaluate v3.0.0+incompatible
 	github.com/antchfx/htmlquery v1.3.0
 	github.com/antchfx/jsonquery v1.3.3
@@ -16,6 +15,7 @@ require (
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/go-zookeeper/zk v1.0.3
+	github.com/procodr/monkey v0.0.0-20221102224215-28eb53c3a645
 	github.com/prometheus-community/pro-bing v0.3.0
 	github.com/prometheus/client_golang v1.16.0
 	github.com/segmentio/kafka-go v0.4.42
@@ -34,6 +34,7 @@ require (
 )
 
 require (
+	bou.ke/monkey v1.0.2 // indirect
 	github.com/a8m/envsubst v1.4.2 // indirect
 	github.com/alecthomas/participle/v2 v2.0.0 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsK
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/procodr/monkey v0.0.0-20221102224215-28eb53c3a645 h1:uwVfHcIpU8nLNL8hX/LURFZ/+cB5ruJmeG6FjJcd84c=
+github.com/procodr/monkey v0.0.0-20221102224215-28eb53c3a645/go.mod h1:PJ3oe00mZwZDQZMwqYEgAqf24FWh8I16/PByYuvCwBM=
 github.com/prometheus-community/pro-bing v0.3.0 h1:SFT6gHqXwbItEDJhTkzPWVqU6CLEtqEfNAPp47RUON4=
 github.com/prometheus-community/pro-bing v0.3.0/go.mod h1:p9dLb9zdmv+eLxWfCT6jESWuDrS+YzpPkQBgysQF8a0=
 github.com/prometheus/client_golang v1.16.0 h1:yk/hx9hDbrGHovbci4BY+pRMfSuuat626eFsHb7tmT8=

--- a/metric/prometheus_test.go
+++ b/metric/prometheus_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/procodr/monkey"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/metric/prometheus_test.go
+++ b/metric/prometheus_test.go
@@ -20,7 +20,7 @@ package metric
 import (
 	"testing"
 
-	"bou.ke/monkey"
+	"github.com/procodr/monkey"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )

--- a/metric/prometheus_test.go
+++ b/metric/prometheus_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/procodr/monkey"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/notify/aws/sns_test.go
+++ b/notify/aws/sns_test.go
@@ -23,13 +23,14 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/procodr/monkey"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/report"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestSNSConfig(t *testing.T) {

--- a/notify/dingtalk/dingtalk_test.go
+++ b/notify/dingtalk/dingtalk_test.go
@@ -25,10 +25,11 @@ import (
 	"strings"
 	"testing"
 
-	"bou.ke/monkey"
+	"github.com/procodr/monkey"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/report"
-	"github.com/stretchr/testify/assert"
 )
 
 func assertError(t *testing.T, err error, msg string, contain bool) {

--- a/notify/discord/discord_test.go
+++ b/notify/discord/discord_test.go
@@ -30,10 +30,11 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe"
 	"github.com/megaease/easeprobe/probe/base"
+
+	"github.com/procodr/monkey"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )

--- a/notify/email/email_test.go
+++ b/notify/email/email_test.go
@@ -22,9 +22,10 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/report"
+
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/gomail.v2"
 )

--- a/notify/lark/lark_test.go
+++ b/notify/lark/lark_test.go
@@ -25,9 +25,10 @@ import (
 	"strings"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/report"
+
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/notify/log/log_test.go
+++ b/notify/log/log_test.go
@@ -22,9 +22,10 @@ import (
 	"os"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/report"
+
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/notify/log/log_unix_test.go
+++ b/notify/log/log_unix_test.go
@@ -24,8 +24,9 @@ import (
 	"log/syslog"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/notify/ringcentral/ringcentral_test.go
+++ b/notify/ringcentral/ringcentral_test.go
@@ -26,9 +26,10 @@ import (
 	"strings"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/report"
+
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/notify/slack/slack_test.go
+++ b/notify/slack/slack_test.go
@@ -25,9 +25,10 @@ import (
 	"strings"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/report"
+
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/notify/sms/nexmo/nexmo_test.go
+++ b/notify/sms/nexmo/nexmo_test.go
@@ -26,8 +26,8 @@ import (
 
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/notify/sms/conf"
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/notify/sms/sms_test.go
+++ b/notify/sms/sms_test.go
@@ -21,12 +21,13 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/notify/sms/conf"
 	"github.com/megaease/easeprobe/notify/sms/nexmo"
 	"github.com/megaease/easeprobe/notify/sms/twilio"
 	"github.com/megaease/easeprobe/notify/sms/yunpian"
+
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/notify/sms/twilio/twilio_test.go
+++ b/notify/sms/twilio/twilio_test.go
@@ -25,8 +25,9 @@ import (
 	"strings"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/notify/sms/conf"
+
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/notify/sms/yunpian/yunpian_test.go
+++ b/notify/sms/yunpian/yunpian_test.go
@@ -25,8 +25,9 @@ import (
 	"strings"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/notify/sms/conf"
+
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/notify/teams/teams_test.go
+++ b/notify/teams/teams_test.go
@@ -26,9 +26,10 @@ import (
 	"strings"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/report"
+
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/notify/telegram/telegram_test.go
+++ b/notify/telegram/telegram_test.go
@@ -27,9 +27,10 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/report"
+
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/notify/wecom/wecom_test.go
+++ b/notify/wecom/wecom_test.go
@@ -25,9 +25,10 @@ import (
 	"strings"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/report"
+
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/probe/base/base_test.go
+++ b/probe/base/base_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/proxy"
 

--- a/probe/client/client_test.go
+++ b/probe/client/client_test.go
@@ -21,7 +21,6 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe/base"
 	"github.com/megaease/easeprobe/probe/client/conf"
@@ -32,6 +31,8 @@ import (
 	"github.com/megaease/easeprobe/probe/client/postgres"
 	"github.com/megaease/easeprobe/probe/client/redis"
 	"github.com/megaease/easeprobe/probe/client/zookeeper"
+
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/probe/client/kafka/kafka_test.go
+++ b/probe/client/kafka/kafka_test.go
@@ -23,9 +23,10 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe/client/conf"
+
+	"github.com/procodr/monkey"
 	"github.com/segmentio/kafka-go"
 	"github.com/stretchr/testify/assert"
 )

--- a/probe/client/memcache/memcache_test.go
+++ b/probe/client/memcache/memcache_test.go
@@ -23,10 +23,11 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
 	"github.com/bradfitz/gomemcache/memcache"
-	"github.com/megaease/easeprobe/probe/client/conf"
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/megaease/easeprobe/probe/client/conf"
 )
 
 func TestMemcache(t *testing.T) {

--- a/probe/client/mongo/mongo_test.go
+++ b/probe/client/mongo/mongo_test.go
@@ -24,11 +24,11 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe/client/conf"
-	"github.com/stretchr/testify/assert"
 
+	"github.com/procodr/monkey"
+	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"

--- a/probe/client/mysql/mysql_test.go
+++ b/probe/client/mysql/mysql_test.go
@@ -25,10 +25,11 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
-	"github.com/go-sql-driver/mysql"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe/client/conf"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/probe/client/postgres/postgres_test.go
+++ b/probe/client/postgres/postgres_test.go
@@ -25,9 +25,10 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe/client/conf"
+
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 	"github.com/uptrace/bun/driver/pgdriver"
 )

--- a/probe/client/redis/redis_test.go
+++ b/probe/client/redis/redis_test.go
@@ -24,11 +24,12 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/go-redis/redis/v8"
+	"github.com/procodr/monkey"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe/client/conf"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestRedis(t *testing.T) {

--- a/probe/client/zookeeper/zookeeper_test.go
+++ b/probe/client/zookeeper/zookeeper_test.go
@@ -25,9 +25,10 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe/client/conf"
+
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/go-zookeeper/zk"

--- a/probe/data_test.go
+++ b/probe/data_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
+	"github.com/procodr/monkey"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"

--- a/probe/host/host_test.go
+++ b/probe/host/host_test.go
@@ -23,10 +23,11 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe/base"
 	"github.com/megaease/easeprobe/probe/ssh"
+
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/probe/http/http_test.go
+++ b/probe/http/http_test.go
@@ -29,11 +29,12 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/eval"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe"
 	"github.com/megaease/easeprobe/probe/base"
+
+	"github.com/procodr/monkey"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )

--- a/probe/ping/ping_test.go
+++ b/probe/ping/ping_test.go
@@ -23,9 +23,10 @@ import (
 	"runtime"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe/base"
+
+	"github.com/procodr/monkey"
 	ping "github.com/prometheus-community/pro-bing"
 	"github.com/stretchr/testify/assert"
 )

--- a/probe/result_test.go
+++ b/probe/result_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 )

--- a/probe/shell/shell_test.go
+++ b/probe/shell/shell_test.go
@@ -24,10 +24,11 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe"
 	"github.com/megaease/easeprobe/probe/base"
+
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/probe/ssh/endpoint_test.go
+++ b/probe/ssh/endpoint_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/probe/ssh/ssh_test.go
+++ b/probe/ssh/ssh_test.go
@@ -26,12 +26,13 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
+	"github.com/procodr/monkey"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/ssh"
+
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe"
 	"github.com/megaease/easeprobe/probe/base"
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/crypto/ssh"
 )
 
 func createSSHConfig() *SSH {

--- a/probe/tcp/tcp_test.go
+++ b/probe/tcp/tcp_test.go
@@ -19,12 +19,12 @@ package tcp
 
 import (
 	"fmt"
+	"github.com/procodr/monkey"
 	"net"
 	"reflect"
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe/base"
 	"github.com/stretchr/testify/assert"

--- a/probe/tls/tls_test.go
+++ b/probe/tls/tls_test.go
@@ -35,9 +35,10 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe/base"
+
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/report/common_test.go
+++ b/report/common_test.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"testing"
 
-	"bou.ke/monkey"
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/report/result_test.go
+++ b/report/result_test.go
@@ -27,9 +27,10 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe"
+
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/report/sla_test.go
+++ b/report/sla_test.go
@@ -25,10 +25,11 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/probe"
 	"github.com/megaease/easeprobe/probe/base"
+
+	"github.com/procodr/monkey"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
No any unit test not be executed as the compiling failed with this issue :

https://stackoverflow.com/questions/74112738/underfined-function-error-in-go-jmptofunctionvalue
https://github.com/jenkins-x/jx/issues/2081
https://github.com/procodr/monkey 

the monkey patch unit tests still failed but the compile finished anyway and unit tests that are not related to the monkey patch can be executed.  