### PR TITLE
add option to print output when meet error

### DIFF
--- a/docs/Manual.md
+++ b/docs/Manual.md
@@ -340,6 +340,7 @@ http:
     # Response Checking
     contain: "success" # response body must contain this string, if not the probe is considered failed.
     not_contain: "failure" # response body must NOT contain this string, if it does the probe is considered failed.
+    with_output: false # if true, the error message will contain the output, it works for `contain` and `not_contain` field.
     regex: false # if true, the contain and not_contain will be treated as regular expression. default: false
     eval: # eval is a expression evaluation for HTTP response message
       doc: XML # support  XML, JSON, HTML, TEXT.
@@ -579,6 +580,7 @@ shell:
     # check the command output, if does not contain the PONG, mark the status down
     contain : "PONG"
     not_contain: "failure" # response body must NOT contain this string, if it does the probe is considered failed.
+    with_output: false # if true, the error message will contain the output, it works for `contain` and `not_contain` field.
     regex: false # if true, the `contain` and `not_contain` will be treated as regular expression. default: false
 
   # Run Zookeeper command `stat` to check the zookeeper status
@@ -640,6 +642,7 @@ ssh:
       # check the command output, if does not contain the PONG, mark the status down
       contain : "PONG"
       not_contain: "failure" # response body must NOT contain this string, if it does the probe is considered failed.
+      with_output: false # if true, the error message will contain the output, it works for `contain` and `not_contain` field.
       regex: false # if true, the contain and not_contain will be treated as regular expression. default: false
 
     # Check the process status of `Kafka`
@@ -1496,6 +1499,7 @@ http:
     # Response Checking
     contain: "success" # response body must contain this string, if not the probe is considered failed.
     not_contain: "failure" # response body must NOT contain this string, if it does the probe is considered failed.
+    with_output: false # if true, the error message will contain the output, it works for `contain` and `not_contain` field.
     regex: false # if true, the contain and not_contain will be treated as regular expression. default: false
     eval: # eval is a expression evaluation for HTTP response message
       doc: XML # support  XML, JSON, HTML, TEXT.
@@ -1547,6 +1551,7 @@ shell:
     # check the command output, if does not contain the PONG, mark the status down
     contain : "PONG"
     not_contain: "failure" # response body must NOT contain this string, if it does the probe is considered failed.
+    with_output: false # if true, the error message will contain the output, it works for `contain` and `not_contain` field.
     regex: false # if true, the `contain` and `not_contain` will be treated as regular expression. default: false
 
 
@@ -1584,6 +1589,7 @@ ssh:
       # check the command output, if does not contain the PONG, mark the status down
       contain : "PONG"
       not_contain: "failure" # response body must NOT contain this string, if it does the probe is considered failed.
+      with_output: false # if true, the error message will contain the output, it works for `contain` and `not_contain` field.
       regex: false # if true, the contain and not_contain will be treated as regular expression. default: false
 
     # Check the process status of `Kafka`

--- a/probe/common.go
+++ b/probe/common.go
@@ -28,6 +28,7 @@ type TextChecker struct {
 	Contain    string `yaml:"contain,omitempty" json:"contain,omitempty" jsonschema:"title=Contain Text,description=the string must be contained"`
 	NotContain string `yaml:"not_contain,omitempty" json:"not_contain,omitempty" jsonschema:"title=Not Contain Text,description=the string must not be contained"`
 	RegExp     bool   `yaml:"regex,omitempty" json:"regex,omitempty" jsonschema:"title=regex,description=use regular expression to check the contain or not contain"`
+	WithOutput bool   `yaml:"with_output,omitempty" json:"with_output,omitempty" jsonschema:"title=with_output,description=generate error message with the output"`
 
 	containReg    *regexp.Regexp `yaml:"-" json:"-"`
 	notContainReg *regexp.Regexp `yaml:"-" json:"-"`
@@ -77,10 +78,16 @@ func (tc *TextChecker) String() string {
 func (tc *TextChecker) CheckText(Output string) error {
 
 	if len(tc.Contain) > 0 && !strings.Contains(Output, tc.Contain) {
+		if tc.WithOutput {
+			return fmt.Errorf("the output does not contain [%s], the output is:\n[%s]", tc.Contain, Output)
+		}
 		return fmt.Errorf("the output does not contain [%s]", tc.Contain)
 	}
 
 	if len(tc.NotContain) > 0 && strings.Contains(Output, tc.NotContain) {
+		if tc.WithOutput {
+			return fmt.Errorf("the output contains [%s], the output is:\n[%s]", tc.NotContain, Output)
+		}
 		return fmt.Errorf("the output contains [%s]", tc.NotContain)
 	}
 	return nil
@@ -92,10 +99,16 @@ func (tc *TextChecker) CheckText(Output string) error {
 func (tc *TextChecker) CheckRegExp(Output string) error {
 
 	if len(tc.Contain) > 0 && tc.containReg != nil && !tc.containReg.MatchString(Output) {
+		if tc.WithOutput {
+			return fmt.Errorf("the output does not match the pattern [%s], the output is:\n[%s]", tc.Contain, Output)
+		}
 		return fmt.Errorf("the output does not match the pattern [%s]", tc.Contain)
 	}
 
 	if len(tc.NotContain) > 0 && tc.notContainReg != nil && tc.notContainReg.MatchString(Output) {
+		if tc.WithOutput {
+			return fmt.Errorf("the output match the pattern [%s], the output is:\n[%s]", tc.NotContain, Output)
+		}
 		return fmt.Errorf("the output match the pattern [%s]", tc.NotContain)
 	}
 	return nil

--- a/probe/common_test.go
+++ b/probe/common_test.go
@@ -60,6 +60,14 @@ func TestCheckText(t *testing.T) {
 	tc.NotContain = "bad"
 	err = tc.Check("easeprobe hello world")
 	assert.NotNil(t, err)
+
+	tc = TextChecker{
+		NotContain: "hello",
+		WithOutput: true,
+	}
+	err = tc.Check("easeprobe hello world")
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "easeprobe")
 }
 
 func testRegExpHelper(t *testing.T, regExp string, str string, match bool) {


### PR DESCRIPTION
This PR add a `with_output` option that, when enabled, appends the output to the error message. 
This way, if an error occurs, users can immediately see what happened, making it easier to diagnose and resolve issues.