### PR TITLE
udpate release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ data/*.yaml
 !.github/workflows/*.yaml
 helm/easeprobe/charts/
 vendor/
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,7 +8,7 @@ before:
     - go generate ./...
 
 snapshot:
-  name_template: '{{ .Tag }}'
+  version_template: '{{ .Tag }}'
 checksum:
   name_template: 'checksums.txt'
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 before:
   hooks:
     # You may remove this if you don't use go modules.
@@ -9,8 +11,6 @@ snapshot:
   name_template: '{{ .Tag }}'
 checksum:
   name_template: 'checksums.txt'
-changelog:
-  skip: true
 
 builds:
   - id: build


### PR DESCRIPTION
based on [goreleaser doc](https://github.com/goreleaser/goreleaser/blob/599ce44c749ef13b4e6a3042ece90aa3e3f3dcaa/www/docs/deprecations.md#--rm-dist) `--rm-dist` is removed and we should use `--clean` instead.