### PR TITLE
replace bou.ke/monkey with bytedance/mockey

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ ${TARGET}: ${SOURCE}
 build: all
 
 test:
-	go test -gcflags=-l -cover -race ${TEST_FLAGS} -v ./...
+	go test -gcflags=all=-l -cover -race ${TEST_FLAGS} -v ./...
 
 docker:
 	sudo DOCKER_BUILDKIT=1 docker build -t megaease/easeprobe -f ${MKFILE_DIR}/resources/Dockerfile ${MKFILE_DIR}

--- a/conf/conf_test.go
+++ b/conf/conf_test.go
@@ -28,8 +28,8 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/notify"
 	"github.com/megaease/easeprobe/notify/discord"
 	"github.com/megaease/easeprobe/notify/email"

--- a/conf/log_test.go
+++ b/conf/log_test.go
@@ -135,7 +135,8 @@ func TestNonSelfRotateLog(t *testing.T) {
 }
 
 func TestOpenLogFail(t *testing.T) {
-	file := "/dev"
+	// User a directory to cause failure
+	file := os.TempDir()
 
 	l := NewLog()
 	l.File = file

--- a/conf/log_test.go
+++ b/conf/log_test.go
@@ -24,7 +24,7 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
+	"github.com/megaease/easeprobe/monkey"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/natefinch/lumberjack.v2"

--- a/conf/log_test.go
+++ b/conf/log_test.go
@@ -21,10 +21,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 
-	"github.com/megaease/easeprobe/monkey"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/natefinch/lumberjack.v2"
@@ -137,14 +135,10 @@ func TestNonSelfRotateLog(t *testing.T) {
 }
 
 func TestOpenLogFail(t *testing.T) {
-	monkey.Patch(os.OpenFile, func(name string, flag int, perm os.FileMode) (*os.File, error) {
-		return nil, fmt.Errorf("error")
-	})
-
-	file := "failed"
+	file := "/dev"
 
 	l := NewLog()
-	l.File = file + ".log"
+	l.File = file
 	l.SelfRotate = false
 	l.InitLog(nil)
 	assert.Equal(t, true, l.IsStdout)
@@ -157,19 +151,13 @@ func TestOpenLogFail(t *testing.T) {
 	w := l.GetWriter()
 	assert.Equal(t, os.Stdout, w)
 
-	monkey.UnpatchAll()
-
 	// test rotate error - log file
+	file = "failed"
 	l = NewLog()
 	l.File = file + ".log"
 	l.SelfRotate = false
 	l.InitLog(nil)
 	assert.Equal(t, false, l.IsStdout)
-
-	var fp *os.File
-	monkey.PatchInstanceMethod(reflect.TypeOf(fp), "Close", func(_ *os.File) error {
-		return fmt.Errorf("error")
-	})
 
 	l.Rotate()
 	files, _ := filepath.Glob(file + "*")
@@ -185,10 +173,6 @@ func TestOpenLogFail(t *testing.T) {
 	l.InitLog(nil)
 	assert.Equal(t, false, l.IsStdout)
 
-	var lum *lumberjack.Logger
-	monkey.PatchInstanceMethod(reflect.TypeOf(lum), "Rotate", func(_ *lumberjack.Logger) error {
-		return fmt.Errorf("error")
-	})
 	l.Rotate()
 	files, _ = filepath.Glob(file + "*")
 	fmt.Println(files)
@@ -196,5 +180,4 @@ func TestOpenLogFail(t *testing.T) {
 	l.Close()
 	os.Remove(l.File)
 
-	monkey.UnpatchAll()
 }

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -23,8 +23,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -24,8 +24,8 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
 	"github.com/Knetic/govaluate"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/eval/extract_test.go
+++ b/eval/extract_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/html"
 )

--- a/global/easeprobe_test.go
+++ b/global/easeprobe_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/global/global_test.go
+++ b/global/global_test.go
@@ -33,7 +33,7 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 )

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,12 @@ toolchain go1.22.5
 
 require (
 	github.com/Knetic/govaluate v3.0.0+incompatible
-	github.com/agiledragon/gomonkey/v2 v2.11.0
 	github.com/antchfx/htmlquery v1.3.2
 	github.com/antchfx/jsonquery v1.3.5
 	github.com/antchfx/xmlquery v1.4.1
 	github.com/aws/aws-sdk-go v1.55.5
 	github.com/bradfitz/gomemcache v0.0.0-20220106215444-fb4bf637b56d
+	github.com/bytedance/mockey v1.2.12
 	github.com/go-chi/chi v4.1.2+incompatible
 	github.com/go-chi/chi/v5 v5.1.0
 	github.com/go-co-op/gocron v1.37.0
@@ -48,7 +48,9 @@ require (
 	github.com/goccy/go-json v0.10.3 // indirect
 	github.com/goccy/go-yaml v1.12.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 // indirect
 	github.com/jinzhu/copier v0.4.0 // indirect
+	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
@@ -56,9 +58,12 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/puzpuzpuz/xsync/v3 v3.4.0 // indirect
+	github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d // indirect
+	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
+	golang.org/x/arch v0.0.0-20201008161808-52c3e6f60cff // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,12 @@
 module github.com/megaease/easeprobe
 
-go 1.21
+go 1.22
+
 toolchain go1.22.5
 
 require (
-	bou.ke/monkey v1.0.2
 	github.com/Knetic/govaluate v3.0.0+incompatible
+	github.com/agiledragon/gomonkey/v2 v2.11.0
 	github.com/antchfx/htmlquery v1.3.2
 	github.com/antchfx/jsonquery v1.3.5
 	github.com/antchfx/xmlquery v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/Knetic/govaluate v3.0.0+incompatible h1:7o6+MAPhYTCF0+fdvoz1xDedhRb4f
 github.com/Knetic/govaluate v3.0.0+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/a8m/envsubst v1.4.2 h1:4yWIHXOLEJHQEFd4UjrWDrYeYlV7ncFWJOCBRLOZHQg=
 github.com/a8m/envsubst v1.4.2/go.mod h1:MVUTQNGQ3tsjOOtKCNd+fl8RzhsXcDvvAEzkhGtlsbY=
-github.com/agiledragon/gomonkey/v2 v2.11.0 h1:5oxSgA+tC1xuGsrIorR+sYiziYltmJyEZ9qA25b6l5U=
-github.com/agiledragon/gomonkey/v2 v2.11.0/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
 github.com/alecthomas/assert/v2 v2.3.0 h1:mAsH2wmvjsuvyBvAmCtm7zFsBlb8mIHx5ySLVdDZXL0=
 github.com/alecthomas/assert/v2 v2.3.0/go.mod h1:pXcQ2Asjp247dahGEmsZ6ru0UVwnkhktn7S0bBDLxvQ=
 github.com/alecthomas/participle/v2 v2.1.1 h1:hrjKESvSqGHzRb4yW1ciisFJ4p3MGYih6icjJvbsmV8=
@@ -30,6 +28,8 @@ github.com/bradfitz/gomemcache v0.0.0-20220106215444-fb4bf637b56d h1:pVrfxiGfwel
 github.com/bradfitz/gomemcache v0.0.0-20220106215444-fb4bf637b56d/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+github.com/bytedance/mockey v1.2.12 h1:aeszOmGw8CPX8CRx1DZ/Glzb1yXvhjDh6jdFBNZjsU4=
+github.com/bytedance/mockey v1.2.12/go.mod h1:3ZA4MQasmqC87Tw0w7Ygdy7eHIc2xgpZ8Pona5rsYIk=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -77,6 +77,7 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
@@ -93,6 +94,7 @@ github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHW
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
@@ -161,7 +163,9 @@ github.com/segmentio/kafka-go v0.4.47 h1:IqziR4pA3vrZq7YdRxaT3w1/5fvIH5qpCwstUan
 github.com/segmentio/kafka-go v0.4.47/go.mod h1:HjF6XbOKh0Pjlkr5GVZxt6CsjjwnmhVOfURM5KMd8qg=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
@@ -202,6 +206,8 @@ go.mongodb.org/mongo-driver v1.16.1 h1:rIVLL3q0IHM39dvE+z2ulZLp9ENZKThVfuvN/IiN4
 go.mongodb.org/mongo-driver v1.16.1/go.mod h1:oB6AhJQvFQL4LEHyXi6aJzQJtBiTQHiAd83l0GdFaiw=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+golang.org/x/arch v0.0.0-20201008161808-52c3e6f60cff h1:XmKBi9R6duxOB3lfc72wyrwiOY7X2Jl1wuI+RFOyMDE=
+golang.org/x/arch v0.0.0-20201008161808-52c3e6f60cff/go.mod h1:flIaEI6LNU6xOCD5PaJvn9wGP0agmIOqjrtsKGRguv4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
@@ -288,3 +294,4 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 mellium.im/sasl v0.3.1 h1:wE0LW6g7U83vhvxjC1IY8DnXM+EU095yeo8XClvCdfo=
 mellium.im/sasl v0.3.1/go.mod h1:xm59PUYpZHhgQ9ZqoJ5QaCqzWMi8IeS49dhp6plPCzw=
+rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
-bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
-bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/Knetic/govaluate v3.0.0+incompatible h1:7o6+MAPhYTCF0+fdvoz1xDedhRb4f6s9Tn1Tt7/WTEg=
 github.com/Knetic/govaluate v3.0.0+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/a8m/envsubst v1.4.2 h1:4yWIHXOLEJHQEFd4UjrWDrYeYlV7ncFWJOCBRLOZHQg=
 github.com/a8m/envsubst v1.4.2/go.mod h1:MVUTQNGQ3tsjOOtKCNd+fl8RzhsXcDvvAEzkhGtlsbY=
+github.com/agiledragon/gomonkey/v2 v2.11.0 h1:5oxSgA+tC1xuGsrIorR+sYiziYltmJyEZ9qA25b6l5U=
+github.com/agiledragon/gomonkey/v2 v2.11.0/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
 github.com/alecthomas/assert/v2 v2.3.0 h1:mAsH2wmvjsuvyBvAmCtm7zFsBlb8mIHx5ySLVdDZXL0=
 github.com/alecthomas/assert/v2 v2.3.0/go.mod h1:pXcQ2Asjp247dahGEmsZ6ru0UVwnkhktn7S0bBDLxvQ=
 github.com/alecthomas/participle/v2 v2.1.1 h1:hrjKESvSqGHzRb4yW1ciisFJ4p3MGYih6icjJvbsmV8=
@@ -77,6 +77,7 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
@@ -92,6 +93,7 @@ github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHW
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
@@ -159,6 +161,8 @@ github.com/segmentio/kafka-go v0.4.47 h1:IqziR4pA3vrZq7YdRxaT3w1/5fvIH5qpCwstUan
 github.com/segmentio/kafka-go v0.4.47/go.mod h1:HjF6XbOKh0Pjlkr5GVZxt6CsjjwnmhVOfURM5KMd8qg=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -207,6 +211,7 @@ golang.org/x/exp v0.0.0-20221031165847-c99f073a8326 h1:QfTh0HpN6hlw6D3vu8DAwC8pB
 golang.org/x/exp v0.0.0-20221031165847-c99f073a8326/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
@@ -251,6 +256,7 @@ golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 golang.org/x/text v0.17.0 h1:XtiM5bkSOt+ewxlOE/aE/AKEHibwj/6gvWMl9Rsh0Qc=
 golang.org/x/text v0.17.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=

--- a/metric/prometheus_test.go
+++ b/metric/prometheus_test.go
@@ -20,7 +20,7 @@ package metric
 import (
 	"testing"
 
-	"bou.ke/monkey"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )

--- a/monkey/monkey.go
+++ b/monkey/monkey.go
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package monkey is a library to patch functions and methods at runtime for testing
+package monkey
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/agiledragon/gomonkey/v2"
+)
+
+var (
+	patchesMap sync.Map
+)
+
+// Patch replaces a function with another
+func Patch(target, replacement interface{}) *gomonkey.Patches {
+	key := fmt.Sprintf("%v", target)
+
+	// If an existing patch exists, reset and delete it
+	if existingPatches, ok := patchesMap.Load(key); ok {
+		existingPatches.(*gomonkey.Patches).Reset()
+		patchesMap.Delete(key)
+	}
+
+	// Apply the new patch
+	patches := gomonkey.ApplyFunc(target, replacement)
+	patchesMap.Store(key, patches)
+	wait()
+	return patches
+}
+
+// Unpatch removes a patch
+func Unpatch(target interface{}) bool {
+	key := fmt.Sprintf("%v", target)
+
+	patches, ok := patchesMap.Load(key)
+	if !ok {
+		return false
+	}
+	patches.(*gomonkey.Patches).Reset()
+	patchesMap.Delete(key)
+	wait()
+	return true
+}
+
+// PatchInstanceMethod replaces an instance method methodName for the type target with replacement
+func PatchInstanceMethod(target reflect.Type, methodName string, replacement interface{}) *gomonkey.Patches {
+	key := fmt.Sprintf("%v:%v", target, methodName)
+
+	// If an existing patch exists, reset and delete it
+	if existingPatches, ok := patchesMap.Load(key); ok {
+		existingPatches.(*gomonkey.Patches).Reset()
+		patchesMap.Delete(key)
+	}
+
+	// Apply the new patch
+	patches := gomonkey.ApplyMethod(target, methodName, replacement)
+	patchesMap.Store(key, patches)
+	wait()
+	return patches
+}
+
+// UnpatchInstanceMethod removes a patch from an instance method
+func UnpatchInstanceMethod(target reflect.Type, methodName string) bool {
+	key := fmt.Sprintf("%v:%v", target, methodName)
+
+	patches, ok := patchesMap.Load(key)
+	if !ok {
+		return false
+	}
+	patches.(*gomonkey.Patches).Reset()
+	patchesMap.Delete(key)
+	wait()
+	return true
+}
+
+// UnpatchAll removes all patches
+func UnpatchAll() {
+	patchesMap.Range(func(key, value interface{}) bool {
+		value.(*gomonkey.Patches).Reset()
+		patchesMap.Delete(key)
+		return true
+	})
+	wait()
+}
+
+// wait ensures that the patches for darwin/arm64 are applied to prevent test failures and runtime errors, such as invalid memory address or nil pointer dereference
+func wait() {
+	if runtime.GOOS == "darwin" {
+		// use busy wait instead of time.Sleep which will cause SIGBUS error occasionally
+		endTime := time.Now().Add(100 * time.Millisecond)
+		for time.Now().Before(endTime) {
+		}
+	}
+}

--- a/monkey/monkey_test.go
+++ b/monkey/monkey_test.go
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022, MegaEase
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monkey
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type myStruct struct{}
+
+func (s *myStruct) Method() string {
+	return "original"
+}
+
+func TestPatch(t *testing.T) {
+	assert.Equal(t, "original", strings.Clone("original"))
+
+	Patch(strings.Clone, func(s string) string { return "replacement" })
+	assert.Equal(t, "replacement", strings.Clone("original"))
+
+	Unpatch(strings.Clone)
+	assert.Equal(t, "original", strings.Clone("original"))
+}
+
+func TestPatchInstanceMethod(t *testing.T) {
+	assert.Equal(t, "original", (&myStruct{}).Method())
+
+	PatchInstanceMethod(reflect.TypeOf(&myStruct{}), "Method", func(*myStruct) string { return "replacement" })
+	assert.Equal(t, "replacement", (&myStruct{}).Method())
+
+	UnpatchInstanceMethod(reflect.TypeOf(&myStruct{}), "Method")
+	assert.Equal(t, "original", (&myStruct{}).Method())
+}
+
+func TestUnpatchAll(t *testing.T) {
+	assert.Equal(t, "original", strings.Clone("original"))
+	Patch(strings.Clone, func() string { return "replacement" })
+	assert.Equal(t, "replacement", strings.Clone("original"))
+
+	assert.Equal(t, "original", (&myStruct{}).Method())
+	PatchInstanceMethod(reflect.TypeOf(&myStruct{}), "Method", func(*myStruct) string { return "replacement" })
+	assert.Equal(t, "replacement", (&myStruct{}).Method())
+
+	UnpatchAll()
+	assert.Equal(t, "original", strings.Clone("original"))
+	assert.Equal(t, "original", (&myStruct{}).Method())
+}

--- a/monkey/monkey_test.go
+++ b/monkey/monkey_test.go
@@ -34,10 +34,10 @@ func (s *myStruct) Method() string {
 func TestPatch(t *testing.T) {
 	assert.Equal(t, "original", strings.Clone("original"))
 
-	Patch(strings.Clone, func(s string) string { return "replacement" })
+	Patch(strings.Clone, func(_ string) string { return "replacement" })
 	assert.Equal(t, "replacement", strings.Clone("original"))
 
-	Patch(strings.Clone, func(s string) string { return "replacement2" })
+	Patch(strings.Clone, func(_ string) string { return "replacement2" })
 	assert.Equal(t, "replacement2", strings.Clone("original"))
 
 	Unpatch(strings.Clone)

--- a/monkey/monkey_test.go
+++ b/monkey/monkey_test.go
@@ -37,8 +37,14 @@ func TestPatch(t *testing.T) {
 	Patch(strings.Clone, func(s string) string { return "replacement" })
 	assert.Equal(t, "replacement", strings.Clone("original"))
 
+	Patch(strings.Clone, func(s string) string { return "replacement2" })
+	assert.Equal(t, "replacement2", strings.Clone("original"))
+
 	Unpatch(strings.Clone)
 	assert.Equal(t, "original", strings.Clone("original"))
+
+	result := Unpatch(strings.Clone)
+	assert.Equal(t, false, result)
 }
 
 func TestPatchInstanceMethod(t *testing.T) {
@@ -47,8 +53,14 @@ func TestPatchInstanceMethod(t *testing.T) {
 	PatchInstanceMethod(reflect.TypeOf(&myStruct{}), "Method", func(*myStruct) string { return "replacement" })
 	assert.Equal(t, "replacement", (&myStruct{}).Method())
 
+	PatchInstanceMethod(reflect.TypeOf(&myStruct{}), "Method", func(*myStruct) string { return "replacement2" })
+	assert.Equal(t, "replacement2", (&myStruct{}).Method())
+
 	UnpatchInstanceMethod(reflect.TypeOf(&myStruct{}), "Method")
 	assert.Equal(t, "original", (&myStruct{}).Method())
+
+	result := UnpatchInstanceMethod(reflect.TypeOf(&myStruct{}), "Method")
+	assert.Equal(t, false, result)
 }
 
 func TestUnpatchAll(t *testing.T) {

--- a/notify/aws/sns_test.go
+++ b/notify/aws/sns_test.go
@@ -23,11 +23,11 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sns"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/report"
 	"github.com/stretchr/testify/assert"
 )

--- a/notify/dingtalk/dingtalk_test.go
+++ b/notify/dingtalk/dingtalk_test.go
@@ -25,8 +25,8 @@ import (
 	"strings"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/report"
 	"github.com/stretchr/testify/assert"
 )

--- a/notify/discord/discord_test.go
+++ b/notify/discord/discord_test.go
@@ -30,8 +30,8 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/probe"
 	"github.com/megaease/easeprobe/probe/base"
 	"github.com/sirupsen/logrus"

--- a/notify/email/email_test.go
+++ b/notify/email/email_test.go
@@ -22,8 +22,8 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/report"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/gomail.v2"

--- a/notify/lark/lark_test.go
+++ b/notify/lark/lark_test.go
@@ -25,8 +25,8 @@ import (
 	"strings"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/report"
 	"github.com/stretchr/testify/assert"
 )

--- a/notify/log/log_test.go
+++ b/notify/log/log_test.go
@@ -22,8 +22,8 @@ import (
 	"os"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/report"
 	"github.com/stretchr/testify/assert"
 )

--- a/notify/log/log_unix_test.go
+++ b/notify/log/log_unix_test.go
@@ -24,8 +24,8 @@ import (
 	"log/syslog"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/notify/ringcentral/ringcentral_test.go
+++ b/notify/ringcentral/ringcentral_test.go
@@ -26,8 +26,8 @@ import (
 	"strings"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/report"
 	"github.com/stretchr/testify/assert"
 )

--- a/notify/slack/slack_test.go
+++ b/notify/slack/slack_test.go
@@ -25,8 +25,8 @@ import (
 	"strings"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/report"
 	"github.com/stretchr/testify/assert"
 )

--- a/notify/sms/nexmo/nexmo_test.go
+++ b/notify/sms/nexmo/nexmo_test.go
@@ -26,7 +26,7 @@ import (
 
 	"testing"
 
-	"bou.ke/monkey"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/notify/sms/conf"
 	"github.com/stretchr/testify/assert"
 )

--- a/notify/sms/sms_test.go
+++ b/notify/sms/sms_test.go
@@ -21,8 +21,8 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/notify/sms/conf"
 	"github.com/megaease/easeprobe/notify/sms/nexmo"
 	"github.com/megaease/easeprobe/notify/sms/twilio"

--- a/notify/sms/twilio/twilio_test.go
+++ b/notify/sms/twilio/twilio_test.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"testing"
 
-	"bou.ke/monkey"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/notify/sms/conf"
 	"github.com/stretchr/testify/assert"
 )

--- a/notify/sms/yunpian/yunpian_test.go
+++ b/notify/sms/yunpian/yunpian_test.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"testing"
 
-	"bou.ke/monkey"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/notify/sms/conf"
 	"github.com/stretchr/testify/assert"
 )

--- a/notify/teams/teams_test.go
+++ b/notify/teams/teams_test.go
@@ -26,8 +26,8 @@ import (
 	"strings"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/report"
 	"github.com/stretchr/testify/assert"
 )

--- a/notify/telegram/telegram_test.go
+++ b/notify/telegram/telegram_test.go
@@ -27,8 +27,8 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/report"
 	"github.com/stretchr/testify/assert"
 )

--- a/notify/wecom/wecom_test.go
+++ b/notify/wecom/wecom_test.go
@@ -25,8 +25,8 @@ import (
 	"strings"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/report"
 	"github.com/stretchr/testify/assert"
 )

--- a/probe/base/base_test.go
+++ b/probe/base/base_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/proxy"
 

--- a/probe/client/client_test.go
+++ b/probe/client/client_test.go
@@ -21,8 +21,8 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/probe/base"
 	"github.com/megaease/easeprobe/probe/client/conf"
 	"github.com/megaease/easeprobe/probe/client/kafka"

--- a/probe/client/kafka/kafka_test.go
+++ b/probe/client/kafka/kafka_test.go
@@ -23,8 +23,8 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/probe/client/conf"
 	"github.com/segmentio/kafka-go"
 	"github.com/stretchr/testify/assert"

--- a/probe/client/memcache/memcache_test.go
+++ b/probe/client/memcache/memcache_test.go
@@ -23,8 +23,8 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
 	"github.com/bradfitz/gomemcache/memcache"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/probe/client/conf"
 	"github.com/stretchr/testify/assert"
 )

--- a/probe/client/mongo/mongo_test.go
+++ b/probe/client/mongo/mongo_test.go
@@ -24,8 +24,8 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/probe/client/conf"
 	"github.com/stretchr/testify/assert"
 

--- a/probe/client/mysql/mysql_test.go
+++ b/probe/client/mysql/mysql_test.go
@@ -25,9 +25,9 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
 	"github.com/go-sql-driver/mysql"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/probe/client/conf"
 	"github.com/stretchr/testify/assert"
 )

--- a/probe/client/postgres/postgres_test.go
+++ b/probe/client/postgres/postgres_test.go
@@ -25,8 +25,8 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/probe/client/conf"
 	"github.com/stretchr/testify/assert"
 	"github.com/uptrace/bun/driver/pgdriver"

--- a/probe/client/redis/redis_test.go
+++ b/probe/client/redis/redis_test.go
@@ -24,9 +24,9 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/go-redis/redis/v8"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/probe/client/conf"
 	"github.com/stretchr/testify/assert"
 )

--- a/probe/client/zookeeper/zookeeper_test.go
+++ b/probe/client/zookeeper/zookeeper_test.go
@@ -25,8 +25,8 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/probe/client/conf"
 	"github.com/stretchr/testify/assert"
 

--- a/probe/data_test.go
+++ b/probe/data_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"

--- a/probe/host/host_test.go
+++ b/probe/host/host_test.go
@@ -23,8 +23,8 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/probe/base"
 	"github.com/megaease/easeprobe/probe/ssh"
 	"github.com/stretchr/testify/assert"

--- a/probe/http/http_test.go
+++ b/probe/http/http_test.go
@@ -29,9 +29,9 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/eval"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/probe"
 	"github.com/megaease/easeprobe/probe/base"
 	log "github.com/sirupsen/logrus"

--- a/probe/ping/ping_test.go
+++ b/probe/ping/ping_test.go
@@ -23,8 +23,8 @@ import (
 	"runtime"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/probe/base"
 	ping "github.com/prometheus-community/pro-bing"
 	"github.com/stretchr/testify/assert"

--- a/probe/result_test.go
+++ b/probe/result_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 )

--- a/probe/shell/shell_test.go
+++ b/probe/shell/shell_test.go
@@ -24,8 +24,8 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/probe"
 	"github.com/megaease/easeprobe/probe/base"
 	"github.com/stretchr/testify/assert"

--- a/probe/ssh/endpoint_test.go
+++ b/probe/ssh/endpoint_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/probe/ssh/ssh_test.go
+++ b/probe/ssh/ssh_test.go
@@ -22,12 +22,11 @@ import (
 	"net"
 	"os"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/probe"
 	"github.com/megaease/easeprobe/probe/base"
 	"github.com/stretchr/testify/assert"
@@ -269,14 +268,8 @@ YWwBAg==
 	}
 
 	// SSHConfig failed - no bastion
-	var guard *monkey.PatchGuard
 	var ed *Endpoint
-	guard = monkey.PatchInstanceMethod(reflect.TypeOf(ed), "SSHConfig", func(e *Endpoint, kind, name string, timeout time.Duration) (*ssh.ClientConfig, error) {
-		guard.Unpatch()
-		defer guard.Restore()
-		if strings.Contains(e.Host, "bastion") {
-			return e.SSHConfig(kind, name, timeout)
-		}
+	monkey.PatchInstanceMethod(reflect.TypeOf(ed), "SSHConfig", func(e *Endpoint, kind, name string, timeout time.Duration) (*ssh.ClientConfig, error) {
 		return nil, errors.New("SSHConfig failed")
 	})
 	checkServer(false, "SSHConfig failed")

--- a/probe/tcp/tcp_test.go
+++ b/probe/tcp/tcp_test.go
@@ -24,8 +24,8 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/probe/base"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/proxy"

--- a/probe/tls/tls_test.go
+++ b/probe/tls/tls_test.go
@@ -35,8 +35,8 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/probe/base"
 	"github.com/stretchr/testify/assert"
 )

--- a/report/common_test.go
+++ b/report/common_test.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"testing"
 
-	"bou.ke/monkey"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/report/result_test.go
+++ b/report/result_test.go
@@ -27,8 +27,8 @@ import (
 	"testing"
 	"time"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/probe"
 	"github.com/stretchr/testify/assert"
 )

--- a/report/sla_test.go
+++ b/report/sla_test.go
@@ -25,8 +25,8 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/megaease/easeprobe/global"
+	"github.com/megaease/easeprobe/monkey"
 	"github.com/megaease/easeprobe/probe"
 	"github.com/megaease/easeprobe/probe/base"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
As mentioned in #519, the `bou.ke/monkey` library has been archived for a long time and fails on the `macos-arm64` architecture. Consequently, we need to find an alternative library.

After extensive testing, I found that ~~`gomonkey`~~ `bytedance/mockey` is the only library that works, although its APIs are not compatible with `bou.ke/monkey`. To address this, I have introduced a separate monkey module in EaseProbe that encapsulates the ~~`gomonkey`~~ `bytedance/mockey` library. This approach minimizes the cost of modifying test code and allows us to easily replace the library in the future without affecting our test code.

Key code changes include:

1. **Makefile Update**: Changed `-gcflags=-l` to `-gcflags=all=-l` to accommodate changes for ~~`gomonkey`~~ `bytedance/mockey`.
2. **Test Files Update**: Most test files only required changing the import path from `bou.ke/monkey` to `github.com/megaease/easeprobe/monkey`. However, in `probe/ssh/ssh_test.go`, where the original usage was unsupported, I modified the logic accordingly.
3. **Monkey Module**: In `monkey/monkey.go`, I used a `sync.Map` to store all patches, which supports reset operations. A notable method called `wait` employs busy waiting to prevent test failures on `macos-arm64`. The exact cause of these errors is unclear to me, and this is a workaround. If anyone has a better solution, please let me know, as I am not very familiar with the ARM64 architecture.

Resolve #519