### PR TITLE
fix goreleaser bug

### DIFF
--- a/resources/Dockerfile.goreleaser
+++ b/resources/Dockerfile.goreleaser
@@ -2,7 +2,7 @@ FROM --platform=$BUILDPLATFORM alpine:latest
 
 WORKDIR /opt/
 
-COPY easeprobe /opt/
+COPY bin/easeprobe /opt/
 COPY resources/scripts/entrypoint.sh /
 RUN apk update && apk add tini tzdata busybox-extras curl redis
 


### PR DESCRIPTION
In `.goreleaser.yaml`, we put easeprobe binary in `bin/easeprobe`.

```
builds:
  - id: build
    main: ./cmd/easeprobe/
    binary: bin/easeprobe
```

then when use it, we should copy it from `bin/easeprobe`. 

the old version of goreleaser works but after a new version of goreleaser, this will cause panic of release process.