### PR TITLE
Add Jitter time to the Probe Interval

### DIFF
--- a/docs/Manual.md
+++ b/docs/Manual.md
@@ -125,6 +125,7 @@ settings:
   probe:
     timeout: 30s # the time out for all probes, default is 30 seconds
     interval: 1m # probe every minute for all probes, default is 60 seconds
+    jitter: false # jitter the interval in the range of (interval * 0.5, interval * 1.5) when jitter is true
     failure: 2 # number of consecutive failed probes needed to determine the status down, default: 1
     success: 1 # number of consecutive successful probes needed to determine the status up, default: 1
 ```

--- a/global/global.go
+++ b/global/global.go
@@ -62,6 +62,8 @@ const (
 	DefaultTimeZone = "UTC"
 	// DefaultProbeInterval is 1 minutes
 	DefaultProbeInterval = time.Second * 60
+	// DefaultProbeJitter is false, for backward compatibility
+	DefaultProbeJitter = false
 	// DefaultTimeOut is 30 seconds
 	DefaultTimeOut = time.Second * 30
 	// DefaultChannelName  is the default wide channel name

--- a/global/probe.go
+++ b/global/probe.go
@@ -33,6 +33,7 @@ type StatusChangeThresholdSettings struct {
 // ProbeSettings is the global probe setting
 type ProbeSettings struct {
 	Interval time.Duration
+	Jitter   bool
 	Timeout  time.Duration
 	StatusChangeThresholdSettings
 	NotificationStrategySettings


### PR DESCRIPTION
In some special cases. e.g. try to probe a group of endpoints to a single gateway.  It may timeout from time to time as the site detects or considers it's spider or something.


1. jitter the probe interval in the range of (d.ProbeTimeInterval * 0.5, d.ProbeTimeInterval * 1.5).

2. add a Global Option `jitter` (default as false) to keep backward compatibility.