### PR TITLE
log notify error with request body

### DIFF
--- a/notify/aws/sns.go
+++ b/notify/aws/sns.go
@@ -19,6 +19,7 @@ package aws
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sns"
@@ -71,7 +72,7 @@ func (c *NotifyConfig) SendSNSNotification(msg string) error {
 		TopicArn: aws.String(c.TopicARN),
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("[%s / %s] - Error response from AWS SNS with request body <%s>, %v", c.Kind(), c.Name(), msg, err)
 	}
 	log.Debugf("[%s / %s] Message ID = %s", c.Kind(), c.NotifyName, *res.MessageId)
 	return nil

--- a/notify/aws/sns_test.go
+++ b/notify/aws/sns_test.go
@@ -65,7 +65,7 @@ func TestSNSConfig(t *testing.T) {
 
 	err = conf.SendSNS("title", "msg")
 	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "publish error")
+	assert.Contains(t, err.Error(), "publish error")
 
 	monkey.UnpatchAll()
 }

--- a/notify/dingtalk/dingtalk.go
+++ b/notify/dingtalk/dingtalk.go
@@ -107,8 +107,8 @@ func (c *NotifyConfig) SendDingtalkNotification(title, msg string) error {
 	ret := make(map[string]interface{})
 	err = json.Unmarshal(buf, &ret)
 	if err != nil || ret["errmsg"] != "ok" {
-		return fmt.Errorf("[%s / %s] - Error response from Dingtalk [%d] - [%s]",
-			c.Kind(), c.Name(), resp.StatusCode, string(buf))
+		return fmt.Errorf("[%s / %s] - Error response from Dingtalk with request body <%s> [%d] - [%s]",
+			c.Kind(), c.Name(), msgContent, resp.StatusCode, string(buf))
 	}
 	return nil
 }

--- a/notify/dingtalk/dingtalk_test.go
+++ b/notify/dingtalk/dingtalk_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func assertError(t *testing.T, err error, msg string, contain bool) {
+	t.Helper()
 	assert.Error(t, err)
 	if contain {
 		assert.Contains(t, err.Error(), msg)
@@ -69,7 +70,8 @@ func TestDingTalk(t *testing.T) {
 		}, nil
 	})
 	err = conf.SendDingtalkNotification("title", "message")
-	assertError(t, err, "Error response from Dingtalk [200]", true)
+	assertError(t, err, "Error response from Dingtalk", true)
+	assertError(t, err, "[200]", true)
 
 	// bad json
 	monkey.PatchInstanceMethod(reflect.TypeOf(client), "Do", func(_ *http.Client, req *http.Request) (*http.Response, error) {
@@ -80,7 +82,8 @@ func TestDingTalk(t *testing.T) {
 		}, nil
 	})
 	err = conf.SendDingtalkNotification("title", "message")
-	assertError(t, err, "Error response from Dingtalk [200]", true)
+	assertError(t, err, "Error response from Dingtalk", true)
+	assertError(t, err, "[200]", true)
 
 	// bad io.ReadAll
 	monkey.Patch(io.ReadAll, func(r io.Reader) ([]byte, error) {

--- a/notify/discord/discord.go
+++ b/notify/discord/discord.go
@@ -348,7 +348,7 @@ func (c *NotifyConfig) SendDiscordNotification(discord Discord, tag string) erro
 		return err
 	}
 	if resp.StatusCode != 204 {
-		return &global.ErrNoRetry{Message: fmt.Sprintf("Error response from Discord [%d] - [%s]", resp.StatusCode, string(buf))}
+		return &global.ErrNoRetry{Message: fmt.Sprintf("Error response from Discord with request body <%s> [%d] - [%s]", json, resp.StatusCode, string(buf))}
 	}
 	return nil
 }

--- a/notify/email/email.go
+++ b/notify/email/email.go
@@ -19,6 +19,7 @@
 package email
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 	"strings"
@@ -82,6 +83,9 @@ func (c *NotifyConfig) SendMail(subject string, message string) error {
 
 	d := gomail.NewDialer(host, port, c.User, c.Pass)
 	err = d.DialAndSend(m)
+	if err != nil {
+		return fmt.Errorf("[%s / %s] - Error response from mail with body <%s>, %v", c.Kind(), c.Name(), message, err)
+	}
 
-	return err
+	return nil
 }

--- a/notify/email/email_test.go
+++ b/notify/email/email_test.go
@@ -38,6 +38,7 @@ func (mwc *MyWriteCloser) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 func assertError(t *testing.T, err error, msg string) {
+	t.Helper()
 	assert.Error(t, err)
 	assert.Equal(t, msg, err.Error())
 }

--- a/notify/lark/lark.go
+++ b/notify/lark/lark.go
@@ -86,7 +86,7 @@ func (c *NotifyConfig) SendLarkNotification(msg string) error {
 	if statusCode, ok := ret["StatusCode"].(float64); !ok || statusCode != 0 {
 		code, _ := ret["code"].(float64)
 		msg, _ := ret["msg"].(string)
-		return fmt.Errorf("Error response from Lark - code [%d] - msg [%v]", int(code), msg)
+		return fmt.Errorf("Error response from Lark with request body <%s> - code [%d] - msg [%v]", msg, int(code), msg)
 	}
 	return nil
 }

--- a/notify/lark/lark_test.go
+++ b/notify/lark/lark_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func assertError(t *testing.T, err error, msg string) {
+	t.Helper()
 	assert.Error(t, err)
 	assert.Equal(t, msg, err.Error())
 }
@@ -62,7 +63,9 @@ func TestLark(t *testing.T) {
 		}, nil
 	})
 	err = conf.SendLark("title", "message")
-	assertError(t, err, "Error response from Lark - code [0] - msg []")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Error response from Lark")
+	assert.Contains(t, err.Error(), "code [0] - msg []")
 
 	monkey.PatchInstanceMethod(reflect.TypeOf(client), "Do", func(_ *http.Client, req *http.Request) (*http.Response, error) {
 		r := io.NopCloser(strings.NewReader(`{"StatusCode": "100", "code": 10, "msg": "lark error"}`))
@@ -72,7 +75,9 @@ func TestLark(t *testing.T) {
 		}, nil
 	})
 	err = conf.SendLark("title", "message")
-	assertError(t, err, "Error response from Lark - code [10] - msg [lark error]")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Error response from Lark")
+	assert.Contains(t, err.Error(), "code [10] - msg [lark error]")
 
 	monkey.PatchInstanceMethod(reflect.TypeOf(client), "Do", func(_ *http.Client, req *http.Request) (*http.Response, error) {
 		r := io.NopCloser(strings.NewReader(`bad : json format`))

--- a/notify/log/log_test.go
+++ b/notify/log/log_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func assertError(t *testing.T, err error, msg string, contain bool) {
+	t.Helper()
 	assert.Error(t, err)
 	if contain {
 		assert.Contains(t, err.Error(), msg)

--- a/notify/ringcentral/ringcentral.go
+++ b/notify/ringcentral/ringcentral.go
@@ -21,7 +21,6 @@ package ringcentral
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -101,11 +100,10 @@ func (c *NotifyConfig) SendRingCentral(title, msg string) error {
 		return err
 	}
 	if resp.StatusCode != 200 {
-		log.Debugf(msg)
-		return fmt.Errorf("Error response from RingCentral - code [%d] - msg [%s]", resp.StatusCode, string(buf))
+		return fmt.Errorf("Error response from RingCentral with request body <%s> - code [%d] - msg [%s]", msgContent, resp.StatusCode, string(buf))
 	}
 	if string(buf) != "{\"status\":\"OK\"}" {
-		return errors.New("Non-ok response returned from RingCentral " + string(buf))
+		return fmt.Errorf("Non-ok response returned from RingCentral with request body <%s>, %s", msgContent, string(buf))
 	}
 	return nil
 }

--- a/notify/ringcentral/ringcentral_test.go
+++ b/notify/ringcentral/ringcentral_test.go
@@ -33,6 +33,7 @@ import (
 )
 
 func assertError(t *testing.T, err error, msg string) {
+	t.Helper()
 	assert.Error(t, err)
 	assert.Equal(t, msg, err.Error())
 }
@@ -64,7 +65,9 @@ func TestRingCentral(t *testing.T) {
 		}, nil
 	})
 	err = conf.SendRingCentral("title", "message")
-	assertError(t, err, "Non-ok response returned from RingCentral {\"status\": \"error\",\"message\": \"Your request was accepted, however a post was not generated\",\"error\": \"Webhook not found!\"}")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Non-ok response returned from RingCentral")
+	assert.Contains(t, err.Error(), "{\"status\": \"error\",\"message\": \"Your request was accepted, however a post was not generated\",\"error\": \"Webhook not found!\"}")
 
 	monkey.Patch(io.ReadAll, func(_ io.Reader) ([]byte, error) {
 		return nil, errors.New("read error")

--- a/notify/slack/slack.go
+++ b/notify/slack/slack.go
@@ -76,7 +76,7 @@ func (c *NotifyConfig) SendSlackNotification(msg string) error {
 	}
 	if resp.StatusCode != 200 {
 		log.Debugf(msg)
-		return fmt.Errorf("Error response from Slack - code [%d] - msg [%s]", resp.StatusCode, string(buf))
+		return fmt.Errorf("Error response from Slack with request body <%s> - code [%d] - msg [%s]", msg, resp.StatusCode, string(buf))
 	}
 	return nil
 }

--- a/notify/slack/slack_test.go
+++ b/notify/slack/slack_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func assertError(t *testing.T, err error, msg string) {
+	t.Helper()
 	assert.Error(t, err)
 	assert.Equal(t, msg, err.Error())
 }
@@ -63,7 +64,7 @@ func TestSlack(t *testing.T) {
 		}, nil
 	})
 	err = conf.SendSlack("title", "message")
-	assertError(t, err, "Error response from Slack - code [404] - msg [not found]")
+	assertError(t, err, "Error response from Slack with request body <message> - code [404] - msg [not found]")
 
 	monkey.Patch(io.ReadAll, func(_ io.Reader) ([]byte, error) {
 		return nil, errors.New("read error")

--- a/notify/sms/nexmo/nexmo.go
+++ b/notify/sms/nexmo/nexmo.go
@@ -72,7 +72,7 @@ func (c Nexmo) Notify(title, text string) error {
 		return err
 	}
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("Error response from SMS [%d] - [%s]", resp.StatusCode, string(buf))
+		return fmt.Errorf("Error response from SMS with request body <%s> [%d] - [%s]", form.Encode(), resp.StatusCode, string(buf))
 	}
 	return nil
 }

--- a/notify/sms/nexmo/nexmo_test.go
+++ b/notify/sms/nexmo/nexmo_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func assertError(t *testing.T, err error, msg string) {
+	t.Helper()
 	assert.Error(t, err)
 	assert.Equal(t, msg, err.Error())
 }
@@ -57,7 +58,7 @@ func testNotify(t *testing.T, provider conf.Provider) {
 		}, nil
 	})
 	err = provider.Notify("title", "text")
-	assertError(t, err, "Error response from SMS [500] - [Internal Server Error]")
+	assertError(t, err, "Error response from SMS with request body <From=&To=&api_key=&api_secret=&text=text> [500] - [Internal Server Error]")
 
 	monkey.Patch(io.ReadAll, func(_ io.Reader) ([]byte, error) {
 		return nil, errors.New("read error")

--- a/notify/sms/twilio/twilio.go
+++ b/notify/sms/twilio/twilio.go
@@ -72,7 +72,7 @@ func (c Twilio) Notify(title, text string) error {
 		return err
 	}
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("Error response from SMS [%d] - [%s]", resp.StatusCode, string(buf))
+		return fmt.Errorf("Error response from SMS with request body <%s> [%d] - [%s]", form.Encode(), resp.StatusCode, string(buf))
 	}
 	return nil
 }

--- a/notify/sms/twilio/twilio_test.go
+++ b/notify/sms/twilio/twilio_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func assertError(t *testing.T, err error, msg string) {
+	t.Helper()
 	assert.Error(t, err)
 	assert.Equal(t, msg, err.Error())
 }
@@ -56,7 +57,7 @@ func testNotify(t *testing.T, provider conf.Provider) {
 		}, nil
 	})
 	err = provider.Notify("title", "text")
-	assertError(t, err, "Error response from SMS [500] - [Internal Server Error]")
+	assertError(t, err, "Error response from SMS with request body <From=&To=&text=text> [500] - [Internal Server Error]")
 
 	monkey.Patch(io.ReadAll, func(_ io.Reader) ([]byte, error) {
 		return nil, errors.New("read error")

--- a/notify/sms/yunpian/yunpian.go
+++ b/notify/sms/yunpian/yunpian.go
@@ -70,7 +70,7 @@ func (c Yunpian) Notify(title, text string) error {
 		return err
 	}
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("Error response from SMS [%d] - [%s]", resp.StatusCode, string(buf))
+		return fmt.Errorf("Error response from SMS with request body <%s> [%d] - [%s]", form.Encode(), resp.StatusCode, string(buf))
 	}
 	return nil
 }

--- a/notify/sms/yunpian/yunpian_test.go
+++ b/notify/sms/yunpian/yunpian_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func assertError(t *testing.T, err error, msg string) {
+	t.Helper()
 	assert.Error(t, err)
 	assert.Equal(t, msg, err.Error())
 }
@@ -56,7 +57,7 @@ func testNotify(t *testing.T, provider conf.Provider) {
 		}, nil
 	})
 	err = provider.Notify("title", "text")
-	assertError(t, err, "Error response from SMS [500] - [Internal Server Error]")
+	assertError(t, err, "Error response from SMS with request body <apikey=&mobile=&text=text> [500] - [Internal Server Error]")
 
 	monkey.Patch(io.ReadAll, func(_ io.Reader) ([]byte, error) {
 		return nil, errors.New("read error")

--- a/notify/teams/teams.go
+++ b/notify/teams/teams.go
@@ -88,7 +88,7 @@ func (c *NotifyConfig) SendTeamsMessage(title, msg string) error {
 		return err
 	}
 	if resp.StatusCode != 200 && string(buf) != "1" {
-		return fmt.Errorf("error response from Teams Webhook - code [%d] - msg [%s]", resp.StatusCode, string(buf))
+		return fmt.Errorf("error response from Teams Webhook with request body <%s> - code [%d] - msg [%s]", json, resp.StatusCode, string(buf))
 	}
 	return nil
 }

--- a/notify/teams/teams_test.go
+++ b/notify/teams/teams_test.go
@@ -33,11 +33,12 @@ import (
 )
 
 func assertError(t *testing.T, err error, msg string) {
+	t.Helper()
 	assert.Error(t, err)
 	assert.Equal(t, msg, err.Error())
 }
 
-func TestSlack(t *testing.T) {
+func TestTeams(t *testing.T) {
 	conf := &NotifyConfig{}
 	conf.NotifyName = "dummy"
 	err := conf.Config(global.NotifySettings{})
@@ -64,7 +65,7 @@ func TestSlack(t *testing.T) {
 		}, nil
 	})
 	err = conf.SendTeamsMessage("title", "message")
-	assertError(t, err, "error response from Teams Webhook - code [404] - msg [not found]")
+	assertError(t, err, "error response from Teams Webhook with request body <{\"@type\":\"MessageCard\",\"@context\":\"https://schema.org/extensions\",\"title\":\"title\",\"text\":\"message\"}> - code [404] - msg [not found]")
 
 	monkey.Patch(io.ReadAll, func(_ io.Reader) ([]byte, error) {
 		return nil, errors.New("read error")

--- a/notify/telegram/telegram_test.go
+++ b/notify/telegram/telegram_test.go
@@ -47,6 +47,7 @@ func generateRandomString(length int) string {
 }
 
 func assertError(t *testing.T, err error, msg string) {
+	t.Helper()
 	assert.Error(t, err)
 	assert.Equal(t, msg, err.Error())
 }

--- a/notify/wecom/wecom.go
+++ b/notify/wecom/wecom.go
@@ -89,7 +89,7 @@ func (c *NotifyConfig) SendWecomNotification(msg string) error {
 		return err
 	}
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("Error response from Wecom - code [%d] - msg [%s]", resp.StatusCode, string(buf))
+		return fmt.Errorf("Error response from Wecom with request body <%s> - code [%d] - msg [%s]", msgContent, resp.StatusCode, string(buf))
 	}
 	// It will be better to check response body.
 	return nil

--- a/notify/wecom/wecom_test.go
+++ b/notify/wecom/wecom_test.go
@@ -32,11 +32,12 @@ import (
 )
 
 func assertError(t *testing.T, err error, msg string) {
+	t.Helper()
 	assert.Error(t, err)
 	assert.Equal(t, msg, err.Error())
 }
 
-func TestSlack(t *testing.T) {
+func TestWecom(t *testing.T) {
 	conf := &NotifyConfig{}
 	conf.NotifyName = "dummy"
 	err := conf.Config(global.NotifySettings{})
@@ -63,7 +64,7 @@ func TestSlack(t *testing.T) {
 		}, nil
 	})
 	err = conf.SendWecom("title", "message")
-	assertError(t, err, "Error response from Wecom - code [404] - msg [not found]")
+	assertError(t, err, "Error response from Wecom with request body <\n\t{\n\t\t\"msgtype\": \"markdown\",\n\t\t\"markdown\": {\n\t\t\t\"content\": \"message\"\n\t\t}\n\t}\n\t> - code [404] - msg [not found]")
 
 	monkey.Patch(io.ReadAll, func(_ io.Reader) ([]byte, error) {
 		return nil, errors.New("read error")


### PR DESCRIPTION
As highlighted in issues #468 and #467, users of EaseProbe encounter difficulties in diagnosing problems when a notification fails to send. The primary challenge lies in the limited information provided by the error messages, which typically consist only of an error code and a brief description. To effectively troubleshoot, users require more detailed data, specifically the request body sent to the notification server.

This PR introduces an enhancement that appends the request body to the error message. With this change, users will receive comprehensive information regarding the failed notification attempt. This addition enables users to easily identify the content sent to the notification server, facilitating quicker and more accurate problem resolution.