### PR TITLE
set timeout for kafka client conn

### DIFF
--- a/probe/client/kafka/kafka.go
+++ b/probe/client/kafka/kafka.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"time"
 
 	"github.com/megaease/easeprobe/probe/client/conf"
 	"github.com/segmentio/kafka-go"
@@ -85,12 +86,11 @@ func (k *Kafka) Probe() (bool, string) {
 	defer cancel()
 
 	conn, err := dialer.DialContext(ctx, "tcp", k.Host)
-
 	if err != nil {
 		return false, err.Error()
 	}
-
 	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(k.Timeout()))
 
 	partitions, err := conn.ReadPartitions()
 	if err != nil {


### PR DESCRIPTION
Currently, for the Kafka client, the timeout is only applicable during the dialing process. Once the connection is established and conn.ReadPartitions is called, it may experience significant delays. This situation can occur if the Kafka server is unresponsive or slow to write responses, potentially taking several minutes. To address this issue, this pr introduces a timeout setting for the connection.

This may cause the problem in issue #442 .