### PR TITLE
Resolve compatibility issues

### DIFF
--- a/probe/host/cpu.go
+++ b/probe/host/cpu.go
@@ -53,7 +53,7 @@ func (c *CPU) Name() string {
 
 // Command returns the command to get the cpu usage
 func (c *CPU) Command() string {
-	return `top -b -n 1 | grep Cpu | awk -F ":" '{print $2}'`
+	return `top -b -n 1 | grep [C]pu | awk -F ":" '{print $2}'`
 }
 
 // OutputLines returns the lines of command output

--- a/probe/host/cpu.go
+++ b/probe/host/cpu.go
@@ -53,7 +53,7 @@ func (c *CPU) Name() string {
 
 // Command returns the command to get the cpu usage
 func (c *CPU) Command() string {
-	return `top -b -n 1 | grep [C]pu | awk -F ":" '{print $2}'`
+	return `top -b -n 1 | grep "[C]pu" | awk -F ":" '{print $2}'`
 }
 
 // OutputLines returns the lines of command output


### PR DESCRIPTION
top -b -n 1 | grep Cpu | awk -F ":" '{print $2}'

在一些场景中，会得到这样的结果

```sh
[root@myserver ~]# top -b -n 1 | grep Cpu | awk -F ":" '{print $2}'
 16.1 us,  2.0 sy,  0.0 ni, 80.2 id,  0.0 wa,  0.2 hi,  1.5 si,  0.0 st
00.00 grep --color=auto Cpu
```

而非预想的
```sh
[root@tuo-3-201 ~]# top -b -n 1 | grep Cpu | awk -F ":" '{print $2}'
 16.1 us,  2.0 sy,  0.0 ni, 80.2 id,  0.0 wa,  0.2 hi,  1.5 si,  0.0 st
```

如果使用

top -b -n 1 | grep [C]pu | awk -F ":" '{print $2}'

就能完美解决