### PR TITLE
fix multi failure notify

### DIFF
--- a/probe/base/base.go
+++ b/probe/base/base.go
@@ -208,7 +208,9 @@ func (d *DefaultProbe) Probe() probe.Result {
 	title := status.Title()
 
 	// process the notification strategy
-	d.ProbeResult.Stat.NotificationStrategyData.ProcessStatus(status == probe.StatusUp)
+	if status != probe.StatusInit {
+		d.ProbeResult.Stat.NotificationStrategyData.ProcessStatus(status == probe.StatusUp)
+	}
 
 	if len(d.ProbeTag) > 0 {
 		d.ProbeResult.Message = fmt.Sprintf("%s (%s/%s): %s", title, d.ProbeKind, d.ProbeTag, msg)


### PR DESCRIPTION
Fix #523 

In `channel.go` within the `Channel.WatchEvent` function, the code checks `result` and uses its information to decide whether to send a notification. However, in `notification_strategy.go`, the `NotificationStrategyData.ProcessStatus` function updates the status and the number of notifications sent.

This means that in the case of #523, since the failure count is set to 2 and a failure occurs in the `init` state, the channel does not send a notification because it is in the `init` state. However, `NotificationStrategyData` considers the notification already sent and `IsExceedMaxTimes` returns true.

As a result, no notification is sent. To fix this problem, when in the init state, `NotificationStrategyData` should not be updated. According to the logic and comments in `channel.go`, `init` is a special state. This fix should be fine.
