### PR TITLE
fix(telegram): escape special characters in message text for Markdown…

### DIFF
--- a/notify/telegram/telegram.go
+++ b/notify/telegram/telegram.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/megaease/easeprobe/global"
 	"github.com/megaease/easeprobe/notify/base"
@@ -79,12 +80,18 @@ func (c *NotifyConfig) SendTelegram(title, text string) error {
 	return nil
 }
 
+// escapeMarkdown escapes special characters for Telegram's Markdown
+func escapeMarkdown(text string) string {
+	return strings.ReplaceAll(text, "_", "\\_")
+}
+
 // SendTelegramNotification will send the notification to telegram.
 func (c *NotifyConfig) SendTelegramNotification(text string) error {
+	escapedText := escapeMarkdown(text)
 	api := "https://api.telegram.org/bot" + c.Token +
 		"/sendMessage?&chat_id=" + c.ChatID +
 		"&parse_mode=markdown" +
-		"&text=" + url.QueryEscape(text)
+		"&text=" + url.QueryEscape(escapedText)
 	log.Debugf("[%s] - API %s", c.Kind(), api)
 	req, err := http.NewRequest(http.MethodPost, api, nil)
 	if err != nil {


### PR DESCRIPTION
This PR includes changes to ensure that special characters in the message text are properly escaped for Telegram's Markdown format.  Since the underscore is currently specific to Telegram, the modification is made within Telegram and not in the higher-level calls.

Resolve #628 

