### PR TITLE
fix json escape

### DIFF
--- a/report/result.go
+++ b/report/result.go
@@ -188,7 +188,7 @@ func ToSlack(r probe.Result) string {
 	}
 	`
 	rtt := r.RoundTripTime.Round(time.Millisecond)
-	body := fmt.Sprintf("*%s*\\n>%s %s - ⏱ %s\n>%s",
+	body := fmt.Sprintf("*%s*\\n>%s %s - ⏱ %s\\n>%s",
 		r.Title(), r.Status.Emoji(), r.Endpoint, rtt, JSONEscape(r.Message))
 	context := SlackTimeFormation(r.StartTime, " probed at ", global.GetTimeFormat())
 	summary := fmt.Sprintf("%s %s - %s", r.Title(), r.Status.Emoji(), JSONEscape(r.Message))


### PR DESCRIPTION
```
	body := fmt.Sprintf("*%s*\\n>%s %s - ⏱ %s\n>%s",
		r.Title(), r.Status.Emoji(), r.Endpoint, rtt, JSONEscape(r.Message))
	output := fmt.Sprintf(jsonMsg, summary, body, context)
```
The second `\n` in `body` will produce invalid json output, we should fix it like first `\n`, use `\\n` instead.