### PR TITLE
Update privilege to fix TestPing on latest ubuntu

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Go Get dependencies
         run: go get -v -t -d ./...
       - name: Allow ping for ubuntu
-        if: runner.os == 'ubuntu-latest'
+        if: runner.os == 'Linux'
         run: sudo sysctl -w net.ipv4.ping_group_range="0   2147483647"
       - name: Go Test
         run: make test TEST_FLAGS="-coverprofile=coverage.txt -covermode=atomic"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,11 +38,10 @@ jobs:
         id: go
       - name: Go Get dependencies
         run: go get -v -t -d ./...
+      - name: Allow ping for ubuntu
+        if: runner.os == 'ubuntu-latest'
+        run: sudo sysctl -w net.ipv4.ping_group_range="0   2147483647"
       - name: Go Test
-        if: runner.os != 'Windows'
-        run: sudo make test TEST_FLAGS="-coverprofile=coverage.txt -covermode=atomic"
-      - name: Go Test Windows
-        if: runner.os == 'Windows'
         run: make test TEST_FLAGS="-coverprofile=coverage.txt -covermode=atomic"
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5.1.2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
           go-version-file: go.mod
         id: go
       - name: Go Get dependencies
-        run: go get -v -t -d ./...
+        run: sudo go get -v -t -d ./...
       - name: Go Test
         run: make test TEST_FLAGS="-coverprofile=coverage.txt -covermode=atomic"
       - name: Upload coverage to Codecov

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,8 +37,12 @@ jobs:
           go-version-file: go.mod
         id: go
       - name: Go Get dependencies
-        run: sudo go get -v -t -d ./...
+        run: go get -v -t -d ./...
       - name: Go Test
+        if: runner.os != 'Windows'
+        run: sudo make test TEST_FLAGS="-coverprofile=coverage.txt -covermode=atomic"
+      - name: Go Test Windows
+        if: runner.os == 'Windows'
         run: make test TEST_FLAGS="-coverprofile=coverage.txt -covermode=atomic"
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5.1.2


### PR DESCRIPTION
There have been changes in `ubuntu-latest` that caused `TestPing` to fail across all PRs. This PR addresses and resolves the issue.