### PR TITLE
Limit redirects

### DIFF
--- a/docs/Manual.md
+++ b/docs/Manual.md
@@ -337,6 +337,8 @@ http:
     success_code:
       - [200,206] # the code >=200 and <= 206
       - [300,308] # the code >=300 and <= 308
+    limit_redirects: true # limit the number of redirects to follow. default: false
+    max_redirects: 3 # maximum number of redirects to follow. default: 0
     # Response Checking
     contain: "success" # response body must contain this string, if not the probe is considered failed.
     not_contain: "failure" # response body must NOT contain this string, if it does the probe is considered failed.

--- a/probe/http/http_test.go
+++ b/probe/http/http_test.go
@@ -94,7 +94,7 @@ func TestHTTPConfig(t *testing.T) {
 	err = h.Config(global.ProbeSettings{})
 	assert.Error(t, err)
 
-	//TLS config success
+	// TLS config success
 	var gtls *global.TLS
 	monkey.PatchInstanceMethod(reflect.TypeOf(gtls), "Config", func(_ *global.TLS) (*tls.Config, error) {
 		return &tls.Config{}, nil
@@ -110,6 +110,13 @@ func TestHTTPConfig(t *testing.T) {
 	err = h.Config(global.ProbeSettings{})
 	assert.NoError(t, err)
 	assert.Equal(t, [][]int{{0, 499}}, h.SuccessCode)
+
+	h.LimitRedirects = true
+	h.MaxRedirects = 3
+	err = h.Config(global.ProbeSettings{})
+	assert.NoError(t, err)
+	assert.Equal(t, true, h.LimitRedirects)
+	assert.Equal(t, 3, h.MaxRedirects)
 
 	err = h.Config(global.ProbeSettings{})
 	assert.NoError(t, err)

--- a/resources/config.yaml
+++ b/resources/config.yaml
@@ -29,6 +29,9 @@
 #     key: /path/to/file.key
 #     # TLS
 #     insecure: true # skip any security checks, useful for self-signed and expired certs. default: false
+#     # HTTP redirect limiting
+#     limit_redirects: true # default: false
+#     max_redirects: 3 # default: 0
 #     # HTTP successful response code range, default is [0, 499].
 #     success_code:
 #       - [200,206] # the code >=200 and <= 206

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -1862,6 +1862,16 @@
           "type": "boolean",
           "title": "Insecure",
           "description": "whether to skip the TLS verification"
+        },
+        "limit_redirects": {
+          "type": "boolean",
+          "title": "Limit Redirects",
+          "description": "whether to limit redirects to follow"
+        },
+        "max_redirects": {
+          "type": "integer",
+          "title": "Maximum redirects to follow",
+          "description": "maximum number of redirects to follow"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Firstly, thanks for creating this application.

The easeprobe http probe has no redirect limit, so testing that a URL is redirecting properly isn't possible. 
For example, I maintain a platform that simply redirects requests for the apex domain to a full url, e.g.
requests for:
https://example.com/shop
should redirect users to the equivalent URL with a 301 status:
https://www.example.com/shop

I've had to include two additional options to make this possible:
```
limit_redirects: <boolean> # needed as max_redirect value of 0 is valid
max_redirects: <integer> # how many response locations to follow before assessing result
```

I think a useful future change would be to assess response headers (Location may be useful for the above).