### PR TITLE
Make linger configurable

### DIFF
--- a/docs/Manual.md
+++ b/docs/Manual.md
@@ -277,7 +277,7 @@ http:
   # A Website without SO_LINGER
   - name: MegaEase Website (Global)
     url: https://megaease.com
-    linger: false
+    nolinger: true
     labels:
       team:  ease
       owner: megaease
@@ -346,7 +346,7 @@ http:
       expression: "x_time('//feed/updated') > '2022-07-01'" # the expression to evaluate.
     # configuration
     timeout: 10s # default is 30 seconds
-    linger: false # Do not set SO_LINGER
+    nolinger: true # Do not set SO_LINGER
 ```
 
 > **Note**:
@@ -519,7 +519,7 @@ tcp:
     host: example.com:22
     timeout: 10s # default is 30 seconds
     interval: 2m # default is 60 seconds
-    linger: false # Disable SO_LINGER
+    nolinger: true # Disable SO_LINGER
     proxy: socks5://proxy.server:1080 # Optional. Only support socks5.
                                       # Also support the `ALL_PROXY` environment.
     labels:
@@ -649,7 +649,7 @@ ssh:
       username: ubuntu
       key: /path/to/private.key
       cmd: "ps -ef | grep kafka"
-      linger: false # Disable SO_LINGER
+      nolinger: true # Disable SO_LINGER
 ```
 > **Note**:
 >
@@ -665,7 +665,7 @@ tls:
     host: expired.badssl.com:443
     proxy: socks5://proxy.server:1080 # Optional. Only support socks5.
                                       # Also support the `ALL_PROXY` environment.
-    linger: false              # Disable SO_LINGER
+    nolinger: true             # Disable SO_LINGER
     insecure_skip_verify: true # don't check cert validity
     expire_skip_verify: true   # don't check cert expire date
     alert_expire_before: 168h  # alert if cert expire date is before X, the value is a Duration,

--- a/docs/Manual.md
+++ b/docs/Manual.md
@@ -274,13 +274,14 @@ the following example configuration is a basic HTTP probe configuration, which o
 # HTTP Probe Configuration
 
 http:
-  # A Website
+  # A Website without SO_LINGER
   - name: MegaEase Website (Global)
     url: https://megaease.com
+    linger: false
     labels:
       team:  ease
       owner: megaease
-  # Some of the Software support the HTTP Query
+  # Some of the Software supports HTTP probing
   - name: ElasticSearch
     url: http://elasticsearch.server:9200
   - name: Eureka
@@ -345,6 +346,7 @@ http:
       expression: "x_time('//feed/updated') > '2022-07-01'" # the expression to evaluate.
     # configuration
     timeout: 10s # default is 30 seconds
+    linger: false # Do not set SO_LINGER
 ```
 
 > **Note**:
@@ -517,6 +519,7 @@ tcp:
     host: example.com:22
     timeout: 10s # default is 30 seconds
     interval: 2m # default is 60 seconds
+    linger: false # Disable SO_LINGER
     proxy: socks5://proxy.server:1080 # Optional. Only support socks5.
                                       # Also support the `ALL_PROXY` environment.
     labels:
@@ -646,6 +649,7 @@ ssh:
       username: ubuntu
       key: /path/to/private.key
       cmd: "ps -ef | grep kafka"
+      linger: false # Disable SO_LINGER
 ```
 > **Note**:
 >
@@ -661,6 +665,7 @@ tls:
     host: expired.badssl.com:443
     proxy: socks5://proxy.server:1080 # Optional. Only support socks5.
                                       # Also support the `ALL_PROXY` environment.
+    linger: false              # Disable SO_LINGER
     insecure_skip_verify: true # don't check cert validity
     expire_skip_verify: true   # don't check cert expire date
     alert_expire_before: 168h  # alert if cert expire date is before X, the value is a Duration,

--- a/probe/http/http.go
+++ b/probe/http/http.go
@@ -49,7 +49,7 @@ type HTTP struct {
 	Method            string            `yaml:"method,omitempty" json:"method,omitempty" jsonschema:"enum=GET,enum=POST,enum=DELETE,enum=PUT,enum=HEAD,enum=OPTIONS,enum=PATCH,enum=TRACE,enum=CONNECT,title=HTTP Method,description=HTTP method to use for HTTP requests"`
 	Headers           map[string]string `yaml:"headers,omitempty" json:"headers,omitempty" jsonschema:"title=HTTP Headers,description=HTTP headers to use for HTTP requests"`
 	Body              string            `yaml:"body,omitempty" json:"body,omitempty" jsonschema:"title=HTTP Body,description=HTTP body to use for HTTP requests"`
-	Linger            bool              `yaml:"linger" json:"linger" jsonschema:"format=linger,title=Set SO_LINGER,description=Set SO_LINGER TCP flag, default=true"`
+	NoLinger          bool              `yaml:"nolinger" json:"nolinger" jsonschema:"format=nolinger,title=Disable SO_LINGER,description=Disable SO_LINGER TCP flag, default=false"`
 
 	// Output Text Checker
 	probe.TextChecker `yaml:",inline"`
@@ -119,7 +119,7 @@ func (h *HTTP) Config(gConf global.ProbeSettings) error {
 			tcpConn, ok := conn.(*net.TCPConn)
 			if ok {
 				log.Debugf("[%s / %s] dial %s:%s", h.ProbeKind, h.ProbeName, network, addr)
-				if h.Linger {
+				if !h.NoLinger {
 					// disable the default TCP delayed-close behavior,
 					// which send the RST to the peer when the connection is closed.
 					// this would remove the TIME_WAIT state of the TCP connection.

--- a/probe/http/http.go
+++ b/probe/http/http.go
@@ -49,6 +49,7 @@ type HTTP struct {
 	Method            string            `yaml:"method,omitempty" json:"method,omitempty" jsonschema:"enum=GET,enum=POST,enum=DELETE,enum=PUT,enum=HEAD,enum=OPTIONS,enum=PATCH,enum=TRACE,enum=CONNECT,title=HTTP Method,description=HTTP method to use for HTTP requests"`
 	Headers           map[string]string `yaml:"headers,omitempty" json:"headers,omitempty" jsonschema:"title=HTTP Headers,description=HTTP headers to use for HTTP requests"`
 	Body              string            `yaml:"body,omitempty" json:"body,omitempty" jsonschema:"title=HTTP Body,description=HTTP body to use for HTTP requests"`
+	Linger            bool              `yaml:"linger" json:"linger" jsonschema:"format=linger,title=Set SO_LINGER,description=Set SO_LINGER TCP flag, default=true"`
 
 	// Output Text Checker
 	probe.TextChecker `yaml:",inline"`
@@ -118,9 +119,12 @@ func (h *HTTP) Config(gConf global.ProbeSettings) error {
 			tcpConn, ok := conn.(*net.TCPConn)
 			if ok {
 				log.Debugf("[%s / %s] dial %s:%s", h.ProbeKind, h.ProbeName, network, addr)
-				tcpConn.SetLinger(0) // disable the default TCP delayed-close behavior,
-				// which send the RST to the peer when the connection is closed.
-				// this would remove the TIME_wAIT state of the TCP connection.
+				if h.Linger {
+					// disable the default TCP delayed-close behavior,
+					// which send the RST to the peer when the connection is closed.
+					// this would remove the TIME_WAIT state of the TCP connection.
+					tcpConn.SetLinger(0)
+				}
 				return tcpConn, nil
 			}
 			return conn, nil

--- a/probe/ssh/ssh.go
+++ b/probe/ssh/ssh.go
@@ -44,7 +44,7 @@ type Server struct {
 	Command           string   `yaml:"cmd" json:"cmd,omitempty" jsonschema:"title=Shell Command,description=command to run"`
 	Args              []string `yaml:"args,omitempty" json:"args,omitempty" jsonschema:"title=Shell Command Arguments,description=arguments for the command"`
 	Env               []string `yaml:"env,omitempty" json:"env,omitempty" jsonschema:"title=Environment Variables,description=environment variables for the command"`
-	Linger            bool     `yaml:"linger" json:"linger" jsonschema:"format=linger,title=Set SO_LINGER,description=Set SO_LINGER TCP flag, default=true"`
+	NoLinger          bool     `yaml:"nolinger" json:"nolinger" jsonschema:"format=nolinger,title=Disable SO_LINGER,description=Disable SO_LINGER TCP flag, default=false"`
 
 	// Output Text Checker
 	probe.TextChecker `yaml:",inline"`
@@ -216,7 +216,7 @@ func (s *Server) GetSSHClientFromBastion() error {
 		return fmt.Errorf("Server: %s", err)
 	}
 
-	if tcpConn, ok := conn.(*net.TCPConn); ok && s.Linger {
+	if tcpConn, ok := conn.(*net.TCPConn); ok && !s.NoLinger {
 		tcpConn.SetLinger(0)
 	}
 

--- a/probe/ssh/ssh.go
+++ b/probe/ssh/ssh.go
@@ -44,6 +44,7 @@ type Server struct {
 	Command           string   `yaml:"cmd" json:"cmd,omitempty" jsonschema:"title=Shell Command,description=command to run"`
 	Args              []string `yaml:"args,omitempty" json:"args,omitempty" jsonschema:"title=Shell Command Arguments,description=arguments for the command"`
 	Env               []string `yaml:"env,omitempty" json:"env,omitempty" jsonschema:"title=Environment Variables,description=environment variables for the command"`
+	Linger            bool     `yaml:"linger" json:"linger" jsonschema:"format=linger,title=Set SO_LINGER,description=Set SO_LINGER TCP flag, default=true"`
 
 	// Output Text Checker
 	probe.TextChecker `yaml:",inline"`
@@ -215,7 +216,7 @@ func (s *Server) GetSSHClientFromBastion() error {
 		return fmt.Errorf("Server: %s", err)
 	}
 
-	if tcpConn, ok := conn.(*net.TCPConn); ok {
+	if tcpConn, ok := conn.(*net.TCPConn); ok && s.Linger {
 		tcpConn.SetLinger(0)
 	}
 

--- a/probe/tcp/tcp.go
+++ b/probe/tcp/tcp.go
@@ -32,6 +32,7 @@ type TCP struct {
 	base.DefaultProbe `yaml:",inline"`
 	Host              string `yaml:"host" json:"host" jsonschema:"required,format=hostname,title=Host,description=The host to probe"`
 	Proxy             string `yaml:"proxy" json:"proxy,omitempty" jsonschema:"format=hostname,title=Proxy,description=The proxy to use"`
+	Linger            bool   `yaml:"linger" json:"linger" jsonschema:"format=linger,title=Set SO_LINGER,description=Set SO_LINGER TCP flag, default=true"`
 }
 
 // Config HTTP Config Object
@@ -56,7 +57,7 @@ func (t *TCP) DoProbe() (bool, string) {
 		status = false
 	} else {
 		message = "TCP Connection Established Successfully!"
-		if tcpCon, ok := conn.(*net.TCPConn); ok {
+		if tcpCon, ok := conn.(*net.TCPConn); ok && t.Linger {
 			tcpCon.SetLinger(0)
 		}
 		defer conn.Close()

--- a/probe/tcp/tcp.go
+++ b/probe/tcp/tcp.go
@@ -32,7 +32,7 @@ type TCP struct {
 	base.DefaultProbe `yaml:",inline"`
 	Host              string `yaml:"host" json:"host" jsonschema:"required,format=hostname,title=Host,description=The host to probe"`
 	Proxy             string `yaml:"proxy" json:"proxy,omitempty" jsonschema:"format=hostname,title=Proxy,description=The proxy to use"`
-	Linger            bool   `yaml:"linger" json:"linger" jsonschema:"format=linger,title=Set SO_LINGER,description=Set SO_LINGER TCP flag, default=true"`
+	NoLinger          bool   `yaml:"nolinger" json:"nolinger" jsonschema:"format=nolinger,title=Disable SO_LINGER,description=Disable SO_LINGER TCP flag, default=false"`
 }
 
 // Config HTTP Config Object
@@ -57,7 +57,7 @@ func (t *TCP) DoProbe() (bool, string) {
 		status = false
 	} else {
 		message = "TCP Connection Established Successfully!"
-		if tcpCon, ok := conn.(*net.TCPConn); ok && t.Linger {
+		if tcpCon, ok := conn.(*net.TCPConn); ok && !t.NoLinger {
 			tcpCon.SetLinger(0)
 		}
 		defer conn.Close()

--- a/probe/tls/tls.go
+++ b/probe/tls/tls.go
@@ -42,7 +42,7 @@ type TLS struct {
 	Host               string `yaml:"host" json:"host" jsonschema:"required,format=hostname,title=Host,description=The host to probe"`
 	Proxy              string `yaml:"proxy" json:"proxy,omitempty" jsonschema:"format=hostname,title=Proxy,description=The proxy to use for the TLS connection"`
 	InsecureSkipVerify bool   `yaml:"insecure_skip_verify" json:"insecure_skip_verify,omitempty" jsonschema:"title=Insecure Skip Verify,description=Whether to skip verifying the certificate chain and host name"`
-	Linger             bool   `yaml:"linger" json:"linger" jsonschema:"format=linger,title=Set SO_LINGER,description=Set SO_LINGER TCP flag, default=true"`
+	NoLinger           bool   `yaml:"nolinger" json:"nolinger" jsonschema:"format=nolinger,title=Disable SO_LINGER,description=Disable SO_LINGER TCP flag, default=false"`
 
 	RootCAPemPath string         `yaml:"root_ca_pem_path" json:"root_ca_pem_path,omitempty" jsonschema:"title=Root CA PEM Path,description=The path to the root CA PEM file"`
 	RootCaPem     string         `yaml:"root_ca_pem" json:"root_ca_pem,omitempty" jsonschema:"title=Root CA PEM,description=The root CA PEM"`
@@ -92,7 +92,7 @@ func (t *TLS) DoProbe() (bool, string) {
 		log.Errorf("[%s / %s] tcp dial error: %v", t.ProbeKind, t.ProbeName, err)
 		return false, fmt.Sprintf("tcp dial error: %v", err)
 	}
-	if tcpConn, ok := conn.(*net.TCPConn); ok && t.Linger {
+	if tcpConn, ok := conn.(*net.TCPConn); ok && !t.NoLinger {
 		tcpConn.SetLinger(0)
 	}
 	defer conn.Close()

--- a/probe/tls/tls.go
+++ b/probe/tls/tls.go
@@ -42,6 +42,7 @@ type TLS struct {
 	Host               string `yaml:"host" json:"host" jsonschema:"required,format=hostname,title=Host,description=The host to probe"`
 	Proxy              string `yaml:"proxy" json:"proxy,omitempty" jsonschema:"format=hostname,title=Proxy,description=The proxy to use for the TLS connection"`
 	InsecureSkipVerify bool   `yaml:"insecure_skip_verify" json:"insecure_skip_verify,omitempty" jsonschema:"title=Insecure Skip Verify,description=Whether to skip verifying the certificate chain and host name"`
+	Linger             bool   `yaml:"linger" json:"linger" jsonschema:"format=linger,title=Set SO_LINGER,description=Set SO_LINGER TCP flag, default=true"`
 
 	RootCAPemPath string         `yaml:"root_ca_pem_path" json:"root_ca_pem_path,omitempty" jsonschema:"title=Root CA PEM Path,description=The path to the root CA PEM file"`
 	RootCaPem     string         `yaml:"root_ca_pem" json:"root_ca_pem,omitempty" jsonschema:"title=Root CA PEM,description=The root CA PEM"`
@@ -91,7 +92,7 @@ func (t *TLS) DoProbe() (bool, string) {
 		log.Errorf("[%s / %s] tcp dial error: %v", t.ProbeKind, t.ProbeName, err)
 		return false, fmt.Sprintf("tcp dial error: %v", err)
 	}
-	if tcpConn, ok := conn.(*net.TCPConn); ok {
+	if tcpConn, ok := conn.(*net.TCPConn); ok && t.Linger {
 		tcpConn.SetLinger(0)
 	}
 	defer conn.Close()


### PR DESCRIPTION
The following PR is an attempt to make SO_LINGER option configurable. 

It introduces a new `bool` option named `nolinger` for tcp, tls, http and ssh probes which disables `SO_LINGER`. Default value set to `false` to match the previous easeprobe operation and not require configuration changes when updated.

Documentation also updated to include the addition of this option.

Notes:
* Needs testing (i am unable to test it currently)
* I dont know how to implement the new option for our test cases.