### PR TITLE
Escape SLA status text for compatibility with notification services s…

### DIFF
--- a/report/sla.go
+++ b/report/sla.go
@@ -384,7 +384,7 @@ func SLALarkSection(r *probe.Result) string {
 	},`
 	return fmt.Sprintf(text, r.Name, r.Endpoint,
 		DurationStr(r.Stat.UpTime), DurationStr(r.Stat.DownTime), r.SLAPercent(),
-		r.Stat.Total, SLAStatusText(r.Stat, Lark),
+		r.Stat.Total, JSONEscape(SLAStatusText(r.Stat, Lark)),
 		FormatTime(r.StartTime),
 		r.Status.Emoji()+" "+r.Status.String(), JSONEscape(r.Message))
 }


### PR DESCRIPTION
As mentioned in issue #468 , when sending SLA notifications, the Lark notification service will generate the following response: 

`code [9499] - msg [Bad Request]) ` 

This is because the SLAStatusText content contains `\t` which is not compatible with Lark.

This PR is a quick fix, the best way is to define content struct as demonstrated in PR #469, which needs a complete refactor and testing work.