### PR TITLE
Update Python version to 3.8 in helm-lint.yaml

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.1


### PR DESCRIPTION
Python 3.7 is not supported on GitHub Actions ubuntu-latest runner: https://github.com/actions/setup-python/issues/962

Python 3.7 has reached EOL more than 1 year ago anyway, so not worth the effort supporting it.