### PR TITLE
fix tls metrics

### DIFF
--- a/probe/tls/tls.go
+++ b/probe/tls/tls.go
@@ -141,7 +141,7 @@ func (t *TLS) DoProbe() (bool, string) {
 	t.metrics.EarliestCertExpiry.With(metric.AddConstLabels(prometheus.Labels{
 		"endpoint": t.ProbeResult.Endpoint,
 	}, t.Labels)).Set(float64(getEarliestCertExpiry(&state).Unix()))
-	t.metrics.EarliestCertExpiry.With(metric.AddConstLabels(prometheus.Labels{
+	t.metrics.LastChainExpiryTimestampSeconds.With(metric.AddConstLabels(prometheus.Labels{
 		"endpoint": t.ProbeResult.Endpoint,
 	}, t.Labels)).Set(float64(getLastChainExpiry(&state).Unix()))
 


### PR DESCRIPTION
fix #496 which was introduced by https://github.com/megaease/easeprobe/pull/386/files#diff-f4ba94b6ceb9d73b8797e5ca558f756010112d0d6b71ca4ffcdf3da10fbe2c1f