### PR TITLE
fix: wrong default `TimeFormat`

### DIFF
--- a/cmd/easeprobe/report.go
+++ b/cmd/easeprobe/report.go
@@ -95,6 +95,7 @@ func scheduleSLA(probers []probe.Prober) {
 	}
 
 	time := conf.Get().Settings.SLAReport.Time
+	tz := global.GetEaseProbe().TimeZone
 	switch conf.Get().Settings.SLAReport.Schedule {
 	case conf.Minutely:
 		cron.Cron("* * * * *").Do(SLAFn)
@@ -104,16 +105,16 @@ func scheduleSLA(probers []probe.Prober) {
 		log.Infof("Scheduling hourly SLA reports...")
 	case conf.Daily:
 		cron.Every(1).Day().At(time).Do(SLAFn)
-		log.Infof("Scheduling daily SLA reports at %s UTC time...", time)
+		log.Infof("Scheduling daily SLA reports at %s %s time...", time, tz)
 	case conf.Weekly:
 		cron.Every(1).Day().Sunday().At(time).Do(SLAFn)
-		log.Infof("Scheduling weekly SLA reports on Sunday at %s UTC time...", time)
+		log.Infof("Scheduling weekly SLA reports on Sunday at %s %s time...", time, tz)
 	case conf.Monthly:
 		cron.Every(1).MonthLastDay().At(time).Do(SLAFn)
-		log.Infof("Scheduling monthly SLA reports for last day of the month at %s UTC time...", time)
+		log.Infof("Scheduling monthly SLA reports for last day of the month at %s %s time...", time, tz)
 	default:
 		cron.Every(1).Day().At("00:00").Do(SLAFn)
-		log.Warnf("Bad Scheduling! Setting daily SLA reports to be sent at 00:00 UTC...")
+		log.Warnf("Bad Scheduling! Setting daily SLA reports to be sent at 00:00 %s...", tz)
 	}
 
 	cron.StartAsync()

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -310,8 +310,8 @@ func New(conf *string) (*Conf, error) {
 			IconURL:    global.DefaultIconURL,
 			PIDFile:    filepath.Join(global.GetWorkDir(), global.DefaultPIDFile),
 			Log:        NewLog(),
-			TimeFormat: "2006-01-02 15:04:05 UTC",
-			TimeZone:   "UTC",
+			TimeFormat: global.DefaultTimeFormat,
+			TimeZone:   global.DefaultTimeZone,
 			Probe: Probe{
 				Interval: global.DefaultProbeInterval,
 				Timeout:  global.DefaultTimeOut,

--- a/docs/Manual.md
+++ b/docs/Manual.md
@@ -1191,7 +1191,9 @@ settings:
   sla:
     #  minutely, hourly, daily, weekly (Sunday), monthly (Last Day), none
     schedule: "weekly"
-    # UTC time, the format is 'hour:min:sec'
+    # the time to send the SLA report. Ignored on hourly and minutely schedules
+    # - the format is 'hour:min:sec'.
+    # - the timezone can be configured by `settings.timezone`, default is UTC.
     time: "23:59"
 ```
 


### PR DESCRIPTION
The default timezone is `2006-01-02 15:04:05 UTC` not `2006-01-02 15:04:05 Z0700`.
Just fixed it.